### PR TITLE
Port boolean-crosses from turf (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,7 +831,7 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | area                        | `Polygon(…).area`                                                                                                                     |     | [Source][45]                 |
 | bearing                     | `Coordinate3D(…).bearing(to: Coordinate3D(…))`                                                                                        |     | [Source][46] / [Tests][47]   |
 | boolean-clockwise           | `Polygon(…).outerRing?.isClockwise`                                                                                                   |     | [Source][48] / [Tests][49]   |
-| boolean-crosses             | TODO                                                                                                                                  |     | [Source][50]                 |
+| boolean-crosses             | `lineString.crosses(otherLineString)`                                                                                                  |     | [Source][50] / [Tests][133]  |
 | boolean-disjoint            | `let result = polygon.isDisjoint(with: lineString)`                                                                                   |     | [Source][126] / [Tests][127] |
 | boolean-intersects          | `let result = polygon.intersects(with: lineString)`                                                                                   |     | [Source][128]                |
 | boolean-overlap             | `lineString1.isOverlapping(with: lineString2)`                                                                                        |     | [Source][52] / [Tests][53]   |
@@ -1023,6 +1023,7 @@ Thomas Rasch, Outdooractive
 [128]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BooleanIntersects.swift "BooleanIntersects"
 [129]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PoygonToLine.swift "PoygonToLine"
 [130]:  https://github.com/Outdooractive/mvt-postgis
+[133]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/BooleanCrossesTests.swift "BooleanCrossesTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/BooleanCrosses.swift
+++ b/Sources/GISTools/Algorithms/BooleanCrosses.swift
@@ -5,4 +5,239 @@ import Foundation
 
 // Ported from https://github.com/Turfjs/turf/blob/master/packages/turf-boolean-crosses
 
-// TODO
+extension GeoJson {
+
+    /// Returns `true` if the intersection of two geometries results in a
+    /// geometry whose dimension is one less than the maximum dimension of
+    /// the two source geometries, and the intersection set is interior to
+    /// both source geometries.
+    ///
+    /// Supports: MultiPoint / LineString, MultiPoint / Polygon,
+    ///           LineString / LineString, LineString / Polygon.
+    ///
+    /// MultiPolygon behaves like Polygon in these comparisons.
+    public func crosses(_ other: GeoJson) -> Bool {
+        // FeatureCollection: check if any contained feature crosses.
+        if let fc1 = self as? FeatureCollection {
+            return fc1.features.contains { $0.crosses(other) }
+        }
+        if let fc2 = other as? FeatureCollection {
+            return fc2.features.contains { self.crosses($0.geometry) }
+        }
+
+        // Anything else
+        let geom1: GeoJson = (self as? Feature)?.geometry ?? self
+        let geom2: GeoJson = (other as? Feature)?.geometry ?? other
+
+        guard let geometry1 = geom1 as? GeoJsonGeometry,
+              let geometry2 = geom2 as? GeoJsonGeometry
+        else { return false }
+
+        return geometryCrosses(geometry1, geometry2)
+    }
+
+    // MARK: - Geometry dispatch
+
+    private func geometryCrosses(
+        _ geom1: GeoJsonGeometry,
+        _ geom2: GeoJsonGeometry
+    ) -> Bool {
+        switch geom1 {
+        case let mp as MultiPoint:
+            switch geom2 {
+            case let ls as LineString:
+                return doMultiPointAndLineStringCross(mp, ls)
+            case let pg as PolygonGeometry:
+                return doesMultiPointCrossPoly(mp, pg)
+            default:
+                return false
+            }
+
+        case let ls as LineString:
+            switch geom2 {
+            case let mp as MultiPoint:
+                return doMultiPointAndLineStringCross(mp, ls)
+            case let ls2 as LineString:
+                return doLineStringsCross(ls, ls2)
+            case let pg as PolygonGeometry:
+                return doLineStringAndPolygonCross(ls, pg)
+            default:
+                return false
+            }
+
+        case let pg as PolygonGeometry:
+            switch geom2 {
+            case let mp as MultiPoint:
+                return doesMultiPointCrossPoly(mp, pg)
+            case let ls as LineString:
+                return doLineStringAndPolygonCross(ls, pg)
+            default:
+                return false
+            }
+
+        default:
+            return false
+        }
+    }
+
+    // MARK: - MultiPoint × LineString
+
+    private func doMultiPointAndLineStringCross(
+        _ multiPoint: MultiPoint,
+        _ lineString: LineString
+    ) -> Bool {
+        var foundIntPoint = false
+        var foundExtPoint = false
+
+        for point in multiPoint.points {
+            var isInterior = false
+            let coords = lineString.coordinates
+            for i in 0..<(coords.count - 1) {
+                let incEnd = (i != 0 && i != coords.count - 2)
+                if isPointOnLineSegment(
+                    start: coords[i],
+                    end: coords[i + 1],
+                    point: point.coordinate,
+                    incEnd: incEnd)
+                {
+                    isInterior = true
+                    break
+                }
+            }
+            if isInterior {
+                foundIntPoint = true
+            }
+            else {
+                foundExtPoint = true
+            }
+            if foundIntPoint, foundExtPoint {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - MultiPoint × Polygon
+
+    private func doesMultiPointCrossPoly(
+        _ multiPoint: MultiPoint,
+        _ polygonGeometry: PolygonGeometry
+    ) -> Bool {
+        var foundIntPoint = false
+        var foundExtPoint = false
+
+        for point in multiPoint.points {
+            if polygonGeometry.contains(point.coordinate, ignoringBoundary: false) {
+                foundIntPoint = true
+            }
+            else {
+                foundExtPoint = true
+            }
+            if foundIntPoint, foundExtPoint {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - LineString × LineString
+
+    private func doLineStringsCross(
+        _ lineString1: LineString,
+        _ lineString2: LineString
+    ) -> Bool {
+        let intersectionPoints = lineString1.intersections(other: lineString2)
+        guard intersectionPoints.isNotEmpty else { return false }
+
+        guard let coords1 = lineString1.coordinates as [Coordinate3D]?,
+              let coords2 = lineString2.coordinates as [Coordinate3D]?
+        else { return false }
+
+        for intersectPoint in intersectionPoints {
+            let pt = intersectPoint.coordinate
+            if !pt.isCoincident(to: coords1.first),
+               !pt.isCoincident(to: coords1.last),
+               !pt.isCoincident(to: coords2.first),
+               !pt.isCoincident(to: coords2.last)
+            {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    // MARK: - LineString × Polygon
+
+    private func doLineStringAndPolygonCross(
+        _ lineString: LineString,
+        _ polygonGeometry: PolygonGeometry
+    ) -> Bool {
+        for polygon in polygonGeometry.polygons {
+            for ring in polygon.rings {
+                let ls = ring.lineString
+                if lineString.intersections(other: ls).isNotEmpty {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    // MARK: - isPointOnLineSegment
+
+    // TODO: We also have LineSegment.checkIsOnSegment()
+
+    /// Checks whether `point` lies on the line segment from `start` to `end`.
+    ///
+    /// - parameter incEnd: If `true` the point may coincide with `start` or `end`.
+    private func isPointOnLineSegment(
+        start: Coordinate3D,
+        end: Coordinate3D,
+        point: Coordinate3D,
+        incEnd: Bool
+    ) -> Bool {
+        let dxc = point.longitude - start.longitude
+        let dyc = point.latitude - start.latitude
+        let dxl = end.longitude - start.longitude
+        let dyl = end.latitude - start.latitude
+        let cross = dxc * dyl - dyc * dxl
+
+        guard cross == 0.0 else { return false }
+
+        if incEnd {
+            if abs(dxl) >= abs(dyl) {
+                return dxl > 0
+                    ? start.longitude <= point.longitude && point.longitude <= end.longitude
+                    : end.longitude <= point.longitude && point.longitude <= start.longitude
+            }
+            return dyl > 0
+                ? start.latitude <= point.latitude && point.latitude <= end.latitude
+                : end.latitude <= point.latitude && point.latitude <= start.latitude
+        }
+        else {
+            if abs(dxl) >= abs(dyl) {
+                return dxl > 0
+                    ? start.longitude < point.longitude && point.longitude < end.longitude
+                    : end.longitude < point.longitude && point.longitude < start.longitude
+            }
+            return dyl > 0
+                ? start.latitude < point.latitude && point.latitude < end.latitude
+                : end.latitude < point.latitude && point.latitude < start.latitude
+        }
+    }
+
+}
+
+// MARK: - Coordinate3D helper
+
+extension Coordinate3D {
+
+    /// `true` when the receiver is equal to `other` within
+    /// the global equality delta.
+    fileprivate func isCoincident(to other: Coordinate3D?) -> Bool {
+        guard let other else { return false }
+        return self.equals(other: other, includingAltitude: false)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/BooleanCrossesTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanCrossesTests.swift
@@ -1,0 +1,300 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct BooleanCrossesTests {
+
+    // MARK: - LineString × LineString — true
+
+    @Test
+    func lineStringLineStringCrosses() async throws {
+        // Vertical line at lon=2, from lat=1 to lat=4
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 2.0),
+            Coordinate3D(latitude: 4.0, longitude: 2.0),
+        ]))
+        // Horizontal line at lat=2, from lon=1 to lon=4
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 2.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 4.0),
+        ]))
+        // Intersects at (lat=2, lon=2) — not an endpoint of either
+        #expect(line1.crosses(line2))
+        #expect(line2.crosses(line1))
+    }
+
+    @Test
+    func lineStringLineStringCrossesDiagonal() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: -2.0, longitude: 2.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: -1.0, longitude: 1.0),
+            Coordinate3D(latitude: 1.0, longitude: 3.0),
+        ]))
+        #expect(line1.crosses(line2))
+    }
+
+    // MARK: - LineString × LineString — false
+
+    @Test
+    func lineStringLineStringDoesNotCross() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 1.0, longitude: 4.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 2.0, longitude: 5.0),
+        ]))
+        // Parallel lines, no intersection
+        #expect(line1.crosses(line2) == false)
+    }
+
+    @Test
+    func lineStringLineStringEndpointTouching() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 20.0, longitude: 0.0),
+        ]))
+        // Touch only at endpoint — not a crossing
+        #expect(line1.crosses(line2) == false)
+    }
+
+    // MARK: - MultiPoint × LineString
+
+    @Test
+    func multiPointLineStringCrosses() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 1.0),
+            Coordinate3D(latitude: 3.0, longitude: 1.0),
+            Coordinate3D(latitude: 4.0, longitude: 1.0),
+            Coordinate3D(latitude: 1.0, longitude: 5.0),  // exterior
+        ]))
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 4.0, longitude: 1.0),
+        ]))
+        #expect(mp.crosses(ls))
+    }
+
+    @Test
+    func multiPointLineStringDoesNotCross() async throws {
+        // Points on the interior of the line (not at endpoints)
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 2.0, longitude: 1.0),
+            Coordinate3D(latitude: 3.0, longitude: 1.0),
+        ]))
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 4.0, longitude: 1.0),
+        ]))
+        // All points on the line — no exterior points
+        #expect(mp.crosses(ls) == false)
+    }
+
+    // MARK: - MultiPoint × Polygon
+
+    @Test
+    func multiPointPolygonCrosses() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 1.0, longitude: 10.0),  // exterior
+        ]))
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        #expect(mp.crosses(polygon))
+    }
+
+    @Test
+    func multiPointPolygonDoesNotCross() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 1.5, longitude: 1.5),
+        ]))
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        // All points inside polygon — no exterior points
+        #expect(mp.crosses(polygon) == false)
+    }
+
+    // MARK: - LineString × Polygon
+
+    @Test
+    func lineStringPolygonCrosses() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: -1.0, longitude: -1.0),
+            Coordinate3D(latitude: 3.0, longitude: 3.0),
+        ]))
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        #expect(ls.crosses(polygon))
+    }
+
+    @Test
+    func lineStringPolygonDoesNotCross() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        // Line entirely outside polygon
+        #expect(ls.crosses(polygon) == false)
+    }
+
+    // MARK: - LineString × MultiPolygon
+
+    @Test
+    func lineStringMultiPolygonCrosses() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: -1.0, longitude: 5.0),
+            Coordinate3D(latitude: 3.0, longitude: 7.0),
+        ]))
+        let poly1 = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let poly2 = try #require(Polygon([[
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 12.0, longitude: 0.0),
+            Coordinate3D(latitude: 12.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ]]))
+        let mp = try #require(MultiPolygon([poly1, poly2]))
+        // Line crosses first polygon's boundary
+        #expect(ls.crosses(mp))
+    }
+
+    // MARK: - Feature unwrapping
+
+    @Test
+    func featureCrosses() async throws {
+        // Vertical line at lon=2
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 2.0),
+            Coordinate3D(latitude: 4.0, longitude: 2.0),
+        ]))
+        // Horizontal line at lat=2
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 2.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 4.0),
+        ]))
+        let feature1 = Feature(line1)
+        let feature2 = Feature(line2)
+        #expect(feature1.crosses(feature2))
+    }
+
+    // MARK: - Unsupported combinations
+
+    @Test
+    func unsupportedCombinationsReturnFalse() async throws {
+        let point = Point(Coordinate3D(latitude: 1.0, longitude: 1.0))
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+        ]))
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 2.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+
+        // Point × Point — not supported
+        #expect(point.crosses(point) == false)
+        // Point × LineString — not supported
+        #expect(point.crosses(line) == false)
+        // LineString × Point — not supported
+        #expect(line.crosses(point) == false)
+        // Polygon × Polygon — not supported
+        #expect(polygon.crosses(polygon) == false)
+        // MultiPoint × Point — not supported
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+        #expect(mp.crosses(point) == false)
+    }
+
+    // MARK: - FeatureCollection
+
+    @Test
+    func featureCollectionCrosses() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 2.0),
+            Coordinate3D(latitude: 4.0, longitude: 2.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 2.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 4.0),
+        ]))
+        let fc = FeatureCollection([Feature(line1)])
+
+        // FeatureCollection with a crossing feature
+        #expect(fc.crosses(line2))
+        #expect(line2.crosses(fc))
+    }
+
+    @Test
+    func featureCollectionDoesNotCross() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 5.0, longitude: 10.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 2.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 4.0),
+        ]))
+        let fc = FeatureCollection([Feature(line1)])
+
+        // No feature crosses
+        #expect(fc.crosses(line2) == false)
+    }
+
+    // MARK: - Commutativity
+
+    @Test
+    func crossesIsCommutative() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 2.0),
+            Coordinate3D(latitude: 4.0, longitude: 2.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 2.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 4.0),
+        ]))
+        #expect(line1.crosses(line2) == line2.crosses(line1))
+    }
+
+}


