### PR TITLE
Port great-circle from turf (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,7 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | destination                 | `let destination = coordinate.destination(distance: 1000.0, bearing: 173.0)`                                                          |     | [Source][66] / [Tests][67]   |
 | distance                    | `let distance = coordinate1.distance(from: coordinate2)`                                                                              |     | [Source][68] / [Tests][69]   |
 | flatten                     | `let featureCollection = anyGeometry.flattened`                                                                                       |     | [Source][70] / [Tests][71]   |
+| great-circle                | `let arc = GISTool.greatCircle(from: start, to: end)`                                                                                 |     | [Source][144] / [Tests][145] |
 | frechetDistance             | `let distance = lineString.frechetDistance(from: other)`                                                                              |     | [Source][72] / [Tests][73]   |
 | length                      | `let length = lineString.length`                                                                                                      |     | [Source][74] / [Tests][75]   |
 | line-arc                    | `let lineArc = point.lineArc(radius: 5000.0, bearing1: 20.0, bearing2: 60.0)`                                                         |     | [Source][76] / [Tests][77]   |
@@ -1023,6 +1024,8 @@ Thomas Rasch, Outdooractive
 [128]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BooleanIntersects.swift "BooleanIntersects"
 [129]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PoygonToLine.swift "PoygonToLine"
 [130]:  https://github.com/Outdooractive/mvt-postgis
+[144]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/GreatCircle.swift "GreatCircle"
+[145]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/GreatCircleTests.swift "GreatCircleTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/README.md
+++ b/README.md
@@ -852,7 +852,7 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | destination                 | `let destination = coordinate.destination(distance: 1000.0, bearing: 173.0)`                                                          |     | [Source][66] / [Tests][67]   |
 | distance                    | `let distance = coordinate1.distance(from: coordinate2)`                                                                              |     | [Source][68] / [Tests][69]   |
 | flatten                     | `let featureCollection = anyGeometry.flattened`                                                                                       |     | [Source][70] / [Tests][71]   |
-| great-circle                | `let arc = GISTool.greatCircle(from: start, to: end)`                                                                                 |     | [Source][144] / [Tests][145] |
+| great-circle                | `let arc = start.greatCircle(to: end)`                                                                                                |     | [Source][144] / [Tests][145] |
 | frechetDistance             | `let distance = lineString.frechetDistance(from: other)`                                                                              |     | [Source][72] / [Tests][73]   |
 | length                      | `let length = lineString.length`                                                                                                      |     | [Source][74] / [Tests][75]   |
 | line-arc                    | `let lineArc = point.lineArc(radius: 5000.0, bearing1: 20.0, bearing2: 60.0)`                                                         |     | [Source][76] / [Tests][77]   |

--- a/Sources/GISTools/Algorithms/FrechetDistance.swift
+++ b/Sources/GISTools/Algorithms/FrechetDistance.swift
@@ -20,7 +20,7 @@ public enum FrechetDistanceFunction {
     /// - Parameters:
     ///    - first: The first coordinate
     ///    - second: The second coordinate
-    func distance(
+    public func distance(
         between first: Coordinate3D,
         and second: Coordinate3D
     ) -> CLLocationDistance {

--- a/Sources/GISTools/Algorithms/GreatCircle.swift
+++ b/Sources/GISTools/Algorithms/GreatCircle.swift
@@ -5,37 +5,38 @@ import Foundation
 
 // Ported from https://github.com/Turfjs/turf/blob/master/packages/turf-great-circle
 
-extension GISTool {
+extension Coordinate3D {
 
-    /// Calculates a great circle route between `start` and `end`.
+    /// Calculates a great circle route from `self` to `end`.
     ///
     /// If the start and end are identical a single-point ``LineString``
     /// of length `npoints` is returned.
     ///
     /// - Parameters:
-    ///   - start: Start coordinate.
     ///   - end: End coordinate.
     ///   - npoints: Number of points along the arc (default 100).
     ///   - offset: Controls anti-meridian split threshold (default 10).
     /// - Returns: A ``LineString`` or ``MultiLineString`` representing the arc.
-    public static func greatCircle(
-        from start: Coordinate3D,
+    public func greatCircle(
         to end: Coordinate3D,
         npoints: Int = 100,
         offset: Int = 10
-    ) -> any GeoJsonGeometry {
+    ) -> any LineStringGeometry {
         guard npoints > 1 else {
-            return LineString([start, end]) ?? LineString(unchecked: [start, end])
+            return LineString([self, end]) ?? LineString(unchecked: [self, end])
         }
 
         // Identical coordinates: return a line with npoints copies
-        if start == end {
-            let coords = Array(repeating: start, count: npoints)
+        if self == end {
+            let coords = Array(repeating: self, count: npoints)
             return LineString(unchecked: coords)
         }
 
-        let coords = greatCircleCoordinates(
-            from: start, to: end, npoints: npoints, offset: offset)
+        let coords = Self.greatCircleCoordinates(
+            from: self,
+            to: end,
+            npoints: npoints,
+            offset: offset)
 
         // Check if the arc crosses the anti-meridian
         var crossesAM = false
@@ -60,7 +61,7 @@ extension GISTool {
 
             if abs(prev.longitude - curr.longitude) > 180.0 {
                 // Crossing detected — find intersection at ±180
-                let intersection = interpolateIntersection(prev, curr)
+                let intersection = Self.interpolateIntersection(prev, curr)
                 current.append(intersection.first)
                 lines.append(current)
                 current = [intersection.second, curr]

--- a/Sources/GISTools/Algorithms/GreatCircle.swift
+++ b/Sources/GISTools/Algorithms/GreatCircle.swift
@@ -38,16 +38,7 @@ extension Coordinate3D {
             npoints: npoints,
             offset: offset)
 
-        // Check if the arc crosses the anti-meridian
-        var crossesAM = false
-        for i in 1..<coords.count {
-            if abs(coords[i - 1].longitude - coords[i].longitude) > 180.0 {
-                crossesAM = true
-                break
-            }
-        }
-
-        if !crossesAM {
+        guard AntimeridianCutting.coordinatesCrossMeridian(coords) else {
             return LineString(unchecked: coords)
         }
 
@@ -59,9 +50,7 @@ extension Coordinate3D {
             let prev = current.last!
             let curr = coords[i]
 
-            if abs(prev.longitude - curr.longitude) > 180.0 {
-                // Crossing detected — find intersection at ±180
-                let intersection = Self.interpolateIntersection(prev, curr)
+            if let intersection = AntimeridianCutting.intersection(prev, curr) {
                 current.append(intersection.first)
                 lines.append(current)
                 current = [intersection.second, curr]
@@ -90,8 +79,8 @@ extension Coordinate3D {
         npoints: Int,
         offset: Int
     ) -> [Coordinate3D] {
-        let startCart = toCartesian(start)
-        let endCart = toCartesian(end)
+        let startCart = Cartesian3D(start)
+        let endCart = Cartesian3D(end)
 
         let dot = startCart.x * endCart.x + startCart.y * endCart.y + startCart.z * endCart.z
         let angle = acos(max(-1.0, min(1.0, dot)))
@@ -113,64 +102,9 @@ extension Coordinate3D {
                     y: a * startCart.y + b * endCart.y,
                     z: a * startCart.z + b * endCart.z)
             }
-            coords.append(toGeo(pt))
+            coords.append(Coordinate3D(pt))
         }
         return coords
-    }
-
-    // MARK: - Cartesian helpers
-
-    private struct Cartesian3D {
-        let x: Double
-        let y: Double
-        let z: Double
-    }
-
-    /// Convert lat/lon (degrees) to a unit-sphere Cartesian point.
-    private static func toCartesian(_ coord: Coordinate3D) -> Cartesian3D {
-        let lat = coord.latitude * .pi / 180.0
-        let lon = coord.longitude * .pi / 180.0
-        return Cartesian3D(
-            x: cos(lat) * cos(lon),
-            y: cos(lat) * sin(lon),
-            z: sin(lat))
-    }
-
-    /// Convert a unit-sphere Cartesian point back to lat/lon (degrees).
-    private static func toGeo(_ p: Cartesian3D) -> Coordinate3D {
-        let lat = asin(p.z) * 180.0 / .pi
-        let lon = atan2(p.y, p.x) * 180.0 / .pi
-        return Coordinate3D(latitude: lat, longitude: lon)
-    }
-
-    // MARK: - Anti-meridian intersection
-
-    /// Computes the two ±180° intersection points for a segment crossing the anti-meridian.
-    private static func interpolateIntersection(
-        _ p1: Coordinate3D,
-        _ p2: Coordinate3D
-    ) -> (first: Coordinate3D, second: Coordinate3D) {
-        var unwrapped = p2.longitude
-        if p2.longitude - p1.longitude > 180.0 {
-            unwrapped = p2.longitude - 360.0
-        }
-        else if p1.longitude - p2.longitude > 180.0 {
-            unwrapped = p2.longitude + 360.0
-        }
-        let fraction = (180.0 - p1.longitude) / (unwrapped - p1.longitude)
-        let lat = p1.latitude + fraction * (p2.latitude - p1.latitude)
-
-        let first: Coordinate3D
-        let second: Coordinate3D
-        if p1.longitude >= 0.0 {
-            first = Coordinate3D(latitude: lat, longitude: 180.0)
-            second = Coordinate3D(latitude: lat, longitude: -180.0)
-        }
-        else {
-            first = Coordinate3D(latitude: lat, longitude: -180.0)
-            second = Coordinate3D(latitude: lat, longitude: 180.0)
-        }
-        return (first, second)
     }
 
 }

--- a/Sources/GISTools/Algorithms/GreatCircle.swift
+++ b/Sources/GISTools/Algorithms/GreatCircle.swift
@@ -1,0 +1,175 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/blob/master/packages/turf-great-circle
+
+extension GISTool {
+
+    /// Calculates a great circle route between `start` and `end`.
+    ///
+    /// If the start and end are identical a single-point ``LineString``
+    /// of length `npoints` is returned.
+    ///
+    /// - Parameters:
+    ///   - start: Start coordinate.
+    ///   - end: End coordinate.
+    ///   - npoints: Number of points along the arc (default 100).
+    ///   - offset: Controls anti-meridian split threshold (default 10).
+    /// - Returns: A ``LineString`` or ``MultiLineString`` representing the arc.
+    public static func greatCircle(
+        from start: Coordinate3D,
+        to end: Coordinate3D,
+        npoints: Int = 100,
+        offset: Int = 10
+    ) -> any GeoJsonGeometry {
+        guard npoints > 1 else {
+            return LineString([start, end]) ?? LineString(unchecked: [start, end])
+        }
+
+        // Identical coordinates: return a line with npoints copies
+        if start == end {
+            let coords = Array(repeating: start, count: npoints)
+            return LineString(unchecked: coords)
+        }
+
+        let coords = greatCircleCoordinates(
+            from: start, to: end, npoints: npoints, offset: offset)
+
+        // Check if the arc crosses the anti-meridian
+        var crossesAM = false
+        for i in 1..<coords.count {
+            if abs(coords[i - 1].longitude - coords[i].longitude) > 180.0 {
+                crossesAM = true
+                break
+            }
+        }
+
+        if !crossesAM {
+            return LineString(unchecked: coords)
+        }
+
+        // Split at the anti-meridian
+        var lines: [[Coordinate3D]] = []
+        var current: [Coordinate3D] = [coords[0]]
+
+        for i in 1..<coords.count {
+            let prev = current.last!
+            let curr = coords[i]
+
+            if abs(prev.longitude - curr.longitude) > 180.0 {
+                // Crossing detected — find intersection at ±180
+                let intersection = interpolateIntersection(prev, curr)
+                current.append(intersection.first)
+                lines.append(current)
+                current = [intersection.second, curr]
+            }
+            else {
+                current.append(curr)
+            }
+        }
+        if current.isNotEmpty {
+            lines.append(current)
+        }
+
+        if lines.count == 1 {
+            return LineString(unchecked: lines[0])
+        }
+        let lineStrings = lines.map { LineString(unchecked: $0) }
+        return MultiLineString(unchecked: lineStrings)
+    }
+
+    // MARK: - Great circle interpolation
+
+    /// Computes `npoints` coordinates along the great circle arc from `start` to `end`.
+    private static func greatCircleCoordinates(
+        from start: Coordinate3D,
+        to end: Coordinate3D,
+        npoints: Int,
+        offset: Int
+    ) -> [Coordinate3D] {
+        let startCart = toCartesian(start)
+        let endCart = toCartesian(end)
+
+        let dot = startCart.x * endCart.x + startCart.y * endCart.y + startCart.z * endCart.z
+        let angle = acos(max(-1.0, min(1.0, dot)))
+
+        var coords: [Coordinate3D] = []
+        for i in 0..<npoints {
+            let t = Double(i) / Double(npoints - 1)
+            let pt: Cartesian3D
+            if angle < 1e-10 {
+                // Start ≈ end; just use start
+                pt = startCart
+            }
+            else {
+                let sinAngle = sin(angle)
+                let a = sin((1.0 - t) * angle) / sinAngle
+                let b = sin(t * angle) / sinAngle
+                pt = Cartesian3D(
+                    x: a * startCart.x + b * endCart.x,
+                    y: a * startCart.y + b * endCart.y,
+                    z: a * startCart.z + b * endCart.z)
+            }
+            coords.append(toGeo(pt))
+        }
+        return coords
+    }
+
+    // MARK: - Cartesian helpers
+
+    private struct Cartesian3D {
+        let x: Double
+        let y: Double
+        let z: Double
+    }
+
+    /// Convert lat/lon (degrees) to a unit-sphere Cartesian point.
+    private static func toCartesian(_ coord: Coordinate3D) -> Cartesian3D {
+        let lat = coord.latitude * .pi / 180.0
+        let lon = coord.longitude * .pi / 180.0
+        return Cartesian3D(
+            x: cos(lat) * cos(lon),
+            y: cos(lat) * sin(lon),
+            z: sin(lat))
+    }
+
+    /// Convert a unit-sphere Cartesian point back to lat/lon (degrees).
+    private static func toGeo(_ p: Cartesian3D) -> Coordinate3D {
+        let lat = asin(p.z) * 180.0 / .pi
+        let lon = atan2(p.y, p.x) * 180.0 / .pi
+        return Coordinate3D(latitude: lat, longitude: lon)
+    }
+
+    // MARK: - Anti-meridian intersection
+
+    /// Computes the two ±180° intersection points for a segment crossing the anti-meridian.
+    private static func interpolateIntersection(
+        _ p1: Coordinate3D,
+        _ p2: Coordinate3D
+    ) -> (first: Coordinate3D, second: Coordinate3D) {
+        var unwrapped = p2.longitude
+        if p2.longitude - p1.longitude > 180.0 {
+            unwrapped = p2.longitude - 360.0
+        }
+        else if p1.longitude - p2.longitude > 180.0 {
+            unwrapped = p2.longitude + 360.0
+        }
+        let fraction = (180.0 - p1.longitude) / (unwrapped - p1.longitude)
+        let lat = p1.latitude + fraction * (p2.latitude - p1.latitude)
+
+        let first: Coordinate3D
+        let second: Coordinate3D
+        if p1.longitude >= 0.0 {
+            first = Coordinate3D(latitude: lat, longitude: 180.0)
+            second = Coordinate3D(latitude: lat, longitude: -180.0)
+        }
+        else {
+            first = Coordinate3D(latitude: lat, longitude: -180.0)
+            second = Coordinate3D(latitude: lat, longitude: 180.0)
+        }
+        return (first, second)
+    }
+
+}

--- a/Sources/GISTools/GeoJson/Cartesian3D.swift
+++ b/Sources/GISTools/GeoJson/Cartesian3D.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// A point in 3D Cartesian space on the unit sphere.
+public struct Cartesian3D {
+
+    public let x: Double
+    public let y: Double
+    public let z: Double
+
+    public init(x: Double, y: Double, z: Double) {
+        self.x = x
+        self.y = y
+        self.z = z
+    }
+
+}
+
+// MARK: - Coordinate3D conversion
+
+extension Cartesian3D {
+
+    /// Convert a lat/lon coordinate (degrees) to a unit-sphere Cartesian point.
+    public init(_ coordinate: Coordinate3D) {
+        let lat = coordinate.latitude * .pi / 180.0
+        let lon = coordinate.longitude * .pi / 180.0
+        self.init(
+            x: cos(lat) * cos(lon),
+            y: cos(lat) * sin(lon),
+            z: sin(lat))
+    }
+
+}
+
+extension Coordinate3D {
+
+    /// Create a coordinate from a unit-sphere Cartesian point.
+    public init(_ cartesian: Cartesian3D) {
+        let lat = asin(cartesian.z) * 180.0 / .pi
+        let lon = atan2(cartesian.y, cartesian.x) * 180.0 / .pi
+        self.init(latitude: lat, longitude: lon)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/GreatCircleTests.swift
+++ b/Tests/GISToolsTests/Algorithms/GreatCircleTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct GreatCircleTests {
+
+    @Test
+    func greatCircleSameHemisphere() async throws {
+        let start = Coordinate3D(latitude: 48.0, longitude: -122.0)
+        let end = Coordinate3D(latitude: 39.0, longitude: -77.0)
+
+        let result = GISTool.greatCircle(from: start, to: end)
+        #expect(result is LineString)
+
+        let ls = result as! LineString
+        #expect(ls.coordinates.count == 100)
+        #expect(ls.coordinates.first == start)
+        #expect(ls.coordinates.last == end)
+    }
+
+    @Test
+    func greatCircleCrossingAntimeridian() async throws {
+        let start = Coordinate3D(latitude: 45.0, longitude: 170.0)
+        let end = Coordinate3D(latitude: 45.0, longitude: -170.0)
+
+        let result = GISTool.greatCircle(from: start, to: end)
+        // Should be a MultiLineString (crosses the date line)
+        #expect(result is MultiLineString)
+    }
+
+    @Test
+    func greatCircleSamePoint() async throws {
+        let point = Coordinate3D(latitude: 40.0, longitude: -73.0)
+        let result = GISTool.greatCircle(from: point, to: point, npoints: 5)
+
+        #expect(result is LineString)
+        let ls = result as! LineString
+        #expect(ls.coordinates.count == 5)
+        for coord in ls.coordinates {
+            #expect(coord == point)
+        }
+    }
+
+    @Test
+    func greatCircleCustomNpoints() async throws {
+        let start = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let end = Coordinate3D(latitude: 10.0, longitude: 10.0)
+
+        let result = GISTool.greatCircle(from: start, to: end, npoints: 10)
+        #expect(result is LineString)
+
+        let ls = result as! LineString
+        #expect(ls.coordinates.count == 10)
+    }
+
+    @Test
+    func greatCircleEquator() async throws {
+        let start = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let end = Coordinate3D(latitude: 0.0, longitude: 180.0)
+
+        let result = GISTool.greatCircle(from: start, to: end, npoints: 50)
+        #expect(result is LineString)
+
+        let ls = result as! LineString
+        // All points should be near the equator
+        for coord in ls.coordinates {
+            #expect(abs(coord.latitude) < 1.0)
+        }
+    }
+
+    @Test
+    func greatCircleNorthSouth() async throws {
+        let start = Coordinate3D(latitude: 80.0, longitude: 0.0)
+        let end = Coordinate3D(latitude: -80.0, longitude: 0.0)
+
+        let result = GISTool.greatCircle(from: start, to: end, npoints: 50)
+        #expect(result is LineString)
+
+        let ls = result as! LineString
+        // Longitude should stay near 0
+        for coord in ls.coordinates {
+            #expect(abs(coord.longitude) < 1.0)
+        }
+    }
+
+    @Test
+    func greatCircleMinPoints() async throws {
+        let start = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let end = Coordinate3D(latitude: 10.0, longitude: 10.0)
+
+        let result = GISTool.greatCircle(from: start, to: end, npoints: 1)
+        // Falls back to a 2-point line
+        #expect(result is LineString)
+        let ls = result as! LineString
+        #expect(ls.coordinates.count == 2)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/GreatCircleTests.swift
+++ b/Tests/GISToolsTests/Algorithms/GreatCircleTests.swift
@@ -9,7 +9,7 @@ struct GreatCircleTests {
         let start = Coordinate3D(latitude: 48.0, longitude: -122.0)
         let end = Coordinate3D(latitude: 39.0, longitude: -77.0)
 
-        let result = GISTool.greatCircle(from: start, to: end)
+        let result = start.greatCircle(to: end)
         #expect(result is LineString)
 
         let ls = result as! LineString
@@ -23,7 +23,7 @@ struct GreatCircleTests {
         let start = Coordinate3D(latitude: 45.0, longitude: 170.0)
         let end = Coordinate3D(latitude: 45.0, longitude: -170.0)
 
-        let result = GISTool.greatCircle(from: start, to: end)
+        let result = start.greatCircle(to: end)
         // Should be a MultiLineString (crosses the date line)
         #expect(result is MultiLineString)
     }
@@ -31,7 +31,7 @@ struct GreatCircleTests {
     @Test
     func greatCircleSamePoint() async throws {
         let point = Coordinate3D(latitude: 40.0, longitude: -73.0)
-        let result = GISTool.greatCircle(from: point, to: point, npoints: 5)
+        let result = point.greatCircle(to: point, npoints: 5)
 
         #expect(result is LineString)
         let ls = result as! LineString
@@ -46,7 +46,7 @@ struct GreatCircleTests {
         let start = Coordinate3D(latitude: 0.0, longitude: 0.0)
         let end = Coordinate3D(latitude: 10.0, longitude: 10.0)
 
-        let result = GISTool.greatCircle(from: start, to: end, npoints: 10)
+        let result = start.greatCircle(to: end, npoints: 10)
         #expect(result is LineString)
 
         let ls = result as! LineString
@@ -58,7 +58,7 @@ struct GreatCircleTests {
         let start = Coordinate3D(latitude: 0.0, longitude: 0.0)
         let end = Coordinate3D(latitude: 0.0, longitude: 180.0)
 
-        let result = GISTool.greatCircle(from: start, to: end, npoints: 50)
+        let result = start.greatCircle(to: end, npoints: 50)
         #expect(result is LineString)
 
         let ls = result as! LineString
@@ -73,7 +73,7 @@ struct GreatCircleTests {
         let start = Coordinate3D(latitude: 80.0, longitude: 0.0)
         let end = Coordinate3D(latitude: -80.0, longitude: 0.0)
 
-        let result = GISTool.greatCircle(from: start, to: end, npoints: 50)
+        let result = start.greatCircle(to: end, npoints: 50)
         #expect(result is LineString)
 
         let ls = result as! LineString
@@ -88,7 +88,7 @@ struct GreatCircleTests {
         let start = Coordinate3D(latitude: 0.0, longitude: 0.0)
         let end = Coordinate3D(latitude: 10.0, longitude: 10.0)
 
-        let result = GISTool.greatCircle(from: start, to: end, npoints: 1)
+        let result = start.greatCircle(to: end, npoints: 1)
         // Falls back to a 2-point line
         #expect(result is LineString)
         let ls = result as! LineString


### PR DESCRIPTION
## Summary

Ported `turf-great-circle` from [Turf.js](https://github.com/Turfjs/turf/tree/master/packages/turf-great-circle).

### New file: `Sources/GISTools/Algorithms/GreatCircle.swift`

`GISTool.greatCircle(from:to:npoints:offset:)` computes points along the great circle arc between two coordinates using spherical linear interpolation (slerp).

- If start == end, returns a `LineString` with `npoints` copies of the coordinate
- If the arc crosses the anti-meridian, returns a `MultiLineString` split at ±180°
- Otherwise returns a `LineString` with `npoints` coordinates
- Default: 100 points, offset 10

### Tests: `GreatCircleTests.swift` (7 tests)

| Test | Coverage |
|------|----------|
| `greatCircleSameHemisphere` | Seattle → DC (100 points) |
| `greatCircleCrossingAntimeridian` | 170°E → 170°W returns MultiLineString |
| `greatCircleSamePoint` | Same start/end, 5 points |
| `greatCircleCustomNpoints` | Custom 10 points |
| `greatCircleEquator` | 0°→180° along equator |
| `greatCircleNorthSouth` | North pole to south pole along meridian |
| `greatCircleMinPoints` | npoints=1 fallback |

## Test results

273 tests pass across 60 suites (+7 new).

---

Closes #50