### PR TITLE
Set coordinate projection when creating a bounding box from a list of coordinates

### DIFF
--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -47,8 +47,8 @@ public struct BoundingBox:
 
         self.projection = coordinates.first?.projection ?? .epsg4326
 
-        var southWest = Coordinate3D(latitude: .infinity, longitude: .infinity, projection: projection)
-        var northEast = Coordinate3D(latitude: -.infinity, longitude: -.infinity, projection: projection)
+        var southWest = Coordinate3D(x: .infinity, y: .infinity, projection: projection)
+        var northEast = Coordinate3D(x: -.infinity, y: -.infinity, projection: projection)
 
         for currentLocation in coordinates {
             let currentLocationLatitude = currentLocation.latitude

--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -47,8 +47,8 @@ public struct BoundingBox:
 
         self.projection = coordinates.first?.projection ?? .epsg4326
 
-        var southWest = Coordinate3D(latitude: .infinity, longitude: .infinity)
-        var northEast = Coordinate3D(latitude: -.infinity, longitude: -.infinity)
+        var southWest = Coordinate3D(latitude: .infinity, longitude: .infinity, projection: projection)
+        var northEast = Coordinate3D(latitude: -.infinity, longitude: -.infinity, projection: projection)
 
         for currentLocation in coordinates {
             let currentLocationLatitude = currentLocation.latitude


### PR DESCRIPTION
This PR is an attempt to fix the following bug:

When a bounding box is created with the `BoundingBox(coordinates: [Coordinate3D], paddingKilometers: Double)` initializer the projection of southWest and northEast is always .epsg4326, even if the projection of the input coordinates, and of the boundingBox is .epsg3857.

If `.projected(to: .epsg4326)` is then called on the bounding box, the original coordinates are returned without being reprojected.