### PR TITLE
Port pole-of-inaccessibility (polylabel) (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | point-on-feature            | `let coordinate = anyGeometry.coordinateOnFeature`                                                                                    |     | [Source][97]                 |
 | points-within-polygon       | `let within = polygon.coordinatesWithin(coordinates)`                                                                                 |     | [Source][98]                 |
 | point-to-line-distance      | `let distance = lineString.distanceFrom(coordinate: Coordinate3D(…))`                                                                 |     | [Source][99] / [Tests][100]  |
-| pole-of-inaccessibility     | TODO                                                                                                                                  |     | [Source][101]                |
+| pole-of-inaccessibility     | `let pole = polygon.poleOfInaccessibility()`                                                                                           |     | [Source][101] / [Tests][152] |
 | polygon-to-line             | `var lineStrings = polygon.lineStrings`                                                                                               |     | [Source][129]                |
 | reverse                     | `let lineStringReversed = lineString.reversed`                                                                                        |     | [Source][102] / [Tests][103] |
 | rhumb-bearing               | `let bearing = start.rhumbBearing(to: end)`                                                                                           |     | [Source][104] / [Tests][105] |
@@ -1023,6 +1023,7 @@ Thomas Rasch, Outdooractive
 [128]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BooleanIntersects.swift "BooleanIntersects"
 [129]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PoygonToLine.swift "PoygonToLine"
 [130]:  https://github.com/Outdooractive/mvt-postgis
+[152]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PoleOfInaccessibilityTests.swift "PoleOfInaccessibilityTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
+++ b/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
@@ -5,4 +5,223 @@ import Foundation
 
 // Ported from https://github.com/mapbox/polylabel
 
-// TODO
+extension Polygon {
+
+    /// Finds the pole of inaccessibility — the most distant internal point
+    /// from the polygon outline.
+    ///
+    /// Uses the polylabel algorithm with a priority-queue grid search.
+    ///
+    /// - Parameter precision: Precision in degrees (default 1.0).
+    /// - Returns: The pole point, or `nil` if no outer ring exists.
+    public func poleOfInaccessibility(precision: Double = 1.0) -> Point? {
+        guard let outerRing else { return nil }
+
+        let coords = outerRing.coordinates
+        guard coords.count >= 4 else { return nil }
+
+        // Bounding box
+        var minX = Double.greatestFiniteMagnitude
+        var minY = Double.greatestFiniteMagnitude
+        var maxX = -Double.greatestFiniteMagnitude
+        var maxY = -Double.greatestFiniteMagnitude
+
+        for coord in coords {
+            let x = coord.longitude
+            let y = coord.latitude
+            if x < minX { minX = x }
+            if y < minY { minY = y }
+            if x > maxX { maxX = x }
+            if y > maxY { maxY = y }
+        }
+
+        let width = maxX - minX
+        let height = maxY - minY
+        let cellSize = max(precision, min(width, height))
+
+        if cellSize == precision {
+            return Point(Coordinate3D(latitude: minY, longitude: minX))
+        }
+
+        var queue: [PQCell] = []
+        var bestCell = centroidCell()
+
+        let bboxCell = PQCell(
+            x: minX + width / 2, y: minY + height / 2,
+            h: 0, polygon: self)
+        if bboxCell.d > bestCell.d { bestCell = bboxCell }
+
+        // Cover with initial grid
+        var h = cellSize / 2
+        var x = minX
+        while x < maxX {
+            var y = minY
+            while y < maxY {
+                let cell = PQCell(x: x + h, y: y + h, h: h, polygon: self)
+                if cell.max > bestCell.d + precision {
+                    insertSorted(&queue, cell)
+                }
+                if cell.d > bestCell.d {
+                    bestCell = cell
+                }
+                y += cellSize
+            }
+            x += cellSize
+        }
+
+        while queue.isNotEmpty {
+            let cell = queue.removeLast()
+
+            if cell.max - bestCell.d <= precision { break }
+
+            if cell.d > bestCell.d {
+                bestCell = cell
+            }
+
+            h = cell.h / 2
+            let c1 = PQCell(x: cell.x - h, y: cell.y - h, h: h, polygon: self)
+            let c2 = PQCell(x: cell.x + h, y: cell.y - h, h: h, polygon: self)
+            let c3 = PQCell(x: cell.x - h, y: cell.y + h, h: h, polygon: self)
+            let c4 = PQCell(x: cell.x + h, y: cell.y + h, h: h, polygon: self)
+
+            for c in [c1, c2, c3, c4] {
+                if c.d > bestCell.d {
+                    bestCell = c
+                }
+                if c.max > bestCell.d + precision {
+                    insertSorted(&queue, c)
+                }
+            }
+        }
+
+        return Point(Coordinate3D(latitude: bestCell.y, longitude: bestCell.x))
+    }
+
+    // MARK: - Private
+
+    /// Insert into a max-sorted array (largest .max at end)
+    private func insertSorted(_ queue: inout [PQCell], _ cell: PQCell) {
+        var lo = 0
+        var hi = queue.count
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if queue[mid].max < cell.max {
+                lo = mid + 1
+            }
+            else {
+                hi = mid
+            }
+        }
+        queue.insert(cell, at: lo)
+    }
+
+    /// Signed distance from point to polygon outline (negative if outside).
+    fileprivate func pointToPolygonDist(
+        x: Double, y: Double, rings: [[Coordinate3D]]
+    ) -> Double {
+        var inside = false
+        var minDistSq = Double.greatestFiniteMagnitude
+
+        for ring in rings {
+            guard ring.count >= 2 else { continue }
+            for i in 0..<(ring.count - 1) {
+                let a = ring[i]
+                let b = ring[i + 1]
+
+                if (a.latitude > y) != (b.latitude > y),
+                    x < (b.longitude - a.longitude) * (y - a.latitude) / (b.latitude - a.latitude) + a.longitude
+                {
+                    inside = !inside
+                }
+
+                minDistSq = min(minDistSq, segDistSq(px: x, py: y, a: a, b: b))
+            }
+        }
+
+        if minDistSq == 0 { return 0 }
+        return (inside ? 1 : -1) * sqrt(minDistSq)
+    }
+
+    /// Squared distance from point to segment.
+    private func segDistSq(
+        px: Double, py: Double,
+        a: Coordinate3D, b: Coordinate3D
+    ) -> Double {
+        var x = a.longitude
+        var y = a.latitude
+        let dx = b.longitude - x
+        let dy = b.latitude - y
+
+        if dx != 0 || dy != 0 {
+            let t = ((px - x) * dx + (py - y) * dy) / (dx * dx + dy * dy)
+            if t > 1 {
+                x = b.longitude
+                y = b.latitude
+            }
+            else if t > 0 {
+                x += dx * t
+                y += dy * t
+            }
+        }
+
+        let ex = px - x
+        let ey = py - y
+        return ex * ex + ey * ey
+    }
+
+    /// Polygon centroid (outer ring area centroid).
+    private func centroidCell() -> PQCell {
+        let points = outerRing!.coordinates
+        var area: Double = 0
+        var cx: Double = 0
+        var cy: Double = 0
+        let n = points.count - 1
+
+        for i in 0..<n {
+            let a = points[i]
+            let b = points[(i + 1) % n]
+            let aLon = a.longitude
+            let aLat = a.latitude
+            let bLon = b.longitude
+            let bLat = b.latitude
+            let f = aLon * bLat - bLon * aLat
+            cx += (aLon + bLon) * f
+            cy += (aLat + bLat) * f
+            area += f * 3
+        }
+
+        if area == 0 {
+            return PQCell(
+                x: points[0].longitude, y: points[0].latitude,
+                h: 0, polygon: self)
+        }
+
+        let cell = PQCell(x: cx / area, y: cy / area, h: 0, polygon: self)
+        if cell.d < 0 {
+            return PQCell(
+                x: points[0].longitude, y: points[0].latitude,
+                h: 0, polygon: self)
+        }
+        return cell
+    }
+
+}
+
+// MARK: - Priority queue cell
+
+private struct PQCell {
+    let x: Double
+    let y: Double
+    let h: Double
+    let d: Double
+    let max: Double
+
+    init(x: Double, y: Double, h: Double, polygon: Polygon) {
+        self.x = x
+        self.y = y
+        self.h = h
+        let rings = polygon.coordinates
+        self.d = polygon.pointToPolygonDist(x: x, y: y, rings: rings)
+        self.max = d + h * 1.4142135623730951 // √2
+    }
+}

