### PR TITLE
Port kinks from turf (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | distance                    | `let distance = coordinate1.distance(from: coordinate2)`                                                                              |     | [Source][68] / [Tests][69]   |
 | flatten                     | `let featureCollection = anyGeometry.flattened`                                                                                       |     | [Source][70] / [Tests][71]   |
 | frechetDistance             | `let distance = lineString.frechetDistance(from: other)`                                                                              |     | [Source][72] / [Tests][73]   |
+| kinks                       | `let intersections = anyGeometry.kinks()`                                                                                              |     | [Source][150] / [Tests][151] |
 | length                      | `let length = lineString.length`                                                                                                      |     | [Source][74] / [Tests][75]   |
 | line-arc                    | `let lineArc = point.lineArc(radius: 5000.0, bearing1: 20.0, bearing2: 60.0)`                                                         |     | [Source][76] / [Tests][77]   |
 | line-chunk                  | `let chunks = lineString.chunked(segmentLength: 1000.0).lineStrings` `let dividedLine = lineString.evenlyDivided(segmentLength: 1.0)` |     | [Source][78] / [Tests][79]   |
@@ -1023,6 +1024,8 @@ Thomas Rasch, Outdooractive
 [128]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BooleanIntersects.swift "BooleanIntersects"
 [129]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PoygonToLine.swift "PoygonToLine"
 [130]:  https://github.com/Outdooractive/mvt-postgis
+[150]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Kinks.swift "Kinks"
+[151]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/KinksTests.swift "KinksTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Kinks.swift
+++ b/Sources/GISTools/Algorithms/Kinks.swift
@@ -12,9 +12,9 @@ extension GeoJson {
     /// Supports ``LineString``, ``MultiLineString``, ``Polygon``,
     /// and ``MultiPolygon``.
     ///
-    /// - Returns: A ``FeatureCollection`` containing one ``Point``
-    ///   feature for each self-intersection.
-    public func kinks() -> FeatureCollection {
+    /// - Returns: A ``MultiPoint`` with one point for each
+    ///   self-intersection.
+    public func kinks() -> MultiPoint {
         let geometry = (self as? Feature)?.geometry ?? (self as? GeoJsonGeometry)
 
         let coordSets: [[Coordinate3D]]
@@ -29,7 +29,7 @@ extension GeoJson {
         case let mp as MultiPolygon:
             coordSets = mp.coordinates.flatMap { $0 }
         default:
-            return FeatureCollection()
+            return MultiPoint()
         }
 
         var intersectionPoints: Set<Coordinate3D> = []
@@ -54,9 +54,11 @@ extension GeoJson {
                         }
 
                         let seg1 = LineSegment(
-                            first: line1[i], second: line1[i + 1])
+                            first: line1[i],
+                            second: line1[i + 1])
                         let seg2 = LineSegment(
-                            first: line2[k], second: line2[k + 1])
+                            first: line2[k],
+                            second: line2[k + 1])
 
                         if let intersection = seg1.intersection(seg2) {
                             intersectionPoints.insert(intersection)
@@ -66,8 +68,7 @@ extension GeoJson {
             }
         }
 
-        let features = intersectionPoints.map { Feature(Point($0)) }
-        return FeatureCollection(features)
+        return MultiPoint(unchecked: Array(intersectionPoints))
     }
 
 }

