### PR TITLE
Antimeridian cutting: bounding boxes (#1) + geometry cutting (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ GIS tools for Swift, including a [GeoJSON][3] implementation and many algorithms
 
 This package makes some assumptions about what is equal, i.e. coordinates that are inside of `1e-10` degrees are regarded as equal (that's μm precision and is probably overkill). See [GISTool.equalityDelta][5].
 
+Per [RFC 7946 §3.1.9](https://tools.ietf.org/html/rfc7946#section-3.1.9), geometries crossing the anti-meridian (±180°) should be cut into parts.
+Contrary to the standard—which calls for returning `MultiLineString` / `MultiPolygon`—the `cutAtAntimeridian()` functions return a `FeatureCollection`
+with one `Feature` per cut geometry part. This makes iterating the results uniform regardless of the input type.
+
 ## Requirements
 
 This package requires Swift 6.0 or higher (at least Xcode 15), and compiles on iOS (\>= iOS 15), macOS (\>= macOS 14), tvOS (\>= tvOS 15), watchOS (\>= watchOS 7) as well as Linux.
@@ -828,6 +832,7 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | Name                        | Example                                                                                                                               |     | Source/Tests                 |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --- | ---------------------------- |
 | along                       | `let coordinate = lineString.coordinateAlong(distance: 100.0)`                                                                        |     | [Source][43] / [Tests][44]   |
+| antimeridian-cutting        | `let result = lineString.cutAtAntimeridian()`                                                                                         |     | [Source][131] / [Tests][132] |
 | area                        | `Polygon(…).area`                                                                                                                     |     | [Source][45]                 |
 | bearing                     | `Coordinate3D(…).bearing(to: Coordinate3D(…))`                                                                                        |     | [Source][46] / [Tests][47]   |
 | boolean-clockwise           | `Polygon(…).outerRing?.isClockwise`                                                                                                   |     | [Source][48] / [Tests][49]   |
@@ -1023,6 +1028,8 @@ Thomas Rasch, Outdooractive
 [128]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BooleanIntersects.swift "BooleanIntersects"
 [129]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PoygonToLine.swift "PoygonToLine"
 [130]:  https://github.com/Outdooractive/mvt-postgis
+[131]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/AntimeridianCutting.swift "AntimeridianCutting"
+[132]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/AntimeridianCuttingTests.swift "AntimeridianCuttingTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/AntimeridianCutting.swift
+++ b/Sources/GISTools/Algorithms/AntimeridianCutting.swift
@@ -3,14 +3,10 @@ import CoreLocation
 #endif
 import Foundation
 
-// MARK: - Antimeridian cutting of GeoJSON geometries
-//
 // Per RFC 7946 §3.1.9, geometries that cross the anti-meridian (±180°)
 // SHOULD be cut into parts such that no individual part crosses it.
 //
 // https://tools.ietf.org/html/rfc7946#section-3.1.9
-
-// MARK: - AntimeridianCutting namespace
 
 /// Namespace for anti-meridian cutting helpers.
 enum AntimeridianCutting {
@@ -42,6 +38,7 @@ enum AntimeridianCutting {
     /// crosses the anti-meridian.
     static func coordinatesCrossMeridian(_ coordinates: [Coordinate3D]) -> Bool {
         guard coordinates.count >= 2 else { return false }
+
         for i in 1..<coordinates.count {
             if segmentCrossesMeridian(coordinates[i - 1], coordinates[i]) {
                 return true
@@ -74,17 +71,17 @@ enum AntimeridianCutting {
         }
 
         let fraction = (180.0 - p1.longitude) / (unwrapped - p1.longitude)
-        let intersectionLat = p1.latitude + fraction * (p2.latitude - p1.latitude)
+        let intersectionLatitude = p1.latitude + fraction * (p2.latitude - p1.latitude)
 
         let first: Coordinate3D
         let second: Coordinate3D
         if p1.longitude >= 0.0 {
-            first = Coordinate3D(latitude: intersectionLat, longitude: 180.0)
-            second = Coordinate3D(latitude: intersectionLat, longitude: -180.0)
+            first = Coordinate3D(latitude: intersectionLatitude, longitude: 180.0)
+            second = Coordinate3D(latitude: intersectionLatitude, longitude: -180.0)
         }
         else {
-            first = Coordinate3D(latitude: intersectionLat, longitude: -180.0)
-            second = Coordinate3D(latitude: intersectionLat, longitude: 180.0)
+            first = Coordinate3D(latitude: intersectionLatitude, longitude: -180.0)
+            second = Coordinate3D(latitude: intersectionLatitude, longitude: 180.0)
         }
 
         return (first, second)
@@ -99,7 +96,7 @@ enum AntimeridianCutting {
         guard coords.count >= 4 else { return result }
 
         var currentPart: [Coordinate3D] = []
-        var currentSide: Side?
+        var currentSide: Side!
 
         for i in 1..<coords.count {
             let prev = coords[i - 1]
@@ -112,7 +109,7 @@ enum AntimeridianCutting {
 
             if let intersection = AntimeridianCutting.intersection(prev, curr) {
                 currentPart.append(intersection.first)
-                appendPart(&result, currentPart, side: currentSide!)
+                appendPart(&result, currentPart, side: currentSide)
                 currentSide = (currentSide == .right) ? .left : .right
                 currentPart = [intersection.second, curr]
             }
@@ -137,8 +134,8 @@ enum AntimeridianCutting {
     ) -> [Polygon] {
         guard outerParts.isNotEmpty else { return [] }
 
-        let lon = (side == .right) ? 180.0 : -180.0
-        let outerRing = connectRingParts(outerParts, alongLongitude: lon)
+        let longitude = (side == .right) ? 180.0 : -180.0
+        let outerRing = connectRingParts(outerParts, alongLongitude: longitude)
 
         var polygonInnerRings: [Ring] = []
         for innerCoords in innerParts {
@@ -209,6 +206,7 @@ enum AntimeridianCutting {
         side: Side
     ) {
         guard part.count >= 2 else { return }
+
         switch side {
         case .right: result.right.append(part)
         case .left: result.left.append(part)

--- a/Sources/GISTools/Algorithms/AntimeridianCutting.swift
+++ b/Sources/GISTools/Algorithms/AntimeridianCutting.swift
@@ -1,0 +1,452 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// MARK: - Antimeridian cutting of GeoJSON geometries
+//
+// Per RFC 7946 §3.1.9, geometries that cross the anti-meridian (±180°)
+// SHOULD be cut into parts such that no individual part crosses it.
+//
+// https://tools.ietf.org/html/rfc7946#section-3.1.9
+
+// MARK: - AntimeridianCutting namespace
+
+/// Namespace for anti-meridian cutting helpers.
+enum AntimeridianCutting {
+
+    /// Which side of the anti-meridian a ring part belongs to.
+    enum Side {
+        case right
+        case left
+    }
+
+    /// Result of cutting a single ring at the anti-meridian.
+    struct RingCutResult {
+        var right: [[Coordinate3D]] = []
+        var left: [[Coordinate3D]] = []
+    }
+
+    // MARK: - Detection
+
+    /// Returns `true` when the shortest path between `p1` and `p2`
+    /// crosses the anti-meridian.
+    static func segmentCrossesMeridian(
+        _ p1: Coordinate3D,
+        _ p2: Coordinate3D
+    ) -> Bool {
+        abs(p1.longitude - p2.longitude) > 180.0
+    }
+
+    /// Returns `true` when any consecutive coordinate pair
+    /// crosses the anti-meridian.
+    static func coordinatesCrossMeridian(_ coordinates: [Coordinate3D]) -> Bool {
+        guard coordinates.count >= 2 else { return false }
+        for i in 1..<coordinates.count {
+            if segmentCrossesMeridian(coordinates[i - 1], coordinates[i]) {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Intersection
+
+    /// Computes the two intersection points at ±180° for a segment
+    /// that crosses the anti-meridian.
+    ///
+    /// The sign of each intersection point depends on whether `p1`
+    /// lies on the positive-latitude side, so that the resulting
+    /// split preserves the natural direction of the line.
+    static func intersection(
+        _ p1: Coordinate3D,
+        _ p2: Coordinate3D
+    ) -> (first: Coordinate3D, second: Coordinate3D)? {
+        let dl = abs(p1.longitude - p2.longitude)
+        guard dl > 180.0 else { return nil }
+
+        var unwrapped = p2.longitude
+        if p2.longitude - p1.longitude > 180.0 {
+            unwrapped = p2.longitude - 360.0
+        }
+        else if p1.longitude - p2.longitude > 180.0 {
+            unwrapped = p2.longitude + 360.0
+        }
+
+        let fraction = (180.0 - p1.longitude) / (unwrapped - p1.longitude)
+        let intersectionLat = p1.latitude + fraction * (p2.latitude - p1.latitude)
+
+        let first: Coordinate3D
+        let second: Coordinate3D
+        if p1.longitude >= 0.0 {
+            first = Coordinate3D(latitude: intersectionLat, longitude: 180.0)
+            second = Coordinate3D(latitude: intersectionLat, longitude: -180.0)
+        }
+        else {
+            first = Coordinate3D(latitude: intersectionLat, longitude: -180.0)
+            second = Coordinate3D(latitude: intersectionLat, longitude: 180.0)
+        }
+
+        return (first, second)
+    }
+
+    // MARK: - Ring cutting
+
+    /// Splits a ring's coordinate array at anti-meridian crossings.
+    static func cutRing(_ ring: Ring) -> RingCutResult {
+        let coords = ring.coordinates
+        var result = RingCutResult()
+        guard coords.count >= 4 else { return result }
+
+        var currentPart: [Coordinate3D] = []
+        var currentSide: Side?
+
+        for i in 1..<coords.count {
+            let prev = coords[i - 1]
+            let curr = coords[i]
+
+            if currentSide == nil {
+                currentSide = prev.longitude >= 0 ? .right : .left
+                currentPart = [prev]
+            }
+
+            if let intersection = AntimeridianCutting.intersection(prev, curr) {
+                currentPart.append(intersection.first)
+                appendPart(&result, currentPart, side: currentSide!)
+                currentSide = (currentSide == .right) ? .left : .right
+                currentPart = [intersection.second, curr]
+            }
+            else {
+                currentPart.append(curr)
+            }
+        }
+
+        if let side = currentSide, currentPart.isNotEmpty {
+            appendPart(&result, currentPart, side: side)
+        }
+
+        return result
+    }
+
+    /// Builds one or more polygons from ring parts on one side of the anti-meridian,
+    /// closing them along ±180°.
+    static func buildPolygons(
+        outerParts: [[Coordinate3D]],
+        innerParts: [[Coordinate3D]],
+        side: Side
+    ) -> [Polygon] {
+        guard outerParts.isNotEmpty else { return [] }
+
+        let lon = (side == .right) ? 180.0 : -180.0
+        let outerRing = connectRingParts(outerParts, alongLongitude: lon)
+
+        var polygonInnerRings: [Ring] = []
+        for innerCoords in innerParts {
+            if let ring = Ring(innerCoords) {
+                polygonInnerRings.append(ring)
+            }
+        }
+
+        var rings: [Ring] = [Ring(unchecked: outerRing)]
+        rings.append(contentsOf: polygonInnerRings)
+
+        if let polygon = Polygon(rings) {
+            return [polygon]
+        }
+        return []
+    }
+
+    /// Connects disjoint ring parts on one side of the anti-meridian
+    /// into a single closed ring by joining their endpoints along ±180°.
+    static func connectRingParts(
+        _ parts: [[Coordinate3D]],
+        alongLongitude lon: Double
+    ) -> [Coordinate3D] {
+        guard parts.isNotEmpty else { return [] }
+        guard parts.count > 1 else {
+            var result = parts[0]
+            if result.first != result.last {
+                result.append(result[0])
+            }
+            return result
+        }
+
+        var result: [Coordinate3D] = []
+        for part in parts {
+            if result.isNotEmpty {
+                let prevEnd = result.last!
+                let thisStart = part.first!
+                if prevEnd.longitude != thisStart.longitude
+                    || prevEnd.latitude != thisStart.latitude
+                {
+                    result.append(Coordinate3D(latitude: prevEnd.latitude, longitude: lon))
+                    result.append(Coordinate3D(latitude: thisStart.latitude, longitude: lon))
+                }
+            }
+            result.append(contentsOf: part)
+        }
+
+        if result.first != result.last {
+            let first = result.first!
+            let last = result.last!
+            if last.longitude != first.longitude
+                || last.latitude != first.latitude
+            {
+                result.append(Coordinate3D(latitude: last.latitude, longitude: lon))
+                result.append(Coordinate3D(latitude: first.latitude, longitude: lon))
+            }
+        }
+        result.append(result.first!)
+
+        return result
+    }
+
+    // MARK: - Private helpers
+
+    private static func appendPart(
+        _ result: inout RingCutResult,
+        _ part: [Coordinate3D],
+        side: Side
+    ) {
+        guard part.count >= 2 else { return }
+        switch side {
+        case .right: result.right.append(part)
+        case .left: result.left.append(part)
+        }
+    }
+
+}
+
+// MARK: - LineString cutting
+
+extension LineString {
+
+    /// Whether the line string crosses the anti-meridian.
+    public var crossesAntimeridian: Bool {
+        AntimeridianCutting.coordinatesCrossMeridian(coordinates)
+    }
+
+    /// Cuts the line string at the anti-meridian.
+    ///
+    /// Returns a ``FeatureCollection`` with one feature per cut part.
+    /// If the line does not cross the anti-meridian the collection
+    /// contains a single feature.
+    ///
+    /// Per RFC 7946 §3.1.9, a line from 45°N,170°E to 45°N,170°W
+    /// becomes two features with parts `[170,45]→[180,45]`
+    /// and `[-180,45]→[-170,45]`.
+    public func cutAtAntimeridian() -> FeatureCollection {
+        FeatureCollection(_cutParts().map { Feature($0) })
+    }
+
+    /// Internal: returns each cut part as a separate `LineString`.
+    fileprivate func _cutParts() -> [LineString] {
+        guard coordinates.count >= 2 else { return [self] }
+        guard crossesAntimeridian else { return [self] }
+
+        var resultParts: [[Coordinate3D]] = []
+        var currentPart: [Coordinate3D] = [coordinates[0]]
+
+        for i in 1..<coordinates.count {
+            let prev = currentPart.last!
+            let curr = coordinates[i]
+
+            if let intersection = AntimeridianCutting.intersection(prev, curr) {
+                currentPart.append(intersection.first)
+                resultParts.append(currentPart)
+                currentPart = [intersection.second, curr]
+            }
+            else {
+                currentPart.append(curr)
+            }
+        }
+
+        if currentPart.isNotEmpty {
+            resultParts.append(currentPart)
+        }
+
+        guard resultParts.count > 1 else { return [self] }
+        return resultParts.map { LineString(unchecked: $0) }
+    }
+
+}
+
+// MARK: - Polygon cutting
+
+extension Polygon {
+
+    /// Whether any ring of the polygon crosses the anti-meridian.
+    public var crossesAntimeridian: Bool {
+        rings.contains { AntimeridianCutting.coordinatesCrossMeridian($0.coordinates) }
+    }
+
+    /// Cuts the polygon at the anti-meridian.
+    ///
+    /// Returns a ``FeatureCollection`` with one feature per resulting
+    /// polygon. If the polygon does not cross the anti-meridian the
+    /// collection contains a single feature.
+    public func cutAtAntimeridian() -> FeatureCollection {
+        FeatureCollection(_cutParts().map { Feature($0) })
+    }
+
+    /// Internal: returns each cut part as a separate `Polygon`.
+    fileprivate func _cutParts() -> [Polygon] {
+        guard crossesAntimeridian else { return [self] }
+
+        let outerResult = AntimeridianCutting.cutRing(outerRing!)
+
+        var rightInnerRings: [[Coordinate3D]] = []
+        var leftInnerRings: [[Coordinate3D]] = []
+
+        if let innerRings {
+            for hole in innerRings {
+                if AntimeridianCutting.coordinatesCrossMeridian(hole.coordinates) {
+                    let holeResult = AntimeridianCutting.cutRing(hole)
+                    rightInnerRings.append(contentsOf: holeResult.right)
+                    leftInnerRings.append(contentsOf: holeResult.left)
+                }
+                else {
+                    if hole.coordinates.first?.longitude ?? 0 >= 0 {
+                        rightInnerRings.append(hole.coordinates)
+                    }
+                    else {
+                        leftInnerRings.append(hole.coordinates)
+                    }
+                }
+            }
+        }
+
+        var polygons: [Polygon] = []
+
+        let rightPolygons = AntimeridianCutting.buildPolygons(
+            outerParts: outerResult.right,
+            innerParts: rightInnerRings,
+            side: .right)
+        polygons.append(contentsOf: rightPolygons)
+
+        let leftPolygons = AntimeridianCutting.buildPolygons(
+            outerParts: outerResult.left,
+            innerParts: leftInnerRings,
+            side: .left)
+        polygons.append(contentsOf: leftPolygons)
+
+        return polygons.isEmpty ? [self] : polygons
+    }
+
+}
+
+// MARK: - MultiLineString cutting
+
+extension MultiLineString {
+
+    /// Cuts each line string at the anti-meridian and returns the combined result.
+    public func cutAtAntimeridian() -> FeatureCollection {
+        var allFeatures: [Feature] = []
+        for ls in lineStrings {
+            for part in ls._cutParts() {
+                allFeatures.append(Feature(part))
+            }
+        }
+        return FeatureCollection(allFeatures)
+    }
+
+}
+
+// MARK: - MultiPolygon cutting
+
+extension MultiPolygon {
+
+    /// Cuts each polygon at the anti-meridian and returns the combined result.
+    public func cutAtAntimeridian() -> FeatureCollection {
+        var allFeatures: [Feature] = []
+        for polygon in polygons {
+            for part in polygon._cutParts() {
+                allFeatures.append(Feature(part))
+            }
+        }
+        return FeatureCollection(allFeatures)
+    }
+
+}
+
+// MARK: - Feature & FeatureCollection
+
+extension Feature {
+
+    /// Cuts the feature's geometry at the anti-meridian.
+    ///
+    /// The feature's properties are preserved on every resulting feature.
+    /// The original feature's identifier is kept on the first result
+    /// and cleared on subsequent parts.
+    public func cutAtAntimeridian() -> FeatureCollection {
+        let fc = geometry.cutAtAntimeridian()
+        var features: [Feature] = []
+        for (index, cutFeature) in fc.features.enumerated() {
+            let featureId: Identifier? = (index == 0) ? id : nil
+            features.append(Feature(cutFeature.geometry, id: featureId, properties: properties))
+        }
+        return FeatureCollection(features)
+    }
+
+}
+
+extension FeatureCollection {
+
+    /// Cuts each feature's geometry at the anti-meridian.
+    public func cutAtAntimeridian() -> FeatureCollection {
+        var allFeatures: [Feature] = []
+        for feature in features {
+            let fc = feature.cutAtAntimeridian()
+            allFeatures.append(contentsOf: fc.features)
+        }
+        var collection = FeatureCollection(allFeatures)
+        if boundingBox != nil {
+            collection.updateBoundingBox(onlyIfNecessary: false)
+        }
+        return collection
+    }
+
+}
+
+// MARK: - GeometryCollection
+
+extension GeometryCollection {
+
+    /// Cuts each sub-geometry at the anti-meridian and returns the
+    /// combined result as a ``FeatureCollection``.
+    public func cutAtAntimeridian() -> FeatureCollection {
+        var allFeatures: [Feature] = []
+        for geometry in geometries {
+            let fc = geometry.cutAtAntimeridian()
+            allFeatures.append(contentsOf: fc.features)
+        }
+        return FeatureCollection(allFeatures)
+    }
+
+}
+
+// MARK: - GeoJsonGeometry extension
+
+extension GeoJsonGeometry {
+
+    /// Cuts the geometry at the anti-meridian.
+    ///
+    /// Dispatches to the appropriate type-specific implementation.
+    public func cutAtAntimeridian() -> FeatureCollection {
+        switch self {
+        case let ls as LineString:
+            return ls.cutAtAntimeridian()
+        case let mls as MultiLineString:
+            return mls.cutAtAntimeridian()
+        case let p as Polygon:
+            return p.cutAtAntimeridian()
+        case let mp as MultiPolygon:
+            return mp.cutAtAntimeridian()
+        case let gc as GeometryCollection:
+            return gc.cutAtAntimeridian()
+        default:
+            return FeatureCollection([Feature(self)])
+        }
+    }
+
+}

--- a/Sources/GISTools/Algorithms/NearestPoint.swift
+++ b/Sources/GISTools/Algorithms/NearestPoint.swift
@@ -14,7 +14,7 @@ extension BoundingBox {
     public func nearestCoordinate(
         from other: Coordinate3D
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance)? {
-        self.boundingBoxPolygon.nearestCoordinate(from: other)
+        self.boundingBoxGeometry.nearestCoordinate(from: other)
     }
 
     /// Takes a reference point and returns the point from the reveiver closest to the reference.
@@ -24,7 +24,7 @@ extension BoundingBox {
     public func nearestPoint(
         from other: Point
     ) -> (point: Point, distance: CLLocationDistance)? {
-        self.boundingBoxPolygon.nearestPoint(from: other)
+        self.boundingBoxGeometry.nearestPoint(from: other)
     }
 
 }

--- a/Sources/GISTools/Algorithms/NearestPointOnFeature.swift
+++ b/Sources/GISTools/Algorithms/NearestPointOnFeature.swift
@@ -12,7 +12,7 @@ extension BoundingBox {
         if self.contains(other) {
             return (coordinate: other, distance: 0.0)
         }
-        return self.boundingBoxPolygon.nearestCoordinateOnFeature(from: other)
+        return self.boundingBoxGeometry.nearestCoordinateOnFeature(from: other)
     }
 
     /// Returns a *Point* guaranteed to be on the surface of the bounding box.
@@ -22,7 +22,7 @@ extension BoundingBox {
         if self.contains(other.coordinate) {
             return (point: other, distance: 0.0)
         }
-        return self.boundingBoxPolygon.nearestPointOnFeature(from: other)
+        return self.boundingBoxGeometry.nearestPointOnFeature(from: other)
     }
 
 }

--- a/Sources/GISTools/Algorithms/TileCover.swift
+++ b/Sources/GISTools/Algorithms/TileCover.swift
@@ -28,7 +28,7 @@ extension BoundingBox {
     /// - Parameter zoom: The zoom level of the map.
     /// - Returns: An array of ``MapTile`` instances.
     public func tileCover(atZoom zoom: Int) -> [MapTile] {
-        boundingBoxPolygon.tileCover(atZoom: zoom)
+        boundingBoxGeometry.tileCover(atZoom: zoom)
     }
 
 }

--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -338,8 +338,44 @@ extension BoundingBox {
     }
 
     /// Converts the bounding box to a `Polygon` object.
+    @available(*, deprecated, message: "Use boundingBoxGeometry instead (handles antimeridian crossing)")
     public var boundingBoxPolygon: Polygon {
         Polygon([[southWest, northWest, northEast, southEast, southWest]])!
+    }
+
+    /// The bounding box as a GeoJSON geometry.
+    ///
+    /// When the bounding box crosses the anti-meridian, the geometry is
+    /// properly cut into a ``MultiPolygon`` with two parts at ±180°.
+    /// Otherwise, a single ``Polygon`` is returned.
+    ///
+    /// Per [RFC 7946 § 5](https://tools.ietf.org/html/rfc7946#section-5):
+    /// a bounding box that crosses the anti-meridian is represented as a
+    /// `MultiPolygon` split at the date line.
+    public var boundingBoxGeometry: any GeoJsonGeometry {
+        let boundingBox = self.normalized()
+
+        guard boundingBox.crossesAntiMeridian else {
+            return Polygon([[boundingBox.southWest, boundingBox.northWest, boundingBox.northEast, boundingBox.southEast, boundingBox.southWest]])!
+        }
+
+        let rightPolygon = Polygon([[
+            Coordinate3D(latitude: boundingBox.southWest.latitude, longitude: 180.0),
+            Coordinate3D(latitude: boundingBox.northEast.latitude, longitude: 180.0),
+            Coordinate3D(latitude: boundingBox.northEast.latitude, longitude: boundingBox.southWest.longitude),
+            Coordinate3D(latitude: boundingBox.southWest.latitude, longitude: boundingBox.southWest.longitude),
+            Coordinate3D(latitude: boundingBox.southWest.latitude, longitude: 180.0),
+        ]])!
+
+        let leftPolygon = Polygon([[
+            Coordinate3D(latitude: boundingBox.southWest.latitude, longitude: boundingBox.northEast.longitude),
+            Coordinate3D(latitude: boundingBox.northEast.latitude, longitude: boundingBox.northEast.longitude),
+            Coordinate3D(latitude: boundingBox.northEast.latitude, longitude: -180.0),
+            Coordinate3D(latitude: boundingBox.southWest.latitude, longitude: -180.0),
+            Coordinate3D(latitude: boundingBox.southWest.latitude, longitude: boundingBox.northEast.longitude),
+        ]])!
+
+        return MultiPolygon([rightPolygon, leftPolygon])!
     }
 
     /// The geodesic center of the bounding box.

--- a/TODO.md
+++ b/TODO.md
@@ -6,53 +6,6 @@
 
 ## TODOs from the GeoJSON spec: https://tools.ietf.org/html/rfc7946
 
-### 3.1.9.  Antimeridian Cutting
-
-```
-In representing Features that cross the antimeridian,
-interoperability is improved by modifying their geometry.  Any
-geometry that crosses the antimeridian SHOULD be represented by
-cutting it in two such that neither part's representation crosses the
-antimeridian.
-
-For example, a line extending from 45 degrees N, 170 degrees E across
-the antimeridian to 45 degrees N, 170 degrees W should be cut in two
-and represented as a MultiLineString.
-
-{
-    "type": "MultiLineString",
-    "coordinates": [
-    [
-    [170.0, 45.0], [180.0, 45.0]
-    ], [
-    [-180.0, 45.0], [-170.0, 45.0]
-    ]
-    ]
-}
-
-A rectangle extending from 40 degrees N, 170 degrees E across the
-antimeridian to 50 degrees N, 170 degrees W should be cut in two and
-represented as a MultiPolygon.
-
-{
-    "type": "MultiPolygon",
-    "coordinates": [
-    [
-    [
-    [180.0, 40.0], [180.0, 50.0], [170.0, 50.0],
-    [170.0, 40.0], [180.0, 40.0]
-    ]
-    ],
-    [
-    [
-    [-170.0, 40.0], [-170.0, 50.0], [-180.0, 50.0],
-    [-180.0, 40.0], [-170.0, 40.0]
-    ]
-    ]
-    ]
-}
-````
-
 ### 5.  Bounding Box
 
 ```

--- a/Tests/GISToolsTests/Algorithms/AntimeridianCuttingTests.swift
+++ b/Tests/GISToolsTests/Algorithms/AntimeridianCuttingTests.swift
@@ -1,0 +1,304 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct AntimeridianCuttingTests {
+
+    // MARK: - LineString
+
+    @Test
+    func lineStringNoCrossing() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 40.0, longitude: -10.0),
+            Coordinate3D(latitude: 40.0, longitude: 10.0),
+        ]))
+        #expect(ls.crossesAntimeridian == false)
+
+        let fc = ls.cutAtAntimeridian()
+        #expect(fc.features.count == 1)
+        #expect(fc.features[0].geometry is LineString)
+    }
+
+    @Test
+    func lineStringCrossingRFCExample() async throws {
+        // RFC 7946 §3.1.9: line from 45N,170E to 45N,170W
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 45.0, longitude: 170.0),
+            Coordinate3D(latitude: 45.0, longitude: -170.0),
+        ]))
+        #expect(ls.crossesAntimeridian)
+
+        let fc = ls.cutAtAntimeridian()
+        #expect(fc.features.count == 2)
+
+        // First feature: [170,45] → [180,45]
+        let part1 = fc.features[0].geometry as! LineString
+        #expect(part1.coordinates[0] == Coordinate3D(latitude: 45.0, longitude: 170.0))
+        #expect(part1.coordinates[1] == Coordinate3D(latitude: 45.0, longitude: 180.0))
+
+        // Second feature: [-180,45] → [-170,45]
+        let part2 = fc.features[1].geometry as! LineString
+        #expect(part2.coordinates[0] == Coordinate3D(latitude: 45.0, longitude: -180.0))
+        #expect(part2.coordinates[1] == Coordinate3D(latitude: 45.0, longitude: -170.0))
+    }
+
+    @Test
+    func lineStringCrossingWithLatitude() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 40.0, longitude: 160.0),
+            Coordinate3D(latitude: 50.0, longitude: -150.0),
+        ]))
+        #expect(ls.crossesAntimeridian)
+
+        let fc = ls.cutAtAntimeridian()
+        #expect(fc.features.count == 2)
+
+        let part1 = fc.features[0].geometry as! LineString
+        #expect(part1.coordinates[0] == Coordinate3D(latitude: 40.0, longitude: 160.0))
+        #expect(abs(part1.coordinates[1].latitude - 44.0) < 0.001)
+        #expect(part1.coordinates[1].longitude == 180.0)
+
+        let part2 = fc.features[1].geometry as! LineString
+        #expect(abs(part2.coordinates[0].latitude - 44.0) < 0.001)
+        #expect(part2.coordinates[0].longitude == -180.0)
+        #expect(part2.coordinates[1] == Coordinate3D(latitude: 50.0, longitude: -150.0))
+    }
+
+    @Test
+    func lineStringMultipleCrossings() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+        ]))
+        #expect(ls.crossesAntimeridian)
+
+        let fc = ls.cutAtAntimeridian()
+        #expect(fc.features.count == 3)
+        #expect(fc.features[0].geometry is LineString)
+        #expect(fc.features[1].geometry is LineString)
+        #expect(fc.features[2].geometry is LineString)
+    }
+
+    @Test
+    func lineStringReverseCrossing() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 45.0, longitude: -170.0),
+            Coordinate3D(latitude: 45.0, longitude: 170.0),
+        ]))
+        #expect(ls.crossesAntimeridian)
+
+        let fc = ls.cutAtAntimeridian()
+        #expect(fc.features.count == 2)
+
+        let part1 = fc.features[0].geometry as! LineString
+        #expect(part1.coordinates[0] == Coordinate3D(latitude: 45.0, longitude: -170.0))
+        #expect(part1.coordinates[1] == Coordinate3D(latitude: 45.0, longitude: -180.0))
+
+        let part2 = fc.features[1].geometry as! LineString
+        #expect(part2.coordinates[0] == Coordinate3D(latitude: 45.0, longitude: 180.0))
+        #expect(part2.coordinates[1] == Coordinate3D(latitude: 45.0, longitude: 170.0))
+    }
+
+    @Test
+    func lineStringSinglePoint() async throws {
+        let ls = LineString()
+        #expect(ls.crossesAntimeridian == false)
+
+        let fc = ls.cutAtAntimeridian()
+        #expect(fc.features.count == 1)
+        #expect(fc.features[0].geometry is LineString)
+    }
+
+    // MARK: - Polygon
+
+    @Test
+    func polygonNoCrossing() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        #expect(polygon.crossesAntimeridian == false)
+
+        let fc = polygon.cutAtAntimeridian()
+        #expect(fc.features.count == 1)
+        #expect(fc.features[0].geometry is Polygon)
+    }
+
+    @Test
+    func polygonCrossingRFCExample() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 40.0, longitude: 170.0),
+            Coordinate3D(latitude: 50.0, longitude: 170.0),
+            Coordinate3D(latitude: 50.0, longitude: -170.0),
+            Coordinate3D(latitude: 40.0, longitude: -170.0),
+            Coordinate3D(latitude: 40.0, longitude: 170.0),
+        ]]))
+        #expect(polygon.crossesAntimeridian)
+
+        let fc = polygon.cutAtAntimeridian()
+        #expect(fc.features.count == 2)
+
+        #expect(fc.features[0].geometry is Polygon)
+        #expect(fc.features[1].geometry is Polygon)
+    }
+
+    @Test
+    func polygonCrossingClosedRings() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 40.0, longitude: 170.0),
+            Coordinate3D(latitude: 50.0, longitude: 170.0),
+            Coordinate3D(latitude: 50.0, longitude: -170.0),
+            Coordinate3D(latitude: 40.0, longitude: -170.0),
+            Coordinate3D(latitude: 40.0, longitude: 170.0),
+        ]]))
+
+        let fc = polygon.cutAtAntimeridian()
+        #expect(fc.features.count == 2)
+
+        for feature in fc.features {
+            let poly = feature.geometry as! Polygon
+            let outerRing = try #require(poly.outerRing)
+            let coords = outerRing.coordinates
+            #expect(coords.count >= 4)
+            #expect(coords.first == coords.last)
+        }
+    }
+
+    // MARK: - MultiLineString
+
+    @Test
+    func multiLineStringCutting() async throws {
+        let mls = try #require(MultiLineString([
+            [
+                Coordinate3D(latitude: 45.0, longitude: 170.0),
+                Coordinate3D(latitude: 45.0, longitude: -170.0),
+            ],
+            [
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 20.0, longitude: 20.0),
+            ],
+        ]))
+
+        let fc = mls.cutAtAntimeridian()
+        // first line crossing → 2 features, second line no crossing → 1 feature
+        #expect(fc.features.count == 3)
+        #expect(fc.features[0].geometry is LineString)
+        #expect(fc.features[1].geometry is LineString)
+        #expect(fc.features[2].geometry is LineString)
+    }
+
+    // MARK: - MultiPolygon
+
+    @Test
+    func multiPolygonCutting() async throws {
+        let crossingPoly = try #require(Polygon([[
+            Coordinate3D(latitude: 40.0, longitude: 170.0),
+            Coordinate3D(latitude: 50.0, longitude: 170.0),
+            Coordinate3D(latitude: 50.0, longitude: -170.0),
+            Coordinate3D(latitude: 40.0, longitude: -170.0),
+            Coordinate3D(latitude: 40.0, longitude: 170.0),
+        ]]))
+        let normalPoly = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+
+        let mp = try #require(MultiPolygon([crossingPoly, normalPoly]))
+
+        let fc = mp.cutAtAntimeridian()
+        // crossing → 2 features, normal → 1 feature
+        #expect(fc.features.count == 3)
+        #expect(fc.features[0].geometry is Polygon)
+        #expect(fc.features[1].geometry is Polygon)
+        #expect(fc.features[2].geometry is Polygon)
+    }
+
+    // MARK: - Feature
+
+    @Test
+    func featureCutting() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 45.0, longitude: 170.0),
+            Coordinate3D(latitude: 45.0, longitude: -170.0),
+        ]))
+        let feature = Feature(ls, id: .string("test"), properties: ["key": "value"])
+
+        let fc = feature.cutAtAntimeridian()
+        #expect(fc.features.count == 2)
+
+        // First part keeps the id
+        let first = fc.features[0]
+        #expect(first.id == .string("test"))
+        #expect(first.properties["key"] as? String == "value")
+        #expect(first.geometry is LineString)
+
+        // Second part has no id
+        let second = fc.features[1]
+        #expect(second.id == nil)
+        #expect(second.properties["key"] as? String == "value")
+        #expect(second.geometry is LineString)
+    }
+
+    // MARK: - FeatureCollection
+
+    @Test
+    func featureCollectionCutting() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 45.0, longitude: 170.0),
+            Coordinate3D(latitude: 45.0, longitude: -170.0),
+        ]))
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+
+        let fc = FeatureCollection([Feature(ls, id: .string("a")), Feature(point, id: .string("b"))])
+
+        let result = fc.cutAtAntimeridian()
+        // line splits into 2, point stays 1 → 3 total
+        #expect(result.features.count == 3)
+
+        #expect(result.features[0].id == .string("a"))
+        #expect(result.features[0].geometry is LineString)
+
+        #expect(result.features[1].id == nil)
+        #expect(result.features[1].geometry is LineString)
+
+        #expect(result.features[2].id == .string("b"))
+        #expect(result.features[2].geometry is Point)
+    }
+
+    // MARK: - GeometryCollection
+
+    @Test
+    func geometryCollectionCutting() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 45.0, longitude: 170.0),
+            Coordinate3D(latitude: 45.0, longitude: -170.0),
+        ]))
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+
+        let gc = GeometryCollection([ls, point])
+
+        let fc = gc.cutAtAntimeridian()
+        #expect(fc.features.count == 3)
+        #expect(fc.features[0].geometry is LineString)
+        #expect(fc.features[1].geometry is LineString)
+        #expect(fc.features[2].geometry is Point)
+    }
+
+    // MARK: - Point (unchanged)
+
+    @Test
+    func pointCutting() async throws {
+        let point = Point(Coordinate3D(latitude: 45.0, longitude: 170.0))
+        let fc = point.cutAtAntimeridian()
+        #expect(fc.features.count == 1)
+        #expect(fc.features[0].geometry is Point)
+    }
+
+}