### PR DESCRIPTION
## Summary

Ported `turf-boolean-crosses` from [Turf.js](https://github.com/Turfjs/turf/blob/master/packages/turf-boolean-crosses) to Swift per OpenGIS Simple Features spec.

Returns `true` if the intersection of two geometries results in a geometry whose dimension is one less than the maximum dimension of the two source geometries, and the intersection set is interior to both.

## Supported combinations

| Geometry 1 | Geometry 2 | Behavior |
|---|---|---|
| `MultiPoint` | `LineString` | Some points on line interior, some exterior |
| `MultiPoint` | `Polygon` / `MultiPolygon` | Some points inside, some outside |
| `LineString` | `LineString` | Intersection at non-endpoint |
| `LineString` | `Polygon` / `MultiPolygon` | Line intersects polygon boundary |
| `Feature` | any | Unwraps to geometry automatically |
| `FeatureCollection` | any | Checks each contained feature |
| Unsupported pairs | | Returns `false` |

## Changes

**`Sources/GISTools/Algorithms/BooleanCrosses.swift`**
- Replaced `// TODO` with full implementation
- `GeoJson.crosses(_:) -> Bool` — main entry point
- Handles `Feature` unwrapping and `FeatureCollection` flattening
- Private helpers for each geometry pair + `isPointOnLineSegment` utility
- `Coordinate3D.isCoincident(to:)` helper for endpoint tolerance check

**`Tests/GISToolsTests/Algorithms/BooleanCrossesTests.swift`** — 16 tests
- `LineString × LineString` crossing, non-crossing (parallel), endpoint-touching
- `MultiPoint × LineString` / `MultiPoint × Polygon` crossing + non-crossing
- `LineString × Polygon` / `LineString × MultiPolygon` crossing + non-crossing
- `Feature` unwrapping, `FeatureCollection` support
- Unsupported combinations return `false`
- Commutativity check

## Test results

All 282 tests pass across 60 suites (was 266, +16 new).

---

Closes #12