### PR TITLE
Port convex hull from turf (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,7 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | center/centroid/center-mean | `let center = polygon.center`                                                                                                         |     | [Source][62]                 |
 | circle                      | `let circle = point.circle(radius: 5000.0)`                                                                                           |     | [Source][63] / [Tests][64]   |
 | conversions/helpers         | `let distance = GISTool.convert(length: 1.0, from: .miles, to: .meters)`                                                              |     | [Source][65]                 |
+| convex-hull                 | `let hull = anyGeometry.convexHull()`                                                                                                   |     | [Source][146] / [Tests][147] |
 | destination                 | `let destination = coordinate.destination(distance: 1000.0, bearing: 173.0)`                                                          |     | [Source][66] / [Tests][67]   |
 | distance                    | `let distance = coordinate1.distance(from: coordinate2)`                                                                              |     | [Source][68] / [Tests][69]   |
 | flatten                     | `let featureCollection = anyGeometry.flattened`                                                                                       |     | [Source][70] / [Tests][71]   |
@@ -1023,6 +1024,8 @@ Thomas Rasch, Outdooractive
 [128]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BooleanIntersects.swift "BooleanIntersects"
 [129]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PoygonToLine.swift "PoygonToLine"
 [130]:  https://github.com/Outdooractive/mvt-postgis
+[146]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/ConvexHull.swift "ConvexHull"
+[147]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/ConvexHullTests.swift "ConvexHullTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/ConvexHull.swift
+++ b/Sources/GISTools/Algorithms/ConvexHull.swift
@@ -1,0 +1,109 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-convex
+// Monotone chain algorithm from https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
+
+extension GeoJson {
+
+    /// Computes the convex hull of all coordinates in the receiver.
+    ///
+    /// Uses Andrew's monotone chain algorithm.
+    /// Returns `nil` if there are fewer than 3 distinct points.
+    public func convexHull() -> Polygon? {
+        let coords = allCoordinates
+
+        // Deduplicate
+        let unique = Array(Set(coords))
+        guard unique.count >= 3 else { return nil }
+
+        // Handle anti-meridian: if the bounding box crosses the date line,
+        // shift negative longitudes to [0, 360] range.
+        let minLon = unique.map(\.longitude).min() ?? 0
+        let maxLon = unique.map(\.longitude).max() ?? 0
+        let spansAntimeridian = (maxLon - minLon) > 180.0
+
+        let normalized: [Coordinate3D]
+        if spansAntimeridian {
+            normalized = unique.map { coord in
+                var c = coord
+                c = Coordinate3D(
+                    latitude: c.latitude,
+                    longitude: c.longitude < 0 ? c.longitude + 360.0 : c.longitude)
+                return c
+            }
+        }
+        else {
+            normalized = unique
+        }
+
+        // Sort by x (longitude), then y (latitude)
+        let sorted = normalized.sorted { a, b in
+            if a.longitude != b.longitude {
+                return a.longitude < b.longitude
+            }
+            return a.latitude < b.latitude
+        }
+
+        // Build lower hull
+        var lower: [Coordinate3D] = []
+        for point in sorted {
+            while lower.count >= 2 {
+                let a = lower[lower.count - 2]
+                let b = lower[lower.count - 1]
+                if cross(a, b, point) > 0 { break }
+                lower.removeLast()
+            }
+            lower.append(point)
+        }
+
+        // Build upper hull
+        var upper: [Coordinate3D] = []
+        for point in sorted.reversed() {
+            while upper.count >= 2 {
+                let a = upper[upper.count - 2]
+                let b = upper[upper.count - 1]
+                if cross(a, b, point) > 0 { break }
+                upper.removeLast()
+            }
+            upper.append(point)
+        }
+
+        // Remove last point of each (duplicate of first of the other)
+        lower.removeLast()
+        upper.removeLast()
+
+        // Combine
+        var hull = lower + upper
+
+        // Close the ring
+        hull.append(hull[0])
+
+        // Normalize back if needed
+        if spansAntimeridian {
+            hull = hull.map { coord in
+                let lon = coord.longitude > 180.0 ? coord.longitude - 360.0 : coord.longitude
+                return Coordinate3D(latitude: coord.latitude, longitude: lon)
+            }
+        }
+
+        return Polygon([hull])
+    }
+
+    // MARK: - Cross product helper
+
+    /// Cross product of vectors (a-o) and (b-o).
+    /// > 0 means counter-clockwise turn, < 0 means clockwise, == 0 means collinear.
+    private func cross(
+        _ o: Coordinate3D,
+        _ a: Coordinate3D,
+        _ b: Coordinate3D
+    ) -> Double {
+        let lhs = (a.longitude - o.longitude) * (b.latitude - o.latitude)
+        let rhs = (a.latitude - o.latitude) * (b.longitude - o.longitude)
+        return lhs - rhs
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/ConvexHullTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ConvexHullTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct ConvexHullTests {
+
+    @Test
+    func convexHullSquare() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ]))
+
+        let hull = try #require(mp.convexHull())
+        #expect(hull.outerRing?.coordinates.count == 5) // 4 corners + closing point
+        #expect(hull.contains(Coordinate3D(latitude: 5.0, longitude: 5.0)))
+    }
+
+    @Test
+    func convexHullTriangle() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ]))
+
+        let hull = try #require(mp.convexHull())
+        #expect(hull.outerRing?.coordinates.count == 4) // 3 corners + closing
+    }
+
+    @Test
+    func convexHullWithInteriorPoint() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),  // interior point
+        ]))
+
+        let hull = try #require(mp.convexHull())
+        #expect(hull.outerRing?.coordinates.count == 5) // 4 corners + closing
+    }
+
+    @Test
+    func convexHullCollinearTop() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 3.0, longitude: 10.0),
+            Coordinate3D(latitude: 7.0, longitude: 10.0),
+        ]))
+
+        let hull = try #require(mp.convexHull())
+        // Should have 4 points: bottom-left, bottom-right, top-right, top-left
+        #expect(hull.outerRing?.coordinates.count == 5)
+    }
+
+    @Test
+    func convexHullInsufficientPoints() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        #expect(mp.convexHull() == nil)
+    }
+
+    @Test
+    func convexHullLineString() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ]))
+
+        let hull = try #require(ls.convexHull())
+        #expect(hull.outerRing?.coordinates.count == 5)
+    }
+
+    @Test
+    func convexHullFeature() async throws {
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ]))
+        let feature = Feature(mp)
+        let hull = try #require(feature.convexHull())
+        #expect(hull.outerRing?.coordinates.count == 4)
+    }
+
+}


### PR DESCRIPTION
## Summary

Ported convex hull algorithm using Andrew's monotone chain algorithm.

### `Sources/GISTools/Algorithms/ConvexHull.swift`

`GeoJson.convexHull() -> Polygon?` — computes the convex hull of all coordinates in any geometry or feature.

- Uses monotone chain (O(n log n))
- Handles anti-meridian spanning by shifting negative longitudes to [0, 360]
- Deduplicates coordinates via Set
- Returns nil for < 3 distinct points

### `Tests/ConvexHullTests.swift` (7 tests)

| Test | Coverage |
|------|----------|
| `convexHullSquare` | 4 corners |
| `convexHullTriangle` | 3 corners |
| `convexHullWithInteriorPoint` | Interior point excluded from hull |
| `convexHullCollinearTop` | Collinear points on top edge |
| `convexHullInsufficientPoints` | < 3 points → nil |
| `convexHullLineString` | From LineString input |
| `convexHullFeature` | From Feature wrapper |

## Test results

273 tests pass across 60 suites (+7 new).

---

Closes #51