--- a/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
+++ b/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
@@ -574,4 +574,72 @@ struct BoundingBoxTests {
         #expect(abs(bbox3_4326.projected(to: .epsg3857).northEast.y - bbox3_3857.northEast.y) < 0.00001)
     }
 
+    // MARK: - boundingBoxGeometry
+
+    @Test
+    func boundingBoxGeometryNormal() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0))
+
+        let geometry = bbox.boundingBoxGeometry
+        #expect(geometry is Polygon)
+
+        let polygon = geometry as! Polygon
+        #expect(polygon.coordinates.count == 1)
+    }
+
+    @Test
+    func boundingBoxGeometryAntimeridian() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 40.0, longitude: 170.0),
+            northEast: Coordinate3D(latitude: 50.0, longitude: -170.0))
+
+        #expect(bbox.crossesAntiMeridian)
+
+        let geometry = bbox.boundingBoxGeometry
+        #expect(geometry is MultiPolygon)
+
+        let multiPolygon = geometry as! MultiPolygon
+        #expect(multiPolygon.polygons.count == 2)
+
+        // Right polygon: from 170° to 180°
+        let rightPolygon = multiPolygon.polygons[0]
+        let rightCoords = rightPolygon.coordinates[0]
+        #expect(rightCoords[0] == Coordinate3D(latitude: 40.0, longitude: 180.0))
+        #expect(rightCoords[1] == Coordinate3D(latitude: 50.0, longitude: 180.0))
+        #expect(rightCoords[2] == Coordinate3D(latitude: 50.0, longitude: 170.0))
+        #expect(rightCoords[3] == Coordinate3D(latitude: 40.0, longitude: 170.0))
+
+        // Left polygon: from -170° to -180°
+        let leftPolygon = multiPolygon.polygons[1]
+        let leftCoords = leftPolygon.coordinates[0]
+        #expect(leftCoords[0] == Coordinate3D(latitude: 40.0, longitude: -170.0))
+        #expect(leftCoords[1] == Coordinate3D(latitude: 50.0, longitude: -170.0))
+        #expect(leftCoords[2] == Coordinate3D(latitude: 50.0, longitude: -180.0))
+        #expect(leftCoords[3] == Coordinate3D(latitude: 40.0, longitude: -180.0))
+    }
+
+    @Test
+    func boundingBoxGeometryAntimeridian2() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: -53.8, longitude: 155.3),
+            northEast: Coordinate3D(latitude: -30.1, longitude: -174.4))
+
+        #expect(bbox.crossesAntiMeridian)
+
+        let geometry = bbox.boundingBoxGeometry
+        #expect(geometry is MultiPolygon)
+
+        let multiPolygon = geometry as! MultiPolygon
+        #expect(multiPolygon.polygons.count == 2)
+    }
+
+    @Test
+    func boundingBoxGeometryWorld() async throws {
+        #expect(BoundingBox.world.crossesAntiMeridian == false)
+        let geometry = BoundingBox.world.boundingBoxGeometry
+        #expect(geometry is Polygon)
+    }
+
 }


