### PR TITLE
Add tests for boolean-point-in-polygon and boolean-point-on-line (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,8 +836,8 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | boolean-intersects          | `let result = polygon.intersects(with: lineString)`                                                                                   |     | [Source][128]                |
 | boolean-overlap             | `lineString1.isOverlapping(with: lineString2)`                                                                                        |     | [Source][52] / [Tests][53]   |
 | boolean-parallel            | `lineString1.isParallel(to: lineString2)`                                                                                             |     | [Source][54] / [Tests][55]   |
-| boolean-point-in-polygon    | `polygon.contains(Coordinate3D(…))`                                                                                                   |     | [Source][56]                 |
-| boolean-point-on-line       | `lineString.checkIsOnLine(Coordinate3D(…))`                                                                                           |     | [Source][57]                 |
+| boolean-point-in-polygon    | `polygon.contains(Coordinate3D(…))`                                                                                                   |     | [Source][56] / [Tests][134]  |
+| boolean-point-on-line       | `lineString.checkIsOnLine(Coordinate3D(…))`                                                                                           |     | [Source][57] / [Tests][135]  |
 | boolean-valid               | `anyGeometry.isValid`                                                                                                                 |     | [Source][58]                 |
 | bbox-clip                   | `let clipped = lineString.clipped(to: boundingBox)`                                                                                   |     | [Source][59] / [Tests][60]   |
 | buffer                      | TODO                                                                                                                                  |     | [Source][61]                 |
@@ -1023,6 +1023,8 @@ Thomas Rasch, Outdooractive
 [128]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BooleanIntersects.swift "BooleanIntersects"
 [129]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PoygonToLine.swift "PoygonToLine"
 [130]:  https://github.com/Outdooractive/mvt-postgis
+[134]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/BooleanPointInPolygonTests.swift "BooleanPointInPolygonTests"
+[135]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/BooleanPointOnLineTests.swift "BooleanPointOnLineTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Tests/GISToolsTests/Algorithms/BooleanPointInPolygonTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanPointInPolygonTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct BooleanPointInPolygonTests {
+
+    // MARK: - Ring.contains(_ coordinate)
+
+    @Test
+    func ringContainsCoordinateInside() async throws {
+        let ring = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        #expect(ring.contains(Coordinate3D(latitude: 5.0, longitude: 5.0)))
+    }
+
+    @Test
+    func ringContainsCoordinateOutside() async throws {
+        let ring = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        #expect(ring.contains(Coordinate3D(latitude: 20.0, longitude: 5.0)) == false)
+    }
+
+    @Test
+    func ringContainsCoordinateOnBoundary() async throws {
+        let ring = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        // Default: on boundary → true
+        #expect(ring.contains(Coordinate3D(latitude: 0.0, longitude: 5.0)))
+        // ignoringBoundary: on boundary → false
+        #expect(ring.contains(Coordinate3D(latitude: 0.0, longitude: 5.0), ignoringBoundary: true) == false)
+    }
+
+    @Test
+    func ringContainsPoint() async throws {
+        let ring = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        let pointInside = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        let pointOutside = Point(Coordinate3D(latitude: 20.0, longitude: 5.0))
+        #expect(ring.contains(pointInside))
+        #expect(ring.contains(pointOutside) == false)
+    }
+
+    // MARK: - Ring (convex)
+
+    @Test
+    func ringContainsConvexShape() async throws {
+        let ring = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 4.0),
+            Coordinate3D(latitude: 4.0, longitude: 4.0),
+            Coordinate3D(latitude: 4.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        // Center
+        #expect(ring.contains(Coordinate3D(latitude: 2.0, longitude: 2.0)))
+        // Near corner but inside
+        #expect(ring.contains(Coordinate3D(latitude: 0.5, longitude: 0.5)))
+        // Just outside
+        #expect(ring.contains(Coordinate3D(latitude: -1.0, longitude: 2.0)) == false)
+    }
+
+    // MARK: - Ring (concave / L-shaped)
+
+    @Test
+    func ringContainsConcaveShape() async throws {
+        let ring = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 6.0),
+            Coordinate3D(latitude: 6.0, longitude: 6.0),
+            Coordinate3D(latitude: 6.0, longitude: 4.0),
+            Coordinate3D(latitude: 2.0, longitude: 4.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 6.0, longitude: 2.0),
+            Coordinate3D(latitude: 6.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        // Inside the L-shaped area
+        #expect(ring.contains(Coordinate3D(latitude: 1.0, longitude: 1.0)))
+        #expect(ring.contains(Coordinate3D(latitude: 4.0, longitude: 1.0)))
+        // Inside the "cutout" — not inside the ring
+        #expect(ring.contains(Coordinate3D(latitude: 4.0, longitude: 3.0)) == false)
+    }
+
+    // MARK: - Polygon (with hole)
+
+    @Test
+    func polygonContainsWithHole() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+            [
+                Coordinate3D(latitude: 3.0, longitude: 3.0),
+                Coordinate3D(latitude: 3.0, longitude: 7.0),
+                Coordinate3D(latitude: 7.0, longitude: 7.0),
+                Coordinate3D(latitude: 7.0, longitude: 3.0),
+                Coordinate3D(latitude: 3.0, longitude: 3.0),
+            ],
+        ]))
+        // Inside outer ring, outside hole
+        #expect(polygon.contains(Coordinate3D(latitude: 1.0, longitude: 5.0)))
+        // Inside the hole → not contained
+        #expect(polygon.contains(Coordinate3D(latitude: 5.0, longitude: 5.0)) == false)
+        // Outside outer ring
+        #expect(polygon.contains(Coordinate3D(latitude: 15.0, longitude: 5.0)) == false)
+    }
+
+    @Test
+    func polygonContainsPoint() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        #expect(polygon.contains(Point(Coordinate3D(latitude: 5.0, longitude: 5.0))))
+        #expect(polygon.contains(Point(Coordinate3D(latitude: 20.0, longitude: 5.0))) == false)
+    }
+
+    // MARK: - MultiPolygon
+
+    @Test
+    func multiPolygonContains() async throws {
+        let poly1 = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let poly2 = try #require(Polygon([[
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 5.0),
+            Coordinate3D(latitude: 15.0, longitude: 5.0),
+            Coordinate3D(latitude: 15.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ]]))
+        let mp = try #require(MultiPolygon([poly1, poly2]))
+
+        #expect(mp.contains(Coordinate3D(latitude: 2.0, longitude: 2.0)))
+        #expect(mp.contains(Coordinate3D(latitude: 12.0, longitude: 2.0)))
+        #expect(mp.contains(Coordinate3D(latitude: 7.0, longitude: 2.0)) == false)
+    }
+
+    // MARK: - Feature
+
+    @Test
+    func featureContains() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let feature = Feature(polygon)
+        #expect(feature.contains(Coordinate3D(latitude: 5.0, longitude: 5.0)))
+        #expect(feature.contains(Coordinate3D(latitude: 20.0, longitude: 5.0)) == false)
+    }
+
+    @Test
+    func featureContainsNonPolygon() async throws {
+        let point = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        let feature = Feature(point)
+        // Feature wraps a Point — not a PolygonGeometry, so always false
+        #expect(feature.contains(point.coordinate) == false)
+    }
+
+    // MARK: - FeatureCollection
+
+    @Test
+    func featureCollectionContains() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let fc = FeatureCollection([Feature(polygon)])
+        #expect(fc.contains(Coordinate3D(latitude: 5.0, longitude: 5.0)))
+        #expect(fc.contains(Coordinate3D(latitude: 20.0, longitude: 5.0)) == false)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/BooleanPointOnLineTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanPointOnLineTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct BooleanPointOnLineTests {
+
+    // MARK: - LineSegment.checkIsOnSegment
+
+    @Test
+    func segmentOnSegmentMidpoint() async throws {
+        let segment = LineSegment(
+            first: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            second: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        #expect(segment.checkIsOnSegment(Coordinate3D(latitude: 5.0, longitude: 5.0)))
+    }
+
+    @Test
+    func segmentOnSegmentEndpoint() async throws {
+        let segment = LineSegment(
+            first: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            second: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        // Endpoints are on the segment
+        #expect(segment.checkIsOnSegment(Coordinate3D(latitude: 0.0, longitude: 0.0)))
+        #expect(segment.checkIsOnSegment(Coordinate3D(latitude: 10.0, longitude: 10.0)))
+    }
+
+    @Test
+    func segmentNotOnSegment() async throws {
+        let segment = LineSegment(
+            first: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            second: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        #expect(segment.checkIsOnSegment(Coordinate3D(latitude: 5.0, longitude: 10.0)) == false)
+    }
+
+    @Test
+    func segmentOnSegmentCollinearOutside() async throws {
+        let segment = LineSegment(
+            first: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            second: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        // Collinear but beyond the segment
+        #expect(segment.checkIsOnSegment(Coordinate3D(latitude: 15.0, longitude: 15.0)) == false)
+    }
+
+    @Test
+    func segmentPointOnSegment() async throws {
+        let segment = LineSegment(
+            first: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            second: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        #expect(segment.checkIsOnSegment(Point(Coordinate3D(latitude: 5.0, longitude: 5.0))))
+    }
+
+    // MARK: - LineString.checkIsOnLine
+
+    @Test
+    func lineStringOnLine() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        // On first segment
+        #expect(ls.checkIsOnLine(Coordinate3D(latitude: 0.0, longitude: 5.0)))
+        // On second segment
+        #expect(ls.checkIsOnLine(Coordinate3D(latitude: 5.0, longitude: 10.0)))
+        // At vertex
+        #expect(ls.checkIsOnLine(Coordinate3D(latitude: 0.0, longitude: 10.0)))
+    }
+
+    @Test
+    func lineStringNotOnLine() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        #expect(ls.checkIsOnLine(Coordinate3D(latitude: 5.0, longitude: 5.0)) == false)
+    }
+
+    @Test
+    func lineStringPointOnLine() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ]))
+        #expect(ls.checkIsOnLine(Point(Coordinate3D(latitude: 0.0, longitude: 5.0))))
+    }
+
+    // MARK: - MultiLineString.checkIsOnLine
+
+    @Test
+    func multiLineStringOnLine() async throws {
+        let mls = try #require(MultiLineString([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+            ],
+            [
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 5.0, longitude: 10.0),
+            ],
+        ]))
+        // On first line
+        #expect(mls.checkIsOnLine(Coordinate3D(latitude: 0.0, longitude: 2.0)))
+        // On second line
+        #expect(mls.checkIsOnLine(Coordinate3D(latitude: 5.0, longitude: 7.0)))
+        // Off both lines
+        #expect(mls.checkIsOnLine(Coordinate3D(latitude: 2.0, longitude: 2.0)) == false)
+    }
+
+}


