### PR TITLE
Add tests for 5 nearest/point-on algorithms (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,12 +857,12 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | line-slice                  | `let slice = lineString.slice(start: Coordinate3D(…), end: Coordinate3D(…))`                                                          |     | [Source][86] / [Tests][87]   |
 | line-slice-along            | `let sliced = lineString.sliceAlong(startDistance: 50.0, stopDistance: 2000.0)`                                                       |     | [Source][88] / [Tests][89]   |
 | midpoint                    | `let middle = coordinate1.midpoint(to: coordinate2)`                                                                                  |     | [Source][90] / [Tests][91]   |
-| nearest-point               | `let nearest = anyGeometry.nearestCoordinate(from: Coordinate3D(…))`                                                                  |     | [Source][92]                 |
-| nearest-point-on-feature    | `let nearest = anyGeometry. nearestCoordinateOnFeature(from: Coordinate3D(…))`                                                        |     | [Source][93]                 |
+| nearest-point               | `let nearest = anyGeometry.nearestCoordinate(from: Coordinate3D(…))`                                                                  |     | [Source][92] / [Tests][138]  |
+| nearest-point-on-feature    | `let nearest = anyGeometry. nearestCoordinateOnFeature(from: Coordinate3D(…))`                                                        |     | [Source][93] / [Tests][139]  |
 | nearest-point-on-line       | `let nearest = lineString.nearestCoordinateOnLine(from: Coordinate3D(…))?.coordinate`                                                 |     | [Source][94] / [Tests][95]   |
-| nearest-point-to-line       | `let nearest = lineString. nearestCoordinate(outOf: coordinates)`                                                                     |     | [Source][96]                 |
-| point-on-feature            | `let coordinate = anyGeometry.coordinateOnFeature`                                                                                    |     | [Source][97]                 |
-| points-within-polygon       | `let within = polygon.coordinatesWithin(coordinates)`                                                                                 |     | [Source][98]                 |
+| nearest-point-to-line       | `let nearest = lineString. nearestCoordinate(outOf: coordinates)`                                                                     |     | [Source][96] / [Tests][140]  |
+| point-on-feature            | `let coordinate = anyGeometry.coordinateOnFeature`                                                                                    |     | [Source][97] / [Tests][141]  |
+| points-within-polygon       | `let within = polygon.coordinatesWithin(coordinates)`                                                                                 |     | [Source][98] / [Tests][142]  |
 | point-to-line-distance      | `let distance = lineString.distanceFrom(coordinate: Coordinate3D(…))`                                                                 |     | [Source][99] / [Tests][100]  |
 | pole-of-inaccessibility     | TODO                                                                                                                                  |     | [Source][101]                |
 | polygon-to-line             | `var lineStrings = polygon.lineStrings`                                                                                               |     | [Source][129]                |
@@ -1023,6 +1023,11 @@ Thomas Rasch, Outdooractive
 [128]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BooleanIntersects.swift "BooleanIntersects"
 [129]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PoygonToLine.swift "PoygonToLine"
 [130]:  https://github.com/Outdooractive/mvt-postgis
+[138]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/NearestPointTests.swift "NearestPointTests"
+[139]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/NearestPointOnFeatureTests.swift "NearestPointOnFeatureTests"
+[140]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/NearestPointToLineTests.swift "NearestPointToLineTests"
+[141]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PointOnFeatureTests.swift "PointOnFeatureTests"
+[142]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PointsWithinPolygonTests.swift "PointsWithinPolygonTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Tests/GISToolsTests/Algorithms/NearestPointOnFeatureTests.swift
+++ b/Tests/GISToolsTests/Algorithms/NearestPointOnFeatureTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct NearestPointOnFeatureTests {
+
+    @Test
+    func nearestOnLineString() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ]))
+        let ref = Coordinate3D(latitude: 5.0, longitude: 5.0)
+
+        let result = try #require(ls.nearestCoordinateOnFeature(from: ref))
+        // Nearest point on segment is (0, 5)
+        #expect(abs(result.coordinate.latitude - 0.0) < 0.001)
+        #expect(abs(result.coordinate.longitude - 5.0) < 0.001)
+        #expect(result.distance > 0)
+    }
+
+    @Test
+    func nearestOnPolygonInside() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        // Point inside polygon → returns the point itself with distance 0
+        let ref = Coordinate3D(latitude: 5.0, longitude: 5.0)
+        let result = try #require(polygon.nearestCoordinateOnFeature(from: ref))
+        #expect(result.coordinate == ref)
+        #expect(result.distance == 0.0)
+    }
+
+    @Test
+    func nearestOnPolygonOutside() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let ref = Coordinate3D(latitude: 20.0, longitude: 5.0)
+        let result = try #require(polygon.nearestCoordinateOnFeature(from: ref))
+        // Nearest point is on the top edge of the polygon
+        #expect(abs(result.coordinate.latitude - 10.0) < 0.001)
+        #expect(result.distance > 0)
+    }
+
+    @Test
+    func nearestOnFeature() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ]))
+        let feature = Feature(ls)
+        let ref = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+
+        let result = try #require(feature.nearestPointOnFeature(from: ref))
+        #expect(result.distance > 0)
+    }
+
+    @Test
+    func nearestOnMultiPoint() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ]))
+        let ref = Coordinate3D(latitude: 8.0, longitude: 0.0)
+        let result = try #require(mp.nearestCoordinateOnFeature(from: ref))
+        #expect(result.coordinate == Coordinate3D(latitude: 10.0, longitude: 0.0))
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/NearestPointTests.swift
+++ b/Tests/GISToolsTests/Algorithms/NearestPointTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct NearestPointTests {
+
+    @Test
+    func nearestPointLineString() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let ref = Coordinate3D(latitude: 0.0, longitude: 10.0)
+
+        let result = try #require(ls.nearestCoordinate(from: ref))
+        // (0,0) is closer to (0,10) than (10,10)
+        #expect(result.coordinate == Coordinate3D(latitude: 0.0, longitude: 0.0))
+        #expect(result.distance > 0)
+    }
+
+    @Test
+    func nearestPointMultiPoint() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let ref = Coordinate3D(latitude: 1.0, longitude: 1.0)
+
+        let result = try #require(mp.nearestCoordinate(from: ref))
+        #expect(result.coordinate == Coordinate3D(latitude: 0.0, longitude: 0.0))
+    }
+
+    @Test
+    func nearestPointFeature() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let feature = Feature(ls)
+        let ref = Point(Coordinate3D(latitude: 0.0, longitude: 10.0))
+
+        let result = try #require(feature.nearestPoint(from: ref))
+        #expect(result.point.coordinate == Coordinate3D(latitude: 0.0, longitude: 0.0))
+    }
+
+    @Test
+    func nearestPointEmpty() async throws {
+        let ls = LineString()
+        #expect(ls.nearestCoordinate(from: Coordinate3D(latitude: 0.0, longitude: 0.0)) == nil)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/NearestPointToLineTests.swift
+++ b/Tests/GISToolsTests/Algorithms/NearestPointToLineTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct NearestPointToLineTests {
+
+    @Test
+    func nearestCoordinateOutOf() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ]))
+        let candidates = [
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 10.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+        ]
+        let result = try #require(ls.nearestCoordinate(outOf: candidates))
+        // (0, 1) is closest to the line (which runs along lon=0)
+        #expect(result.coordinate == Coordinate3D(latitude: 0.0, longitude: 1.0))
+    }
+
+    @Test
+    func nearestPointAndDistance() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ]))
+        let candidates = [
+            Point(Coordinate3D(latitude: 5.0, longitude: 5.0)),
+            Point(Coordinate3D(latitude: 0.0, longitude: 2.0)),
+        ]
+        let result = try #require(ls.nearestPointAndDistance(outOf: candidates))
+        #expect(result.point.coordinate == Coordinate3D(latitude: 0.0, longitude: 2.0))
+    }
+
+    @Test
+    func nearestCoordinateOutOfEmpty() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ]))
+        #expect(ls.nearestCoordinate(outOf: []) == nil)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/PointOnFeatureTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PointOnFeatureTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct PointOnFeatureTests {
+
+    @Test
+    func pointOnPoint() async throws {
+        let p = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        let result = try #require(p.coordinateOnFeature)
+        #expect(result == Coordinate3D(latitude: 5.0, longitude: 5.0))
+    }
+
+    @Test
+    func pointOnLineString() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let result = try #require(ls.coordinateOnFeature)
+        // Centroid is (5,5) which is on the line
+        #expect(result == Coordinate3D(latitude: 5.0, longitude: 5.0))
+    }
+
+    @Test
+    func pointOnPolygon() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let result = try #require(polygon.pointOnFeature)
+        // Should be on the surface
+        #expect(result.coordinate.latitude >= 0.0)
+        #expect(result.coordinate.latitude <= 10.0)
+    }
+
+    @Test
+    func pointOnMultiPolygon() async throws {
+        let poly1 = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let poly2 = try #require(Polygon([[
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 15.0, longitude: 10.0),
+            Coordinate3D(latitude: 15.0, longitude: 15.0),
+            Coordinate3D(latitude: 10.0, longitude: 15.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]]))
+        let mp = try #require(MultiPolygon([poly1, poly2]))
+        let result = try #require(mp.pointOnFeature)
+        // Should be inside one of the polygons
+        #expect(result.coordinate.latitude >= 0.0)
+        #expect(result.coordinate.latitude <= 15.0)
+    }
+
+    @Test
+    func pointOnFeature() async throws {
+        let point = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        let feature = Feature(point)
+        let result = try #require(feature.pointOnFeature)
+        #expect(result.coordinate == Coordinate3D(latitude: 5.0, longitude: 5.0))
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/PointsWithinPolygonTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PointsWithinPolygonTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct PointsWithinPolygonTests {
+
+    @Test
+    func coordinatesWithin() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let candidates = [
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 15.0, longitude: 5.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+        ]
+        let result = polygon.coordinatesWithin(candidates)
+        #expect(result.count == 2)
+        #expect(result.contains(Coordinate3D(latitude: 5.0, longitude: 5.0)))
+        #expect(result.contains(Coordinate3D(latitude: 2.0, longitude: 2.0)))
+        #expect(!result.contains(Coordinate3D(latitude: 15.0, longitude: 5.0)))
+    }
+
+    @Test
+    func pointsWithin() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let candidates = [
+            Point(Coordinate3D(latitude: 5.0, longitude: 5.0)),
+            Point(Coordinate3D(latitude: 15.0, longitude: 5.0)),
+        ]
+        let result = polygon.pointsWithin(candidates)
+        #expect(result.count == 1)
+        #expect(result[0].coordinate == Coordinate3D(latitude: 5.0, longitude: 5.0))
+    }
+
+    @Test
+    func pointsWithinMultiPolygon() async throws {
+        let poly1 = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let poly2 = try #require(Polygon([[
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 15.0, longitude: 10.0),
+            Coordinate3D(latitude: 15.0, longitude: 15.0),
+            Coordinate3D(latitude: 10.0, longitude: 15.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]]))
+        let mp = try #require(MultiPolygon([poly1, poly2]))
+        let candidates = [
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 12.0, longitude: 12.0),
+            Coordinate3D(latitude: 7.0, longitude: 7.0),
+        ]
+        let result = mp.coordinatesWithin(candidates)
+        #expect(result.count == 2)
+    }
+
+    @Test
+    func coordinatesWithinEmpty() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let result = polygon.coordinatesWithin([])
+        #expect(result.isEmpty)
+    }
+
+}