### PR DESCRIPTION
## Summary

### Issue #1 — Antimeridian Cutting for Bounding Boxes
- Added `BoundingBox.boundingBoxGeometry` — returns the correct GeoJSON geometry for any bounding box
- Returns `Polygon` normally, `MultiPolygon` split at ±180° when crossing the antimeridian per RFC 7946 §5
- Deprecated `boundingBoxPolygon` in favor of the new property
- Updated internal callers (NearestPointOnFeature, NearestPoint, TileCover)

### Issue #3 — GeoJSON Antimeridian Cutting (RFC 7946 §3.1.9)
- Added `cutAtAntimeridian()` to every geometry and feature type
- All methods return `FeatureCollection` with one `Feature` per cut part
- Feature `id` preserved on the first part, `nil` on subsequent; `properties` copied to all

| Type | Behavior |
|------|----------|
| `LineString` | Each cut part → separate `Feature(LineString)` |
| `Polygon` | Each cut polygon → separate `Feature(Polygon)` |
| `MultiLineString` | Sub-lines cut, flattened into features |
| `MultiPolygon` | Sub-polygons cut, flattened into features |
| `GeometryCollection` | Each sub-geometry cut → features |
| `Feature` | Geometry cut → features preserving `id`/`properties` |
| `FeatureCollection` | Each feature cut individually, flattened |
| `Point` / `MultiPoint` | Wrapped in `FeatureCollection` unchanged |

### Design note
Contrary to RFC 7946 §3.1.9 which calls for returning `MultiLineString` / `MultiPolygon`, the `cutAtAntimeridian()` functions return a `FeatureCollection` with one `Feature` per cut geometry part, providing a uniform iteration interface.

## New files
- `Sources/GISTools/Algorithms/AntimeridianCutting.swift` — namespace + all cutting logic
- `Tests/GISToolsTests/Algorithms/AntimeridianCuttingTests.swift` — 15 tests

## Test results
285 tests pass across 60 suites.

---

Closes #1, closes #3