### PR TITLE
Always include the m value of Coordinate3D in JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package requires Swift 5.10 or higher (at least Xcode 14), and compiles on 
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Outdooractive/gis-tools", from: "1.6.0"),
+    .package(url: "https://github.com/Outdooractive/gis-tools", from: "1.7.0"),
 ],
 targets: [
     .target(name: "MyTarget", dependencies: [
@@ -36,6 +36,8 @@ targets: [
 - Includes many spatial algorithms (ported from turf.js), and more to come
 - Has a helper for working with x/y/z map tiles (center/bounding box/resolution/…)
 - Can encode/decode Polylines
+- Pure Swift without external dependencies
+- Swift 6 ready
 
 ## Usage
 
@@ -297,7 +299,10 @@ var altitude: CLLocationDistance?
 /// The GeoJSON specification doesn't specifiy the meaning of this value,
 /// and it doesn't guarantee that parsers won't ignore or discard it. See
 /// https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1.
-/// - Important: `asJson` will output `m` only if the coordinate also has an `altitude`.
+/// - Important: The JSON for a coordinate will contain a `null` altitude value
+///              if `altitude` is `nil` so that `m` won't get lost (since it is
+///              the 4th value).
+///              This might lead to compatibilty issues with other GeoJSON readers.
 var m: Double?
 
 /// Alias for longitude

--- a/Sources/GISTools/GeoJson/GeoJsonCodable.swift
+++ b/Sources/GISTools/GeoJson/GeoJsonCodable.swift
@@ -234,8 +234,8 @@ extension KeyedDecodingContainer where Key == GeoJsonCodingKey {
 
 extension UnkeyedDecodingContainer {
 
-    fileprivate mutating func decodeGeoJsonArray() -> [Any] {
-        var result: [Any] = []
+    fileprivate mutating func decodeGeoJsonArray() -> [Any?] {
+        var result: [Any?] = []
 
         while !isAtEnd {
             // Again, order is important
@@ -253,6 +253,9 @@ extension UnkeyedDecodingContainer {
             }
             else if let decoded = try? decode(Float.self) {
                 result.append(decoded)
+            }
+            else if let isNil = try? decodeNil(), isNil {
+                result.append(nil)
             }
             else if var decoded = try? nestedUnkeyedContainer() {
                 result.append(decoded.decodeGeoJsonArray())

--- a/Tests/GISToolsTests/GeoJson/CoordinateTests.swift
+++ b/Tests/GISToolsTests/GeoJson/CoordinateTests.swift
@@ -38,13 +38,24 @@ final class CoordinateTests: XCTestCase {
         XCTAssertEqual(String(data: coordinateData, encoding: .utf8), "[10,15]")
     }
 
+    func testEncodableNull() throws {
+        let coordinateM = Coordinate3D(latitude: 15.0, longitude: 10.0, altitude: nil, m: 1234)
+        let coordinateZ = Coordinate3D(latitude: 15.0, longitude: 10.0, altitude: 500.0, m: nil)
+
+        let coordinateDataM = try JSONEncoder().encode(coordinateM)
+        let coordinateDataZ = try JSONEncoder().encode(coordinateZ)
+
+        XCTAssertEqual(String(data: coordinateDataM, encoding: .utf8), "[10,15,null,1234]")
+        XCTAssertEqual(String(data: coordinateDataZ, encoding: .utf8), "[10,15,500]")
+    }
+
     func testEncodable3857() throws {
         let coordinate = Coordinate3D(latitude: 15.0, longitude: 10.0).projected(to: .epsg3857)
         let coordinateData = try JSONEncoder().encode(coordinate)
         let decodedCoordinate = try JSONDecoder().decode(Coordinate3D.self, from: coordinateData)
 
-        XCTAssertEqual(Double(decodedCoordinate.asJson[0]), 10.0, accuracy: 0.000001)
-        XCTAssertEqual(Double(decodedCoordinate.asJson[1]), 15.0, accuracy: 0.000001)
+        XCTAssertEqual(Double(decodedCoordinate.asJson[0]!), 10.0, accuracy: 0.000001)
+        XCTAssertEqual(Double(decodedCoordinate.asJson[1]!), 15.0, accuracy: 0.000001)
     }
 
     func testDecodable() throws {
@@ -52,6 +63,42 @@ final class CoordinateTests: XCTestCase {
         let decodedCoordinate = try JSONDecoder().decode(Coordinate3D.self, from: coordinateData)
 
         XCTAssertEqual(decodedCoordinate.asJson, [10.0, 15.0])
+    }
+
+    func testDecodableInvalid() throws {
+        let coordinateData1 =  try XCTUnwrap("[10]".data(using: .utf8))
+        XCTAssertThrowsError(try JSONDecoder().decode(Coordinate3D.self, from: coordinateData1))
+
+        let coordinateData2 =  try XCTUnwrap("[10,]".data(using: .utf8))
+        XCTAssertThrowsError(try JSONDecoder().decode(Coordinate3D.self, from: coordinateData2))
+
+        let coordinateData3 =  try XCTUnwrap("[null,null]".data(using: .utf8))
+        XCTAssertThrowsError(try JSONDecoder().decode(Coordinate3D.self, from: coordinateData3))
+
+        let coordinateData4 =  try XCTUnwrap("[]".data(using: .utf8))
+        XCTAssertThrowsError(try JSONDecoder().decode(Coordinate3D.self, from: coordinateData4))
+
+        let coordinateData5 =  try XCTUnwrap("[,15]".data(using: .utf8))
+        XCTAssertThrowsError(try JSONDecoder().decode(Coordinate3D.self, from: coordinateData5))
+    }
+
+    func testDecodableInvalidNull() throws {
+        let coordinateDataM =  try XCTUnwrap("[10,null,null,1234]".data(using: .utf8))
+        XCTAssertThrowsError(try JSONDecoder().decode(Coordinate3D.self, from: coordinateDataM))
+    }
+
+    func testDecodableNull() throws {
+        let coordinateDataM =  try XCTUnwrap("[10,15,null,1234]".data(using: .utf8))
+        let coordinateDataZ =  try XCTUnwrap("[10,15,500]".data(using: .utf8))
+        let coordinateDataZM =  try XCTUnwrap("[10,15,500,null]".data(using: .utf8))
+
+        let decodedCoordinateM = try JSONDecoder().decode(Coordinate3D.self, from: coordinateDataM)
+        let decodedCoordinateZ = try JSONDecoder().decode(Coordinate3D.self, from: coordinateDataZ)
+        let decodedCoordinateZM = try JSONDecoder().decode(Coordinate3D.self, from: coordinateDataZM)
+
+        XCTAssertEqual(decodedCoordinateM.asJson, [10.0, 15.0, nil, 1234])
+        XCTAssertEqual(decodedCoordinateZ.asJson, [10.0, 15.0, 500])
+        XCTAssertEqual(decodedCoordinateZM.asJson, [10.0, 15.0, 500])
     }
 
 }


### PR DESCRIPTION
The `m` value of `Coordinate3D` will now always be includeded in the JSON dump of a coordinate. This means that a `null` value will be added for the `altitude` if the coordinate's `altitude` is `nil`.

```
let coordinateM = Coordinate3D(latitude: 15.0, longitude: 10.0, altitude: nil, m: 1234)
let coordinateDataM = try JSONEncoder().encode(coordinateM)
print(String(data: coordinateDataM, encoding: .utf8)) // [10,15,null,1234]
```