### PR DESCRIPTION
## Summary

21 tests across 5 suites for previously untested algorithms.

### NearestPointTests (4 tests)
- `nearestPointLineString` — nearest coordinate to reference
- `nearestPointMultiPoint` — nearest among multipoint
- `nearestPointFeature` — nearest point via Feature
- `nearestPointEmpty` — empty geometry → nil

### NearestPointOnFeatureTests (5 tests)
- `nearestOnLineString` — nearest on line segment surface
- `nearestOnPolygonInside` — inside → distance 0
- `nearestOnPolygonOutside` — nearest on boundary
- `nearestOnFeature` — via Feature wrapper
- `nearestOnMultiPoint` — nearest point among set

### NearestPointToLineTests (3 tests)
- `nearestCoordinateOutOf` — closest candidate to line
- `nearestPointAndDistance` — Point variant
- `nearestCoordinateOutOfEmpty` — empty candidates → nil

### PointOnFeatureTests (5 tests)
- `pointOnPoint` — returns the point itself
- `pointOnLineString` — centroid on segment
- `pointOnPolygon` — point on polygon surface
- `pointOnMultiPolygon` — point on multipolygon surface
- `pointOnFeature` — via Feature wrapper

### PointsWithinPolygonTests (4 tests)
- `coordinatesWithin` — filter with inside/outside/mixed
- `pointsWithin` — Point variant
- `pointsWithinMultiPolygon` — MultiPolygon
- `coordinatesWithinEmpty` — empty candidates

## Test results

287 tests pass across 64 suites (+21 new).

---

Closes #20