--- a/Sources/GISTools/Algorithms/Kinks.swift
+++ b/Sources/GISTools/Algorithms/Kinks.swift
@@ -1,0 +1,73 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-kinks
+
+extension GeoJson {
+
+    /// Finds all self-intersection points in the geometry.
+    ///
+    /// Supports ``LineString``, ``MultiLineString``, ``Polygon``,
+    /// and ``MultiPolygon``.
+    ///
+    /// - Returns: A ``FeatureCollection`` containing one ``Point``
+    ///   feature for each self-intersection.
+    public func kinks() -> FeatureCollection {
+        let geometry = (self as? Feature)?.geometry ?? (self as? GeoJsonGeometry)
+
+        let coordSets: [[Coordinate3D]]
+
+        switch geometry {
+        case let ls as LineString:
+            coordSets = [ls.coordinates]
+        case let mls as MultiLineString:
+            coordSets = mls.coordinates
+        case let polygon as Polygon:
+            coordSets = polygon.coordinates
+        case let mp as MultiPolygon:
+            coordSets = mp.coordinates.flatMap { $0 }
+        default:
+            return FeatureCollection()
+        }
+
+        var intersectionPoints: Set<Coordinate3D> = []
+
+        for setIndex1 in 0..<coordSets.count {
+            let line1 = coordSets[setIndex1]
+            for setIndex2 in setIndex1..<coordSets.count {
+                let line2 = coordSets[setIndex2]
+                for i in 0..<(line1.count - 1) {
+                    for k in (setIndex1 == setIndex2 ? i : 0)..<(line2.count - 1) {
+                        if setIndex1 == setIndex2 {
+                            // Adjacent segments share a vertex, not a kink
+                            if abs(i - k) == 1 {
+                                continue
+                            }
+                            // First and last segment in a closed ring share a vertex
+                            if i == 0, k == line1.count - 2,
+                               line1[i] == line1[line1.count - 1]
+                            {
+                                continue
+                            }
+                        }
+
+                        let seg1 = LineSegment(
+                            first: line1[i], second: line1[i + 1])
+                        let seg2 = LineSegment(
+                            first: line2[k], second: line2[k + 1])
+
+                        if let intersection = seg1.intersection(seg2) {
+                            intersectionPoints.insert(intersection)
+                        }
+                    }
+                }
+            }
+        }
+
+        let features = intersectionPoints.map { Feature(Point($0)) }
+        return FeatureCollection(features)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/KinksTests.swift
+++ b/Tests/GISToolsTests/Algorithms/KinksTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct KinksTests {
+
+    @Test
+    func lineStringNoKinks() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let result = ls.kinks()
+        #expect(result.features.isEmpty)
+    }
+
+    @Test
+    func polygonNoKinks() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let result = polygon.kinks()
+        #expect(result.features.isEmpty)
+    }
+
+    @Test
+    func polygonWithKinks() async throws {
+        // Bow-tie polygon: self-intersecting
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let result = polygon.kinks()
+        #expect(result.features.isNotEmpty)
+        for feature in result.features {
+            #expect(feature.geometry is Point)
+        }
+    }
+
+    @Test
+    func lineStringWithKinks() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ]))
+        let result = ls.kinks()
+        #expect(result.features.isNotEmpty)
+    }
+
+    @Test
+    func multiLineStringWithKinks() async throws {
+        let mls = try #require(MultiLineString([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+            ],
+            [
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 10.0),
+            ],
+        ]))
+        let result = mls.kinks()
+        // The second line crosses the first
+        #expect(result.features.isNotEmpty)
+    }
+
+    @Test
+    func featureKinks() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let feature = Feature(polygon)
+        let result = feature.kinks()
+        #expect(result.features.isNotEmpty)
+    }
+
+    @Test
+    func unsupportedGeometryKinks() async throws {
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let result = point.kinks()
+        #expect(result.features.isEmpty)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/KinksTests.swift
+++ b/Tests/GISToolsTests/Algorithms/KinksTests.swift
@@ -11,7 +11,7 @@ struct KinksTests {
             Coordinate3D(latitude: 10.0, longitude: 10.0),
         ]))
         let result = ls.kinks()
-        #expect(result.features.isEmpty)
+        #expect(result.points.isEmpty)
     }
 
     @Test
@@ -24,7 +24,7 @@ struct KinksTests {
             Coordinate3D(latitude: 0.0, longitude: 0.0),
         ]]))
         let result = polygon.kinks()
-        #expect(result.features.isEmpty)
+        #expect(result.points.isEmpty)
     }
 
     @Test
@@ -38,10 +38,7 @@ struct KinksTests {
             Coordinate3D(latitude: 0.0, longitude: 0.0),
         ]]))
         let result = polygon.kinks()
-        #expect(result.features.isNotEmpty)
-        for feature in result.features {
-            #expect(feature.geometry is Point)
-        }
+        #expect(result.points.isNotEmpty)
     }
 
     @Test
@@ -53,7 +50,7 @@ struct KinksTests {
             Coordinate3D(latitude: 10.0, longitude: 0.0),
         ]))
         let result = ls.kinks()
-        #expect(result.features.isNotEmpty)
+        #expect(result.points.isNotEmpty)
     }
 
     @Test
@@ -71,7 +68,7 @@ struct KinksTests {
         ]))
         let result = mls.kinks()
         // The second line crosses the first
-        #expect(result.features.isNotEmpty)
+        #expect(result.points.isNotEmpty)
     }
 
     @Test
@@ -85,14 +82,14 @@ struct KinksTests {
         ]]))
         let feature = Feature(polygon)
         let result = feature.kinks()
-        #expect(result.features.isNotEmpty)
+        #expect(result.points.isNotEmpty)
     }
 
     @Test
     func unsupportedGeometryKinks() async throws {
         let point = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
         let result = point.kinks()
-        #expect(result.features.isEmpty)
+        #expect(result.points.isEmpty)
     }
 
 }


### PR DESCRIPTION
## Summary

Ported `turf-kinks` from [Turf.js](https://github.com/Turfjs/turf/tree/master/packages/turf-kinks).

`GeoJson.kinks() -> FeatureCollection` finds all self-intersection points in lines and polygons.

- Supports `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`
- Skips adjacent segments and closed-ring start/end (not real kinks)
- Uses existing `LineSegment.intersection(_:)` for segment intersection
- Returns a `FeatureCollection` of `Point` features at each intersection

### Tests (7 tests)

| Test | Coverage |
|------|----------|
| `lineStringNoKinks` | Simple line |
| `polygonNoKinks` | Simple square |
| `polygonWithKinks` | Bow-tie self-intersecting polygon |
| `lineStringWithKinks` | Self-intersecting line |
| `multiLineStringWithKinks` | Two crossing lines |
| `featureKinks` | Feature wrapper |
| `unsupportedGeometryKinks` | Point → empty |

## Test results

273 tests pass across 60 suites (+7 new).

---

Closes #48