--- a/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
+++ b/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
@@ -47,9 +47,13 @@ extension Polygon {
         var bestCell = centroidCell()
 
         let bboxCell = PQCell(
-            x: minX + width / 2, y: minY + height / 2,
-            h: 0, polygon: self)
-        if bboxCell.d > bestCell.d { bestCell = bboxCell }
+            x: minX + width / 2,
+            y: minY + height / 2,
+            h: 0,
+            polygon: self)
+        if bboxCell.d > bestCell.d {
+            bestCell = bboxCell
+        }
 
         // Cover with initial grid
         var h = cellSize / 2
@@ -57,7 +61,11 @@ extension Polygon {
         while x < maxX {
             var y = minY
             while y < maxY {
-                let cell = PQCell(x: x + h, y: y + h, h: h, polygon: self)
+                let cell = PQCell(
+                    x: x + h,
+                    y: y + h,
+                    h: h,
+                    polygon: self)
                 if cell.max > bestCell.d + precision {
                     insertSorted(&queue, cell)
                 }
@@ -72,8 +80,9 @@ extension Polygon {
         while queue.isNotEmpty {
             let cell = queue.removeLast()
 
-            if cell.max - bestCell.d <= precision { break }
-
+            if cell.max - bestCell.d <= precision {
+                break
+            }
             if cell.d > bestCell.d {
                 bestCell = cell
             }
@@ -100,7 +109,10 @@ extension Polygon {
     // MARK: - Private
 
     /// Insert into a max-sorted array (largest .max at end)
-    private func insertSorted(_ queue: inout [PQCell], _ cell: PQCell) {
+    private func insertSorted(
+        _ queue: inout [PQCell],
+        _ cell: PQCell)
+    {
         var lo = 0
         var hi = queue.count
         while lo < hi {
@@ -117,7 +129,9 @@ extension Polygon {
 
     /// Signed distance from point to polygon outline (negative if outside).
     fileprivate func pointToPolygonDist(
-        x: Double, y: Double, rings: [[Coordinate3D]]
+        x: Double,
+        y: Double,
+        rings: [[Coordinate3D]]
     ) -> Double {
         var inside = false
         var minDistSq = Double.greatestFiniteMagnitude
@@ -138,14 +152,18 @@ extension Polygon {
             }
         }
 
-        if minDistSq == 0 { return 0 }
+        if minDistSq == 0 {
+            return 0
+        }
         return (inside ? 1 : -1) * sqrt(minDistSq)
     }
 
     /// Squared distance from point to segment.
     private func segDistSq(
-        px: Double, py: Double,
-        a: Coordinate3D, b: Coordinate3D
+        px: Double,
+        py: Double,
+        a: Coordinate3D,
+        b: Coordinate3D
     ) -> Double {
         var x = a.longitude
         var y = a.latitude
@@ -192,15 +210,23 @@ extension Polygon {
 
         if area == 0 {
             return PQCell(
-                x: points[0].longitude, y: points[0].latitude,
-                h: 0, polygon: self)
+                x: points[0].longitude,
+                y: points[0].latitude,
+                h: 0,
+                polygon: self)
         }
 
-        let cell = PQCell(x: cx / area, y: cy / area, h: 0, polygon: self)
+        let cell = PQCell(
+            x: cx / area,
+            y: cy / area,
+            h: 0,
+            polygon: self)
         if cell.d < 0 {
             return PQCell(
-                x: points[0].longitude, y: points[0].latitude,
-                h: 0, polygon: self)
+                x: points[0].longitude,
+                y: points[0].latitude,
+                h: 0,
+                polygon: self)
         }
         return cell
     }
@@ -210,13 +236,18 @@ extension Polygon {
 // MARK: - Priority queue cell
 
 private struct PQCell {
+
     let x: Double
     let y: Double
     let h: Double
     let d: Double
     let max: Double
 
-    init(x: Double, y: Double, h: Double, polygon: Polygon) {
+    init(x: Double,
+         y: Double,
+         h: Double,
+         polygon: Polygon
+    ) {
         self.x = x
         self.y = y
         self.h = h
@@ -224,4 +255,5 @@ private struct PQCell {
         self.d = polygon.pointToPolygonDist(x: x, y: y, rings: rings)
         self.max = d + h * 1.4142135623730951 // √2
     }
+
 }

--- a/Tests/GISToolsTests/Algorithms/PoleOfInaccessibilityTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PoleOfInaccessibilityTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct PoleOfInaccessibilityTests {
+
+    @Test
+    func squarePole() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+
+        let pole = try #require(polygon.poleOfInaccessibility())
+        // Should be near the center
+        #expect(abs(pole.coordinate.latitude - 5.0) < 1.0)
+        #expect(abs(pole.coordinate.longitude - 5.0) < 1.0)
+        #expect(polygon.contains(pole.coordinate))
+    }
+
+    @Test
+    func trianglePole() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+
+        let pole = try #require(polygon.poleOfInaccessibility())
+        #expect(polygon.contains(pole.coordinate))
+    }
+
+    @Test
+    func poleWithPrecision() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+
+        let pole1 = try #require(polygon.poleOfInaccessibility(precision: 1.0))
+        let pole2 = try #require(polygon.poleOfInaccessibility(precision: 0.1))
+        #expect(polygon.contains(pole1.coordinate))
+        #expect(polygon.contains(pole2.coordinate))
+    }
+
+    @Test
+    func poleLShaped() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 20.0),
+            Coordinate3D(latitude: 20.0, longitude: 20.0),
+            Coordinate3D(latitude: 20.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+
+        let pole = try #require(polygon.poleOfInaccessibility())
+        #expect(polygon.contains(pole.coordinate))
+    }
+
+    @Test
+    func poleNoOuterRing() async throws {
+        let polygon = Polygon()
+        #expect(polygon.poleOfInaccessibility() == nil)
+    }
+
+}


### PR DESCRIPTION
## Summary

Ported [polylabel](https://github.com/mapbox/polylabel) (Mapbox) algorithm for finding the pole of inaccessibility.

### `Sources/GISTools/Algorithms/PoleOfInaccessibility.swift`

`Polygon.poleOfInaccessibility(precision:) -> Point?` — finds the most distant internal point from the polygon outline.

- Uses a priority-queue grid search
- Starts with the polygon centroid and bounding box center as guesses
- Subdivides the most promising cells until precision threshold is met
- Handles holes (all rings are considered for distance)
- Returns nil for polygons without an outer ring

### `Tests/PoleOfInaccessibilityTests.swift` (5 tests)

| Test | Coverage |
|------|----------|
| `squarePole` | Square center |
| `trianglePole` | Triangle interior |
| `poleWithPrecision` | High and low precision |
| `poleLShaped` | Concave L-shape |
| `poleNoOuterRing` | Empty polygon → nil |

### README
Updated `pole-of-inaccessibility` from TODO to example with test link.

## Test results

271 tests pass across 60 suites (+5 new).

---

Closes #21