### PR DESCRIPTION
## Summary

Added tests for two previously untested algorithms.

### BooleanPointInPolygonTests (13 tests)

| Test | Coverage |
|------|----------|
| `ringContainsCoordinateInside` | Point inside ring |
| `ringContainsCoordinateOutside` | Point outside ring |
| `ringContainsCoordinateOnBoundary` | Boundary point (default and `ignoringBoundary: true`) |
| `ringContainsPoint` | `Point` variant |
| `ringContainsConvexShape` | Convex ring, near-corner + just-outside |
| `ringContainsConcaveShape` | L-shaped ring, interior, in-cutout (false) |
| `polygonContainsWithHole` | Outer ring ✓, inside hole ✗, outside outer ring ✗ |
| `polygonContainsPoint` | `Point` variant |
| `multiPolygonContains` | Inside poly1, inside poly2, between both ✗ |
| `featureContains` | Feature wrapping Polygon |
| `featureContainsNonPolygon` | Feature wrapping Point → always false |
| `featureCollectionContains` | FeatureCollection with Polygon feature |

### BooleanPointOnLineTests (8 tests)

| Test | Coverage |
|------|----------|
| `segmentOnSegmentMidpoint` | Point at segment midpoint |
| `segmentOnSegmentEndpoint` | Point at segment endpoints |
| `segmentNotOnSegment` | Point off segment |
| `segmentOnSegmentCollinearOutside` | Collinear but beyond segment |
| `segmentPointOnSegment` | `Point` variant |
| `lineStringOnLine` | On first segment, second segment, vertex |
| `lineStringNotOnLine` | Point off all segments |
| `multiLineStringOnLine` | On first line, second line, off both |

## Test results

287 tests pass across 61 suites (+21 new).

---

Closes #14