### PR TITLE
Add tests for center/centroid/center-mean (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,7 +841,7 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | boolean-valid               | `anyGeometry.isValid`                                                                                                                 |     | [Source][58]                 |
 | bbox-clip                   | `let clipped = lineString.clipped(to: boundingBox)`                                                                                   |     | [Source][59] / [Tests][60]   |
 | buffer                      | TODO                                                                                                                                  |     | [Source][61]                 |
-| center/centroid/center-mean | `let center = polygon.center`                                                                                                         |     | [Source][62]                 |
+| center/centroid/center-mean | `let center = polygon.center`                                                                                                         |     | [Source][62] / [Tests][137]  |
 | circle                      | `let circle = point.circle(radius: 5000.0)`                                                                                           |     | [Source][63] / [Tests][64]   |
 | conversions/helpers         | `let distance = GISTool.convert(length: 1.0, from: .miles, to: .meters)`                                                              |     | [Source][65]                 |
 | destination                 | `let destination = coordinate.destination(distance: 1000.0, bearing: 173.0)`                                                          |     | [Source][66] / [Tests][67]   |
@@ -1023,6 +1023,7 @@ Thomas Rasch, Outdooractive
 [128]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BooleanIntersects.swift "BooleanIntersects"
 [129]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PoygonToLine.swift "PoygonToLine"
 [130]:  https://github.com/Outdooractive/mvt-postgis
+[137]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/CenterTests.swift "CenterTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Tests/GISToolsTests/Algorithms/CenterTests.swift
+++ b/Tests/GISToolsTests/Algorithms/CenterTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct CenterTests {
+
+    // MARK: - center
+
+    @Test
+    func pointCenter() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
+        let center = try #require(point.center)
+        #expect(center.coordinate.latitude == 10.0)
+        #expect(center.coordinate.longitude == 20.0)
+    }
+
+    @Test
+    func lineStringCenter() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let center = try #require(ls.center)
+        // Geodesic center should be near (5, 5) but shifted due to curvature
+        #expect(abs(center.coordinate.latitude - 5.0) < 0.2)
+        #expect(abs(center.coordinate.longitude - 5.0) < 0.2)
+    }
+
+    @Test
+    func polygonCenter() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let center = try #require(polygon.center)
+        #expect(abs(center.coordinate.latitude - 5.0) < 1.0)
+        #expect(abs(center.coordinate.longitude - 5.0) < 1.0)
+    }
+
+    @Test
+    func featureCenter() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
+        let feature = Feature(point)
+        let center = try #require(feature.center)
+        #expect(center.coordinate.latitude == 10.0)
+        #expect(center.coordinate.longitude == 20.0)
+    }
+
+    // MARK: - centroid
+
+    @Test
+    func pointCentroid() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
+        let centroid = try #require(point.centroid)
+        #expect(centroid.coordinate.latitude == 10.0)
+        #expect(centroid.coordinate.longitude == 20.0)
+    }
+
+    @Test
+    func lineStringCentroid() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let centroid = try #require(ls.centroid)
+        // Mean of (0,0) and (10,10) = (5,5)
+        #expect(centroid.coordinate.latitude == 5.0)
+        #expect(centroid.coordinate.longitude == 5.0)
+    }
+
+    @Test
+    func polygonCentroid() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let centroid = try #require(polygon.centroid)
+        // Mean of all 5 coordinates (including the closing point)
+        let expectedLat = (0.0 + 0.0 + 10.0 + 10.0 + 0.0) / 5.0
+        let expectedLon = (0.0 + 10.0 + 10.0 + 0.0 + 0.0) / 5.0
+        #expect(centroid.coordinate.latitude == expectedLat)
+        #expect(centroid.coordinate.longitude == expectedLon)
+    }
+
+    @Test
+    func multiPointCentroid() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let centroid = try #require(mp.centroid)
+        #expect(centroid.coordinate.latitude == 5.0)
+        #expect(centroid.coordinate.longitude == 5.0)
+    }
+
+    // MARK: - centroid (edge cases)
+
+    @Test
+    func emptyCentroid() async throws {
+        let ls = LineString()
+        #expect(ls.centroid == nil)
+    }
+
+    // MARK: - centerMean
+
+    @Test
+    func centerMeanUnweighted() async throws {
+        let p1 = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let p2 = Point(Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let fc = FeatureCollection([Feature(p1), Feature(p2)])
+
+        let mean = try #require(fc.centerMean())
+        #expect(mean.coordinate.latitude == 5.0)
+        #expect(mean.coordinate.longitude == 5.0)
+    }
+
+    @Test
+    func centerMeanWeighted() async throws {
+        let p1 = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let p2 = Point(Coordinate3D(latitude: 10.0, longitude: 10.0))
+        var f1 = Feature(p1)
+        f1.setProperty(2.0, for: "w")
+        var f2 = Feature(p2)
+        f2.setProperty(8.0, for: "w")
+
+        let fc = FeatureCollection([f1, f2])
+        let mean = try #require(fc.centerMean(weightAttribute: "w"))
+
+        // Weighted: (0*2 + 10*8) / 10 = 8 for both lat and lon
+        #expect(mean.coordinate.latitude == 8.0)
+        #expect(mean.coordinate.longitude == 8.0)
+    }
+
+    @Test
+    func centerMeanZeroWeightSkipped() async throws {
+        let p1 = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let p2 = Point(Coordinate3D(latitude: 10.0, longitude: 10.0))
+        var f1 = Feature(p1)
+        f1.setProperty(0.0, for: "w")
+        var f2 = Feature(p2)
+        f2.setProperty(1.0, for: "w")
+
+        let fc = FeatureCollection([f1, f2])
+        let mean = try #require(fc.centerMean(weightAttribute: "w"))
+        // f1 skipped (weight 0), only f2 counts
+        #expect(mean.coordinate.latitude == 10.0)
+        #expect(mean.coordinate.longitude == 10.0)
+    }
+
+    @Test
+    func centerMeanEmpty() async throws {
+        let fc = FeatureCollection()
+        #expect(fc.centerMean() == nil)
+    }
+
+    // MARK: - centerMean with LineString coordinates
+
+    @Test
+    func centerMeanLineString() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ]))
+        let fc = FeatureCollection([Feature(ls)])
+        let mean = try #require(fc.centerMean())
+        #expect(mean.coordinate.latitude == 5.0)
+        #expect(mean.coordinate.longitude == 0.0)
+    }
+
+}


### PR DESCRIPTION
## Summary

14 tests covering all three center algorithms.

### `center` (bounding box midpoint)
| Test | Coverage |
|------|----------|
| `pointCenter` | Single point |
| `lineStringCenter` | LineString geodesic center |
| `polygonCenter` | Polygon bounding box center |
| `featureCenter` | Feature wrapping point |

### `centroid` (mean of all vertices)
| Test | Coverage |
|------|----------|
| `pointCentroid` | Single point = same point |
| `lineStringCentroid` | Mean of two coordinates |
| `polygonCentroid` | Mean of ring coordinates (including closing point) |
| `multiPointCentroid` | Mean of four points |
| `emptyCentroid` | Empty geometry → nil |

### `centerMean` (weighted mean for FeatureCollections)
| Test | Coverage |
|------|----------|
| `centerMeanUnweighted` | Two points, equal weights |
| `centerMeanWeighted` | Weighted by property (2:8 ratio) |
| `centerMeanZeroWeightSkipped` | Feature with weight 0 excluded |
| `centerMeanEmpty` | Empty FC → nil |
| `centerMeanLineString` | LineString with multiple coordinates |

## Test results

280 tests pass across 60 suites (+14 new).

---

Closes #17