### PR TITLE
[#2] Add support for GeoJSON Number Identifiers

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,23 @@
+# This workflow will build a Swift project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
+
+name: Swift
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Clean Package
+      run: swift package clean
+    - name: Build Test
+      run: swift test
+

--- a/Sources/GISTools/GeoJson/Feature.swift
+++ b/Sources/GISTools/GeoJson/Feature.swift
@@ -3,6 +3,7 @@ import Foundation
 /// A GeoJSON `Feature`.
 public struct Feature: GeoJson {
 
+    /// A GeoJSON identifier that can either be a string or a JSON number (represented as an Int or Doulbe in Swift).
     public enum Identifier: Equatable {
         case string(String)
         case int(Int)
@@ -12,17 +13,19 @@ public struct Feature: GeoJson {
             guard let value else { return nil }
             if let int = value as? Int {
                 self = .int(int)
-            } else if let string = value as? String {
+            }
+            else if let string = value as? String {
                 self = .string(string)
-            } else if let double = value as? Double {
+            }
+            else if let double = value as? Double {
                 self = .double(double)
-            } else {
+            }
+            else {
                 return nil
             }
-
         }
 
-        var jsonValue: Any {
+        var asJson: Any {
             switch self {
             case .double(let double): return double
             case .int(let int): return int
@@ -56,10 +59,12 @@ public struct Feature: GeoJson {
     public init(
         _ geometry: GeoJsonGeometry,
         properties: [String: Any] = [:],
-        calculateBoundingBox: Bool = false)
+        calculateBoundingBox: Bool = false,
+        id: Identifier? = nil)
     {
         self.geometry = geometry
         self.properties = properties
+        self.id = id
 
         if calculateBoundingBox {
             self.boundingBox = self.calculateBoundingBox()
@@ -102,7 +107,7 @@ public struct Feature: GeoJson {
             "geometry": geometry.asJson
         ]
         if let id = id {
-            result["id"] = id
+            result["id"] = id.asJson
         }
         if let boundingBox = boundingBox {
             result["bbox"] = boundingBox.asJson

--- a/Sources/GISTools/GeoJson/Feature.swift
+++ b/Sources/GISTools/GeoJson/Feature.swift
@@ -3,12 +3,40 @@ import Foundation
 /// A GeoJSON `Feature`.
 public struct Feature: GeoJson {
 
+    public enum Identifier: Equatable {
+        case string(String)
+        case int(Int)
+        case double(Double)
+
+        init?(value: Any?) {
+            guard let value else { return nil }
+            if let int = value as? Int {
+                self = .int(int)
+            } else if let string = value as? String {
+                self = .string(string)
+            } else if let double = value as? Double {
+                self = .double(double)
+            } else {
+                return nil
+            }
+
+        }
+
+        var jsonValue: Any {
+            switch self {
+            case .double(let double): return double
+            case .int(let int): return int
+            case .string(let string): return string
+            }
+        }
+    }
+
     public var type: GeoJsonType {
         return .feature
     }
 
     /// An arbitrary identifier.
-    public var id: String?
+    public var id: Identifier?
 
     /// The `Feature`s geometry object.
     public let geometry: GeoJsonGeometry
@@ -51,6 +79,7 @@ public struct Feature: GeoJson {
         self.geometry = geometry
         self.properties = (geoJson["properties"] as? [String: Any]) ?? [:]
         self.boundingBox = Feature.tryCreate(json: geoJson["bbox"])
+        self.id = Identifier(value: geoJson["id"])
 
         if calculateBoundingBox, self.boundingBox == nil {
             self.boundingBox = self.calculateBoundingBox()

--- a/Sources/GISTools/GeoJson/Feature.swift
+++ b/Sources/GISTools/GeoJson/Feature.swift
@@ -8,7 +8,7 @@ public struct Feature: GeoJson {
         case int(Int)
         case double(Double)
 
-        init?(value: Any?) {
+        public init?(value: Any?) {
             guard let value else { return nil }
             if let int = value as? Int {
                 self = .int(int)

--- a/Sources/GISTools/GeoJson/Feature.swift
+++ b/Sources/GISTools/GeoJson/Feature.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A GeoJSON `Feature`.
 public struct Feature: GeoJson {
 
-    /// A GeoJSON identifier that can either be a string or a JSON number (represented as an Int or Doulbe in Swift).
+    /// A GeoJSON identifier that can either be a string or number.
     public enum Identifier: Equatable {
         case string(String)
         case int(Int)

--- a/Tests/GISToolsTests/GeoJson/FeatureTests.swift
+++ b/Tests/GISToolsTests/GeoJson/FeatureTests.swift
@@ -80,9 +80,10 @@ final class FeatureTests: XCTestCase {
 
 
     func testCreateJson() throws {
-        let feature = Feature(Point(.zero))
+        let feature = Feature(Point(.zero), id: .int(5))
         let json = feature.asJson
         XCTAssertEqual(json["type"] as? String, "Feature")
+        XCTAssertEqual(json["id"] as? Int, 5)
         let geometry = json["geometry"] as! [String: Any]
         XCTAssertEqual(geometry["type"] as? String, "Point")
         XCTAssertEqual(geometry["coordinates"] as? [Double], [0.0, 0.0])

--- a/Tests/GISToolsTests/GeoJson/FeatureTests.swift
+++ b/Tests/GISToolsTests/GeoJson/FeatureTests.swift
@@ -24,7 +24,8 @@ final class FeatureTests: XCTestCase {
                "this": "that"
            }
        },
-       "other": "something else"
+       "other": "something else",
+       "id": "abcd.1234"
     }
     """
 
@@ -40,15 +41,57 @@ final class FeatureTests: XCTestCase {
         XCTAssertEqual(feature["prop0"], "value0")
         XCTAssertEqual(feature.foreignMember(for: "other"), "something else")
         XCTAssertEqual(feature[foreignMember: "other"], "something else")
+        XCTAssertEqual(feature.id, .string("abcd.1234"))
     }
 
-    func testCreateJson() {
-        // TODO:
+    private let featureJsonWithIntId = """
+    {
+       "type": "Feature",
+       "geometry": {
+           "type": "Polygon",
+           "coordinates": [
+               [
+                   [100.0, 0.0],
+                   [101.0, 0.0],
+                   [101.0, 1.0],
+                   [100.0, 1.0],
+                   [100.0, 0.0]
+               ]
+           ]
+       },
+       "properties": {
+           "prop0": "value0",
+           "prop1": {
+               "this": "that"
+           }
+       },
+       "other": "something else",
+       "id": 1234
+    }
+    """
+
+    func testLoadJsonWithIntId() throws {
+        guard let feature = Feature(jsonString: featureJsonWithIntId) else {
+            throw "feature is nil"
+        }
+
+        XCTAssertEqual(feature.id, .int(1234))
+    }
+
+
+    func testCreateJson() throws {
+        let feature = Feature(Point(.zero))
+        let json = feature.asJson
+        XCTAssertEqual(json["type"] as? String, "Feature")
+        let geometry = json["geometry"] as! [String: Any]
+        XCTAssertEqual(geometry["type"] as? String, "Point")
+        XCTAssertEqual(geometry["coordinates"] as? [Double], [0.0, 0.0])
     }
 
     static var allTests = [
         ("testLoadJson", testLoadJson),
-        ("testCreateJson", testCreateJson),
+        ("testLoadJsonWithIntId", testLoadJsonWithIntId),
+        ("testCreateJson", testCreateJson)
     ]
 
 }


### PR DESCRIPTION
[Problem]
* Currently the package does not support parsing the identifier field from GeoJSON at all.
* Also it only models the id as `String`

[Solution]
* Parse `"id"` from the JSON.
* Introduce `Identifier` enum that models `String`/`Int`/`Double` based identifiers.

[Testing]
* Updated unit tests.