### PR TITLE
Add TWKB read support (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,10 +690,10 @@ Then create your models like this:
 
 This is necessary because SwiftData doesn't work well with the default Codable implementation, so you need to do the serialization for yourself...
 
-# WKB/WKT
+# WKB/WKT/TWKB
 The following geometry types are supported: `point`, `linestring`, `linearring`, `polygon`, `multipoint`, `multilinestring`, `multipolygon`, `geometrycollection` and `triangle`. Please open an issue if you need more.
 
-Every GeoJSON object has convenience methods to encode and decode themselves to and from WKB/WKT, and there are extensions for `Data` and `String` to decode from WKB and WKT to GeoJSON. In the end, they all forward to `WKBCoder` and `WKTCoder` which do the heavy lifting.
+Every GeoJSON object has convenience methods to encode and decode themselves to and from WKB/WKT, and there are extensions for `Data` and `String` to decode from WKB, WKT and TWKB to GeoJSON. In the end, they all forward to `WKBCoder`, `WKTCoder` and `TWKBCoder` which do the heavy lifting.
 
 ## WKB
 Also have a look at  the [WKB test cases][40].
@@ -778,6 +778,42 @@ let encodedPoint = WKTCoder.encode(geometry: point, targetProjection: nil)
 
 // Convenience
 let encodedPoint = point.asWKT
+```
+
+## TWKB
+This is a decode-only coder for [Tiny WKB][154]. Also have a look at the [TWKB test cases][155].
+
+Decoding:
+```swift
+// TWKB Point at (0, 0) with precision 6
+private let pointData = Data([0x61, 0x00, 0x00, 0x00])
+
+// Generic
+let point = try TWKBCoder.decode(twkb: pointData) as! Point
+let point = pointData.asGeoJsonGeometryFromTWKB(sourceProjection: .epsg4326) as! Point
+
+// Or with sourceSrid
+let point = try TWKBCoder.decode(twkb: pointData, sourceSrid: 4326) as! Point
+let point = pointData.asGeoJsonGeometryFromTWKB(sourceSrid: 4326) as! Point
+
+// Or create the geometry directly
+let point = Point(twkb: pointData)!
+
+// Or create a Feature that contains the geometry
+let feature = Feature(twkb: pointData)
+let feature = pointData.asFeatureFromTWKB(sourceProjection: .epsg4326)
+
+// Or create a FeatureCollection that contains a feature with the geometry
+let featureCollection = FeatureCollection(twkb: pointData)
+let featureCollection = pointData.asFeatureCollectionFromTWKB(sourceProjection: .epsg4326)
+
+// Can also reproject on the fly
+let point = try TWKBCoder.decode(
+    twkb: pointData,
+    sourceProjection: .epsg4326,
+    targetProjection: .epsg3857
+) as! Point
+print(point.projection) // EPSG:3857
 ```
 
 # Spatial index
@@ -1055,6 +1091,8 @@ Thomas Rasch, Outdooractive
 [151]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/KinksTests.swift "KinksTests"
 [152]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PoleOfInaccessibilityTests.swift "PoleOfInaccessibilityTests"
 [153]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/UnionTests.swift "UnionTests"
+[154]:	https://github.com/TWKB/Specification/blob/master/twkb.md
+[155]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/GeoJson/TWKBTests.swift
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/GeoJson/TWKBCoder.swift
+++ b/Sources/GISTools/GeoJson/TWKBCoder.swift
@@ -3,29 +3,306 @@ import CoreLocation
 #endif
 import Foundation
 
+// MARK: - GeoJsonGeometry extension
+
+extension GeoJsonGeometry {
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public init?(
+        twkb: Data,
+        sourceSrid: Int?,
+        targetProjection: Projection = .epsg4326,
+        calculateBoundingBox: Bool = false
+    ) {
+        guard let geometry = try? TWKBCoder.decode(
+            twkb: twkb,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection
+        ) else { return nil }
+        self.init(json: geometry.asJson, calculateBoundingBox: calculateBoundingBox)
+    }
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public init?(
+        twkb: Data,
+        sourceProjection: Projection? = nil,
+        targetProjection: Projection = .epsg4326,
+        calculateBoundingBox: Bool = false
+    ) {
+        guard let geometry = try? TWKBCoder.decode(
+            twkb: twkb,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection
+        ) else { return nil }
+        self.init(json: geometry.asJson, calculateBoundingBox: calculateBoundingBox)
+    }
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public static func parse(
+        twkb: Data,
+        sourceSrid: Int?,
+        targetProjection: Projection = .epsg4326
+    ) -> GeoJsonGeometry? {
+        try? TWKBCoder.decode(
+            twkb: twkb,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection)
+    }
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public static func parse(
+        twkb: Data,
+        sourceProjection: Projection? = nil,
+        targetProjection: Projection = .epsg4326
+    ) -> GeoJsonGeometry? {
+        try? TWKBCoder.decode(
+            twkb: twkb,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection)
+    }
+
+}
+
+// MARK: - Feature extension
+
+extension Feature {
+
+    /// Decode a GeoJSON Feature from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public init?(
+        twkb: Data,
+        sourceSrid: Int?,
+        targetProjection: Projection = .epsg4326,
+        id: Identifier? = nil,
+        properties: [String: Sendable] = [:],
+        calculateBoundingBox: Bool = false
+    ) {
+        guard let geometry = try? TWKBCoder.decode(
+            twkb: twkb,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection
+        ) else { return nil }
+        self.init(geometry, id: id, properties: properties, calculateBoundingBox: calculateBoundingBox)
+    }
+
+    /// Decode a GeoJSON Feature from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public init?(
+        twkb: Data,
+        sourceProjection: Projection? = nil,
+        targetProjection: Projection = .epsg4326,
+        id: Identifier? = nil,
+        properties: [String: Sendable] = [:],
+        calculateBoundingBox: Bool = false
+    ) {
+        guard let geometry = try? TWKBCoder.decode(
+            twkb: twkb,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection
+        ) else { return nil }
+        self.init(geometry, id: id, properties: properties, calculateBoundingBox: calculateBoundingBox)
+    }
+
+}
+
+// MARK: - FeatureCollection extension
+
+extension FeatureCollection {
+
+    /// Decode a GeoJSON FeatureCollection from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public init?(
+        twkb: Data,
+        sourceSrid: Int?,
+        targetProjection: Projection = .epsg4326,
+        calculateBoundingBox: Bool = false
+    ) {
+        guard let geometry = try? TWKBCoder.decode(
+            twkb: twkb,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection
+        ) else { return nil }
+        self.init([geometry], calculateBoundingBox: calculateBoundingBox)
+    }
+
+    /// Decode a GeoJSON FeatureCollection from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public init?(
+        twkb: Data,
+        sourceProjection: Projection? = nil,
+        targetProjection: Projection = .epsg4326,
+        calculateBoundingBox: Bool = false
+    ) {
+        guard let geometry = try? TWKBCoder.decode(
+            twkb: twkb,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection
+        ) else { return nil }
+        self.init([geometry], calculateBoundingBox: calculateBoundingBox)
+    }
+
+}
+
+// MARK: - Data extensions
+
+extension Data {
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public func asGeoJsonGeometryFromTWKB(
+        sourceSrid: Int?,
+        targetProjection: Projection = .epsg4326
+    ) -> GeoJsonGeometry? {
+        GeometryCollection.parse(
+            twkb: self,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection)
+    }
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public func asGeoJsonGeometryFromTWKB(
+        sourceProjection: Projection?,
+        targetProjection: Projection = .epsg4326
+    ) -> GeoJsonGeometry? {
+        GeometryCollection.parse(
+            twkb: self,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection)
+    }
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public func asFeatureFromTWKB(
+        sourceSrid: Int?,
+        targetProjection: Projection = .epsg4326,
+        id: Feature.Identifier? = nil,
+        properties: [String: Sendable] = [:]
+    ) -> Feature? {
+        Feature(
+            twkb: self,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection,
+            id: id,
+            properties: properties)
+    }
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public func asFeatureFromTWKB(
+        sourceProjection: Projection?,
+        targetProjection: Projection = .epsg4326,
+        id: Feature.Identifier? = nil,
+        properties: [String: Sendable] = [:]
+    ) -> Feature? {
+        Feature(
+            twkb: self,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection,
+            id: id,
+            properties: properties)
+    }
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public func asFeatureCollectionFromTWKB(
+        sourceSrid: Int?,
+        targetProjection: Projection = .epsg4326
+    ) -> FeatureCollection? {
+        FeatureCollection(
+            twkb: self,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection)
+    }
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public func asFeatureCollectionFromTWKB(
+        sourceProjection: Projection?,
+        targetProjection: Projection = .epsg4326
+    ) -> FeatureCollection? {
+        FeatureCollection(
+            twkb: self,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection)
+    }
+
+}
+
 // https://github.com/TWKB/Specification/blob/master/twkb.md
 
+/// A tool for decoding GeoJSON objects from TWKB.
 public enum TWKBCoder {
 
+    /// TWKB decoding errors.
     public enum TWKBError: Error {
+        /// The TWKB data is corrupted.
         case dataCorrupted
+        /// The geometry is empty.
         case emptyGeometry
+        /// The geometry is invalid.
         case invalidGeometry
+        /// The SRID is unknown.
         case unknownSRID
+        /// The geometry type is unexpected.
         case unexpectedType
     }
 
     // MARK: - Public decode entry points
 
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
+    public static func decode(
+        twkb: Data,
+        sourceSrid: Int?,
+        targetProjection: Projection = .epsg4326
+    ) throws -> GeoJsonGeometry {
+        var sourceProjection: Projection?
+
+        if let sourceSrid {
+            sourceProjection = Projection(srid: sourceSrid)
+            guard sourceProjection != nil else { throw TWKBError.unknownSRID }
+        }
+
+        return try decode(
+            twkb: twkb,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection)
+    }
+
+    /// Decode a GeoJSON object from TWKB.
+    ///
+    /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func decode(
         twkb: Data,
         sourceProjection: Projection? = nil,
         targetProjection: Projection = .epsg4326
-    ) throws -> (any GeoJsonGeometry)? {
+    ) throws -> GeoJsonGeometry {
         let bytes = [UInt8](twkb)
         var offset = 0
+
         return try decodeGeometry(
-            bytes: bytes, offset: &offset,
+            bytes: bytes,
+            offset: &offset,
             sourceProjection: sourceProjection,
             targetProjection: targetProjection,
             parentPrecision: nil)
@@ -35,9 +312,12 @@ public enum TWKBCoder {
 
     /// Reads the header byte: lower 4 bits = geometry type, upper 4 bits = precision exponent.
     private static func decodeHeader(
-        bytes: [UInt8], offset: inout Int, parentPrecision: Int?
+        bytes: [UInt8],
+        offset: inout Int,
+        parentPrecision: Int?
     ) throws -> (type: Int, precision: Int) {
         guard offset < bytes.count else { throw TWKBError.dataCorrupted }
+
         let byte = bytes[offset]
         offset += 1
         let geomType = Int(byte & 0x0F)
@@ -49,9 +329,11 @@ public enum TWKBCoder {
 
     /// Reads the metadata header varint: flags for Z, M, SRID.
     private static func decodeMetadata(
-        bytes: [UInt8], offset: inout Int
+        bytes: [UInt8],
+        offset: inout Int
     ) throws -> (hasZ: Bool, hasM: Bool, hasSRID: Bool, srid: Int?) {
         guard offset < bytes.count else { throw TWKBError.dataCorrupted }
+
         let meta = Int(try decodeVarInt(bytes: bytes, offset: &offset))
         _ = (meta & 0x01) != 0  // hasBBox
         _ = (meta & 0x02) != 0  // hasSize
@@ -72,30 +354,30 @@ public enum TWKBCoder {
         sourceProjection: Projection?,
         targetProjection: Projection,
         parentPrecision: Int?
-    ) throws -> (any GeoJsonGeometry)? {
+    ) throws -> GeoJsonGeometry {
         guard offset < bytes.count else { throw TWKBError.emptyGeometry }
 
         let (geomType, precision) = try decodeHeader(bytes: bytes, offset: &offset, parentPrecision: parentPrecision)
-        let (hasZ, hasM, hasSRID, srid) = try decodeMetadata(bytes: bytes, offset: &offset)
+        let (hasZ, hasM, _, srid) = try decodeMetadata(bytes: bytes, offset: &offset)
 
         let srcProj = sourceProjection ?? srid.flatMap { Projection(srid: $0) } ?? .epsg4326
         let scale = pow(10.0, Double(precision))
 
         switch geomType {
         case 1:
-            return try decodePoint(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: targetProjection)
+            return try decodePoint(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, sourceProjection: srcProj, targetProjection: targetProjection)
         case 2:
-            return try decodeLineString(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+            return try decodeLineString(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, sourceProjection: srcProj, targetProjection: targetProjection)
         case 3:
-            return try decodePolygon(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+            return try decodePolygon(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, sourceProjection: srcProj, targetProjection: targetProjection)
         case 4:
-            return try decodeMultiPoint(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+            return try decodeMultiPoint(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, sourceProjection: srcProj, targetProjection: targetProjection)
         case 5:
-            return try decodeMultiLineString(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+            return try decodeMultiLineString(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, sourceProjection: srcProj, targetProjection: targetProjection)
         case 6:
-            return try decodeMultiPolygon(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+            return try decodeMultiPolygon(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, sourceProjection: srcProj, targetProjection: targetProjection)
         case 7:
-            return try decodeGeometryCollection(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+            return try decodeGeometryCollection(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, sourceProjection: srcProj, targetProjection: targetProjection)
         default:
             throw TWKBError.unexpectedType
         }
@@ -104,40 +386,52 @@ public enum TWKBCoder {
     // MARK: - Point
 
     private static func decodePoint(
-        bytes: [UInt8], offset: inout Int,
-        hasZ: Bool, hasM: Bool,
-        scale: Double, srcProj: Projection, target: Projection
+        bytes: [UInt8],
+        offset: inout Int,
+        hasZ: Bool,
+        hasM: Bool,
+        scale: Double,
+        sourceProjection: Projection,
+        targetProjection: Projection
     ) throws -> Point {
-        let coord = try decodeCoordinate(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+        let coord = try decodeCoordinate(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, sourceProjection: sourceProjection, targetProjection: targetProjection)
         return Point(coord)
     }
 
     // MARK: - LineString
 
     private static func decodeLineString(
-        bytes: [UInt8], offset: inout Int,
-        hasZ: Bool, hasM: Bool,
-        scale: Double, precision: Int,
-        srcProj: Projection, target: Projection
+        bytes: [UInt8],
+        offset: inout Int,
+        hasZ: Bool,
+        hasM: Bool,
+        scale: Double,
+        precision: Int,
+        sourceProjection: Projection,
+        targetProjection: Projection
     ) throws -> LineString {
         let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
-        let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: count, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+        let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: count, hasZ: hasZ, hasM: hasM, scale: scale, sourceProjection: sourceProjection, targetProjection: targetProjection)
         return LineString(unchecked: coords)
     }
 
     // MARK: - Polygon
 
     private static func decodePolygon(
-        bytes: [UInt8], offset: inout Int,
-        hasZ: Bool, hasM: Bool,
-        scale: Double, precision: Int,
-        srcProj: Projection, target: Projection
+        bytes: [UInt8],
+        offset: inout Int,
+        hasZ: Bool,
+        hasM: Bool,
+        scale: Double,
+        precision: Int,
+        sourceProjection: Projection,
+        targetProjection: Projection
     ) throws -> Polygon {
         let ringCount = Int(try decodeVarInt(bytes: bytes, offset: &offset))
         var rings: [[Coordinate3D]] = []
         for _ in 0..<ringCount {
             let pointCount = Int(try decodeVarInt(bytes: bytes, offset: &offset))
-            let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: pointCount, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+            let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: pointCount, hasZ: hasZ, hasM: hasM, scale: scale, sourceProjection: sourceProjection, targetProjection: targetProjection)
             // Close the ring
             var ring = coords
             ring.append(ring[0])
@@ -150,41 +444,53 @@ public enum TWKBCoder {
     // MARK: - Multi-geometries
 
     private static func decodeMultiPoint(
-        bytes: [UInt8], offset: inout Int,
-        hasZ: Bool, hasM: Bool,
-        scale: Double, precision: Int,
-        srcProj: Projection, target: Projection
+        bytes: [UInt8],
+        offset: inout Int,
+        hasZ: Bool,
+        hasM: Bool,
+        scale: Double,
+        precision: Int,
+        sourceProjection: Projection,
+        targetProjection: Projection
     ) throws -> MultiPoint {
         let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
         var points: [Point] = []
         // MultiPoint stores all coordinates as a single sequence deltas
-        let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: count, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+        let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: count, hasZ: hasZ, hasM: hasM, scale: scale, sourceProjection: sourceProjection, targetProjection: targetProjection)
         points = coords.map { Point($0) }
         guard let mp = MultiPoint(points.map(\.coordinate)) else { throw TWKBError.invalidGeometry }
         return mp
     }
 
     private static func decodeMultiLineString(
-        bytes: [UInt8], offset: inout Int,
-        hasZ: Bool, hasM: Bool,
-        scale: Double, precision: Int,
-        srcProj: Projection, target: Projection
+        bytes: [UInt8],
+        offset: inout Int,
+        hasZ: Bool,
+        hasM: Bool,
+        scale: Double,
+        precision: Int,
+        sourceProjection: Projection,
+        targetProjection: Projection
     ) throws -> MultiLineString {
         let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
         var lineStrings: [[Coordinate3D]] = []
         for _ in 0..<count {
             let pointCount = Int(try decodeVarInt(bytes: bytes, offset: &offset))
-            let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: pointCount, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+            let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: pointCount, hasZ: hasZ, hasM: hasM, scale: scale, sourceProjection: sourceProjection, targetProjection: targetProjection)
             lineStrings.append(coords)
         }
         return MultiLineString(unchecked: lineStrings)
     }
 
     private static func decodeMultiPolygon(
-        bytes: [UInt8], offset: inout Int,
-        hasZ: Bool, hasM: Bool,
-        scale: Double, precision: Int,
-        srcProj: Projection, target: Projection
+        bytes: [UInt8],
+        offset: inout Int,
+        hasZ: Bool,
+        hasM: Bool,
+        scale: Double,
+        precision: Int,
+        sourceProjection: Projection,
+        targetProjection: Projection
     ) throws -> MultiPolygon {
         let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
         var polygons: [Polygon] = []
@@ -193,7 +499,7 @@ public enum TWKBCoder {
             var rings: [[Coordinate3D]] = []
             for _ in 0..<ringCount {
                 let pointCount = Int(try decodeVarInt(bytes: bytes, offset: &offset))
-                let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: pointCount, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+                let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: pointCount, hasZ: hasZ, hasM: hasM, scale: scale, sourceProjection: sourceProjection, targetProjection: targetProjection)
                 var ring = coords
                 if ring.first != ring.last {
                     ring.append(ring[0])
@@ -207,17 +513,20 @@ public enum TWKBCoder {
     }
 
     private static func decodeGeometryCollection(
-        bytes: [UInt8], offset: inout Int,
-        hasZ: Bool, hasM: Bool,
-        scale: Double, precision: Int,
-        srcProj: Projection, target: Projection
+        bytes: [UInt8],
+        offset: inout Int,
+        hasZ: Bool,
+        hasM: Bool,
+        scale: Double,
+        precision: Int,
+        sourceProjection: Projection,
+        targetProjection: Projection
     ) throws -> GeometryCollection {
         let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
         var geoms: [any GeoJsonGeometry] = []
         for _ in 0..<count {
-            if let geom = try decodeGeometry(bytes: bytes, offset: &offset, sourceProjection: srcProj, targetProjection: target, parentPrecision: precision) {
-                geoms.append(geom)
-            }
+            let geom = try decodeGeometry(bytes: bytes, offset: &offset, sourceProjection: sourceProjection, targetProjection: targetProjection, parentPrecision: precision)
+            geoms.append(geom)
         }
         return GeometryCollection(geoms)
     }
@@ -226,27 +535,36 @@ public enum TWKBCoder {
 
     /// Decodes a single coordinate from zigzag-encoded int64 values scaled by `scale`.
     private static func decodeCoordinate(
-        bytes: [UInt8], offset: inout Int,
-        hasZ: Bool, hasM: Bool,
-        scale: Double, srcProj: Projection, target: Projection
+        bytes: [UInt8],
+        offset: inout Int,
+        hasZ: Bool,
+        hasM: Bool,
+        scale: Double,
+        sourceProjection: Projection,
+        targetProjection: Projection
     ) throws -> Coordinate3D {
         let x = Double(decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))) / scale
         let y = Double(decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))) / scale
         let z: Double? = hasZ ? Double(decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))) / scale : nil
         let m: Double? = hasM ? Double(decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))) / scale : nil
 
-        let coord = makeCoordinate(x: x, y: y, z: z, m: m, srcProj: srcProj)
-        if srcProj != target {
-            return coord.projected(to: target)
+        let coord = makeCoordinate(x: x, y: y, z: z, m: m, sourceProjection: sourceProjection)
+        if sourceProjection != targetProjection {
+            return coord.projected(to: targetProjection)
         }
         return coord
     }
 
     /// Decodes a sequence of `count` coordinates as deltas from a running base.
     private static func decodeCoordinateSequence(
-        bytes: [UInt8], offset: inout Int,
-        count: Int, hasZ: Bool, hasM: Bool,
-        scale: Double, srcProj: Projection, target: Projection
+        bytes: [UInt8],
+        offset: inout Int,
+        count: Int,
+        hasZ: Bool,
+        hasM: Bool,
+        scale: Double,
+        sourceProjection: Projection,
+        targetProjection: Projection
     ) throws -> [Coordinate3D] {
         guard count > 0 else { return [] }
 
@@ -267,8 +585,8 @@ public enum TWKBCoder {
             let z: Double? = hasZ ? Double(baseZ) / scale : nil
             let m: Double? = hasM ? Double(baseM) / scale : nil
 
-            let coord = makeCoordinate(x: x, y: y, z: z, m: m, srcProj: srcProj)
-            coords.append(srcProj != target ? coord.projected(to: target) : coord)
+            let coord = makeCoordinate(x: x, y: y, z: z, m: m, sourceProjection: sourceProjection)
+            coords.append(sourceProjection != targetProjection ? coord.projected(to: targetProjection) : coord)
         }
         return coords
     }
@@ -276,16 +594,19 @@ public enum TWKBCoder {
     // MARK: - Coordinate construction
 
     private static func makeCoordinate(
-        x: Double, y: Double, z: Double?, m: Double?,
-        srcProj: Projection
+        x: Double,
+        y: Double,
+        z: Double?,
+        m: Double?,
+        sourceProjection: Projection
     ) -> Coordinate3D {
-        switch srcProj {
+        switch sourceProjection {
         case .epsg4326:
             return Coordinate3D(latitude: y, longitude: x, altitude: z, m: m)
         case .epsg3857:
             return Coordinate3D(x: x, y: y, z: z, m: m)
         case .noSRID:
-            return Coordinate3D(x: x, y: y, z: z, m: m, projection: srcProj)
+            return Coordinate3D(x: x, y: y, z: z, m: m, projection: sourceProjection)
         }
     }
 
@@ -293,7 +614,8 @@ public enum TWKBCoder {
 
     /// Decodes an unsigned variable-length integer (MSB continuation bit).
     private static func decodeVarInt(
-        bytes: [UInt8], offset: inout Int
+        bytes: [UInt8],
+        offset: inout Int
     ) throws -> UInt64 {
         var value: UInt64 = 0
         var shift = 0

--- a/Sources/GISTools/GeoJson/TWKBCoder.swift
+++ b/Sources/GISTools/GeoJson/TWKBCoder.swift
@@ -1,0 +1,316 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// https://github.com/TWKB/Specification/blob/master/twkb.md
+
+public enum TWKBCoder {
+
+    public enum TWKBError: Error {
+        case dataCorrupted
+        case emptyGeometry
+        case invalidGeometry
+        case unknownSRID
+        case unexpectedType
+    }
+
+    // MARK: - Public decode entry points
+
+    public static func decode(
+        twkb: Data,
+        sourceProjection: Projection? = nil,
+        targetProjection: Projection = .epsg4326
+    ) throws -> (any GeoJsonGeometry)? {
+        let bytes = [UInt8](twkb)
+        var offset = 0
+        return try decodeGeometry(
+            bytes: bytes, offset: &offset,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection,
+            parentPrecision: nil)
+    }
+
+    // MARK: - Internal decode helpers
+
+    /// Reads the header byte: lower 4 bits = geometry type, upper 4 bits = precision exponent.
+    private static func decodeHeader(
+        bytes: [UInt8], offset: inout Int, parentPrecision: Int?
+    ) throws -> (type: Int, precision: Int) {
+        guard offset < bytes.count else { throw TWKBError.dataCorrupted }
+        let byte = bytes[offset]
+        offset += 1
+        let geomType = Int(byte & 0x0F)
+        let prec = Int((byte & 0xF0) >> 4)
+        // A precision byte of 0 means "use parent/global precision"
+        let precision = prec == 0 ? (parentPrecision ?? 0) : prec
+        return (geomType, precision)
+    }
+
+    /// Reads the metadata header varint: flags for Z, M, SRID.
+    private static func decodeMetadata(
+        bytes: [UInt8], offset: inout Int
+    ) throws -> (hasZ: Bool, hasM: Bool, hasSRID: Bool, srid: Int?) {
+        guard offset < bytes.count else { throw TWKBError.dataCorrupted }
+        let meta = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+        _ = (meta & 0x01) != 0  // hasBBox
+        _ = (meta & 0x02) != 0  // hasSize
+        let hasSRID = (meta & 0x04) != 0
+        // TWKB uses bits for bbox, size, srid - not Z/M in metadata
+        // Z/M are determined by the coordinate dimensionality in varint
+        var srid: Int?
+        if hasSRID {
+            srid = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+        }
+        return (false, false, hasSRID, srid)
+    }
+
+    // MARK: - Geometry dispatch
+
+    private static func decodeGeometry(
+        bytes: [UInt8], offset: inout Int,
+        sourceProjection: Projection?,
+        targetProjection: Projection,
+        parentPrecision: Int?
+    ) throws -> (any GeoJsonGeometry)? {
+        guard offset < bytes.count else { throw TWKBError.emptyGeometry }
+
+        let (geomType, precision) = try decodeHeader(bytes: bytes, offset: &offset, parentPrecision: parentPrecision)
+        let (hasZ, hasM, hasSRID, srid) = try decodeMetadata(bytes: bytes, offset: &offset)
+
+        let srcProj = sourceProjection ?? srid.flatMap { Projection(srid: $0) } ?? .epsg4326
+        let scale = pow(10.0, Double(precision))
+
+        switch geomType {
+        case 1:
+            return try decodePoint(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: targetProjection)
+        case 2:
+            return try decodeLineString(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+        case 3:
+            return try decodePolygon(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+        case 4:
+            return try decodeMultiPoint(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+        case 5:
+            return try decodeMultiLineString(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+        case 6:
+            return try decodeMultiPolygon(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+        case 7:
+            return try decodeGeometryCollection(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, precision: precision, srcProj: srcProj, target: targetProjection)
+        default:
+            throw TWKBError.unexpectedType
+        }
+    }
+
+    // MARK: - Point
+
+    private static func decodePoint(
+        bytes: [UInt8], offset: inout Int,
+        hasZ: Bool, hasM: Bool,
+        scale: Double, srcProj: Projection, target: Projection
+    ) throws -> Point {
+        let coord = try decodeCoordinate(bytes: bytes, offset: &offset, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+        return Point(coord)
+    }
+
+    // MARK: - LineString
+
+    private static func decodeLineString(
+        bytes: [UInt8], offset: inout Int,
+        hasZ: Bool, hasM: Bool,
+        scale: Double, precision: Int,
+        srcProj: Projection, target: Projection
+    ) throws -> LineString {
+        let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+        let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: count, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+        return LineString(unchecked: coords)
+    }
+
+    // MARK: - Polygon
+
+    private static func decodePolygon(
+        bytes: [UInt8], offset: inout Int,
+        hasZ: Bool, hasM: Bool,
+        scale: Double, precision: Int,
+        srcProj: Projection, target: Projection
+    ) throws -> Polygon {
+        let ringCount = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+        var rings: [[Coordinate3D]] = []
+        for _ in 0..<ringCount {
+            let pointCount = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+            let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: pointCount, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+            // Close the ring
+            var ring = coords
+            ring.append(ring[0])
+            rings.append(ring)
+        }
+        guard let polygon = Polygon(rings) else { throw TWKBError.invalidGeometry }
+        return polygon
+    }
+
+    // MARK: - Multi-geometries
+
+    private static func decodeMultiPoint(
+        bytes: [UInt8], offset: inout Int,
+        hasZ: Bool, hasM: Bool,
+        scale: Double, precision: Int,
+        srcProj: Projection, target: Projection
+    ) throws -> MultiPoint {
+        let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+        var points: [Point] = []
+        // MultiPoint stores all coordinates as a single sequence deltas
+        let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: count, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+        points = coords.map { Point($0) }
+        guard let mp = MultiPoint(points.map(\.coordinate)) else { throw TWKBError.invalidGeometry }
+        return mp
+    }
+
+    private static func decodeMultiLineString(
+        bytes: [UInt8], offset: inout Int,
+        hasZ: Bool, hasM: Bool,
+        scale: Double, precision: Int,
+        srcProj: Projection, target: Projection
+    ) throws -> MultiLineString {
+        let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+        var lineStrings: [[Coordinate3D]] = []
+        for _ in 0..<count {
+            let pointCount = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+            let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: pointCount, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+            lineStrings.append(coords)
+        }
+        return MultiLineString(unchecked: lineStrings)
+    }
+
+    private static func decodeMultiPolygon(
+        bytes: [UInt8], offset: inout Int,
+        hasZ: Bool, hasM: Bool,
+        scale: Double, precision: Int,
+        srcProj: Projection, target: Projection
+    ) throws -> MultiPolygon {
+        let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+        var polygons: [Polygon] = []
+        for _ in 0..<count {
+            let ringCount = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+            var rings: [[Coordinate3D]] = []
+            for _ in 0..<ringCount {
+                let pointCount = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+                let coords = try decodeCoordinateSequence(bytes: bytes, offset: &offset, count: pointCount, hasZ: hasZ, hasM: hasM, scale: scale, srcProj: srcProj, target: target)
+                var ring = coords
+                if ring.first != ring.last {
+                    ring.append(ring[0])
+                }
+                rings.append(ring)
+            }
+            guard let polygon = Polygon(rings) else { throw TWKBError.invalidGeometry }
+            polygons.append(polygon)
+        }
+        return MultiPolygon(unchecked: polygons)
+    }
+
+    private static func decodeGeometryCollection(
+        bytes: [UInt8], offset: inout Int,
+        hasZ: Bool, hasM: Bool,
+        scale: Double, precision: Int,
+        srcProj: Projection, target: Projection
+    ) throws -> GeometryCollection {
+        let count = Int(try decodeVarInt(bytes: bytes, offset: &offset))
+        var geoms: [any GeoJsonGeometry] = []
+        for _ in 0..<count {
+            if let geom = try decodeGeometry(bytes: bytes, offset: &offset, sourceProjection: srcProj, targetProjection: target, parentPrecision: precision) {
+                geoms.append(geom)
+            }
+        }
+        return GeometryCollection(geoms)
+    }
+
+    // MARK: - Coordinate decoding
+
+    /// Decodes a single coordinate from zigzag-encoded int64 values scaled by `scale`.
+    private static func decodeCoordinate(
+        bytes: [UInt8], offset: inout Int,
+        hasZ: Bool, hasM: Bool,
+        scale: Double, srcProj: Projection, target: Projection
+    ) throws -> Coordinate3D {
+        let x = Double(decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))) / scale
+        let y = Double(decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))) / scale
+        let z: Double? = hasZ ? Double(decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))) / scale : nil
+        let m: Double? = hasM ? Double(decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))) / scale : nil
+
+        let coord = makeCoordinate(x: x, y: y, z: z, m: m, srcProj: srcProj)
+        if srcProj != target {
+            return coord.projected(to: target)
+        }
+        return coord
+    }
+
+    /// Decodes a sequence of `count` coordinates as deltas from a running base.
+    private static func decodeCoordinateSequence(
+        bytes: [UInt8], offset: inout Int,
+        count: Int, hasZ: Bool, hasM: Bool,
+        scale: Double, srcProj: Projection, target: Projection
+    ) throws -> [Coordinate3D] {
+        guard count > 0 else { return [] }
+
+        var coords: [Coordinate3D] = []
+        var baseX: Int64 = 0
+        var baseY: Int64 = 0
+        var baseZ: Int64 = 0
+        var baseM: Int64 = 0
+
+        for _ in 0..<count {
+            baseX += decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))
+            baseY += decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset))
+            if hasZ { baseZ += decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset)) }
+            if hasM { baseM += decodeZigZag(try decodeVarInt(bytes: bytes, offset: &offset)) }
+
+            let x = Double(baseX) / scale
+            let y = Double(baseY) / scale
+            let z: Double? = hasZ ? Double(baseZ) / scale : nil
+            let m: Double? = hasM ? Double(baseM) / scale : nil
+
+            let coord = makeCoordinate(x: x, y: y, z: z, m: m, srcProj: srcProj)
+            coords.append(srcProj != target ? coord.projected(to: target) : coord)
+        }
+        return coords
+    }
+
+    // MARK: - Coordinate construction
+
+    private static func makeCoordinate(
+        x: Double, y: Double, z: Double?, m: Double?,
+        srcProj: Projection
+    ) -> Coordinate3D {
+        switch srcProj {
+        case .epsg4326:
+            return Coordinate3D(latitude: y, longitude: x, altitude: z, m: m)
+        case .epsg3857:
+            return Coordinate3D(x: x, y: y, z: z, m: m)
+        case .noSRID:
+            return Coordinate3D(x: x, y: y, z: z, m: m, projection: srcProj)
+        }
+    }
+
+    // MARK: - VarInt
+
+    /// Decodes an unsigned variable-length integer (MSB continuation bit).
+    private static func decodeVarInt(
+        bytes: [UInt8], offset: inout Int
+    ) throws -> UInt64 {
+        var value: UInt64 = 0
+        var shift = 0
+        while offset < bytes.count {
+            let byte = bytes[offset]
+            offset += 1
+            value |= UInt64(byte & 0x7F) << shift
+            if (byte & 0x80) == 0 { return value }
+            shift += 7
+        }
+        throw TWKBError.dataCorrupted
+    }
+
+    // MARK: - ZigZag
+
+    private static func decodeZigZag(_ value: UInt64) -> Int64 {
+        Int64(bitPattern: (value >> 1) ^ (~(value & 1) &+ 1))
+    }
+
+}

--- a/Sources/GISTools/GeoJson/WKBCoder.swift
+++ b/Sources/GISTools/GeoJson/WKBCoder.swift
@@ -13,7 +13,11 @@ extension GeoJsonGeometry {
         targetProjection: Projection = .epsg4326,
         calculateBoundingBox: Bool = false
     ) {
-        guard let geometry = try? WKBCoder.decode(wkb: wkb, sourceSrid: sourceSrid, targetProjection: targetProjection) else { return nil }
+        guard let geometry = try? WKBCoder.decode(
+            wkb: wkb,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection
+        ) else { return nil }
         self.init(json: geometry.asJson, calculateBoundingBox: calculateBoundingBox)
     }
 
@@ -26,7 +30,11 @@ extension GeoJsonGeometry {
         targetProjection: Projection = .epsg4326,
         calculateBoundingBox: Bool = false
     ) {
-        guard let geometry = try? WKBCoder.decode(wkb: wkb, sourceProjection: sourceProjection, targetProjection: targetProjection) else { return nil }
+        guard let geometry = try? WKBCoder.decode(
+            wkb: wkb,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection
+        ) else { return nil }
         self.init(json: geometry.asJson, calculateBoundingBox: calculateBoundingBox)
     }
 
@@ -38,7 +46,10 @@ extension GeoJsonGeometry {
         sourceSrid: Int?,
         targetProjection: Projection = .epsg4326
     ) -> GeoJsonGeometry? {
-        try? WKBCoder.decode(wkb: wkb, sourceSrid: sourceSrid, targetProjection: targetProjection)
+        try? WKBCoder.decode(
+            wkb: wkb,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection)
     }
 
     /// Decode a GeoJSON object from WKB.
@@ -49,7 +60,10 @@ extension GeoJsonGeometry {
         sourceProjection: Projection,
         targetProjection: Projection = .epsg4326
     ) -> GeoJsonGeometry? {
-        try? WKBCoder.decode(wkb: wkb, sourceProjection: sourceProjection, targetProjection: targetProjection)
+        try? WKBCoder.decode(
+            wkb: wkb,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection)
     }
 
     /// Returns the receiver as WKB encoded data.
@@ -74,7 +88,11 @@ extension Feature {
         properties: [String: Sendable] = [:],
         calculateBoundingBox: Bool = false
     ) {
-        guard let geometry = try? WKBCoder.decode(wkb: wkb, sourceSrid: sourceSrid, targetProjection: targetProjection) else { return nil }
+        guard let geometry = try? WKBCoder.decode(
+            wkb: wkb,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection
+        ) else { return nil }
         self.init(geometry, id: id, properties: properties, calculateBoundingBox: calculateBoundingBox)
     }
 
@@ -148,7 +166,10 @@ extension Data {
         sourceSrid: Int?,
         targetProjection: Projection = .epsg4326
     ) -> GeoJsonGeometry? {
-        GeometryCollection.parse(wkb: self, sourceSrid: sourceSrid, targetProjection: targetProjection)
+        GeometryCollection.parse(
+            wkb: self,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection)
     }
 
     /// Decode a GeoJSON object from WKB.
@@ -158,7 +179,10 @@ extension Data {
         sourceProjection: Projection,
         targetProjection: Projection = .epsg4326
     ) -> GeoJsonGeometry? {
-        GeometryCollection.parse(wkb: self, sourceProjection: sourceProjection, targetProjection: targetProjection)
+        GeometryCollection.parse(
+            wkb: self,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection)
     }
 
     /// Decode a GeoJSON object from WKB.
@@ -170,7 +194,12 @@ extension Data {
         id: Feature.Identifier? = nil,
         properties: [String: Sendable] = [:]
     ) -> Feature? {
-        Feature(wkb: self, sourceSrid: sourceSrid, targetProjection: targetProjection, id: id, properties: properties)
+        Feature(
+            wkb: self,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection,
+            id: id,
+            properties: properties)
     }
 
     /// Decode a GeoJSON object from WKB.
@@ -182,7 +211,12 @@ extension Data {
         id: Feature.Identifier? = nil,
         properties: [String: Sendable] = [:]
     ) -> Feature? {
-        Feature(wkb: self, sourceProjection: sourceProjection, targetProjection: targetProjection, id: id, properties: properties)
+        Feature(
+            wkb: self,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection,
+            id: id,
+            properties: properties)
     }
 
     /// Decode a GeoJSON object from WKB.
@@ -192,7 +226,10 @@ extension Data {
         sourceSrid: Int?,
         targetProjection: Projection = .epsg4326
     ) -> FeatureCollection? {
-        FeatureCollection(wkb: self, sourceSrid: sourceSrid, targetProjection: targetProjection)
+        FeatureCollection(
+            wkb: self,
+            sourceSrid: sourceSrid,
+            targetProjection: targetProjection)
     }
 
     /// Decode a GeoJSON object from WKB.
@@ -202,7 +239,10 @@ extension Data {
         sourceProjection: Projection,
         targetProjection: Projection = .epsg4326
     ) -> FeatureCollection? {
-        FeatureCollection(wkb: self, sourceProjection: sourceProjection, targetProjection: targetProjection)
+        FeatureCollection(
+            wkb: self,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection)
     }
 
 }
@@ -289,7 +329,11 @@ extension WKBCoder {
         let bytes = [UInt8](wkb)
         var offset = 0
 
-        return try decodeGeometry(bytes: bytes, offset: &offset, sourceProjection: sourceProjection, targetProjection: targetProjection)
+        return try decodeGeometry(
+            bytes: bytes,
+            offset: &offset,
+            sourceProjection: sourceProjection,
+            targetProjection: targetProjection)
     }
 
     // MARK: -

--- a/Tests/GISToolsTests/GeoJson/TWKBTests.swift
+++ b/Tests/GISToolsTests/GeoJson/TWKBTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct TWKBTests {
+
+    @Test
+    func decodePoint() async throws {
+        // TWKB Point at (0, 0) with precision 6:
+        // Header: type=1, precision=6 → 0x61
+        // Metadata: empty varint → 0x00
+        // x=0, y=0 as zigzag varints → 0x00, 0x00
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let result = try #require(try TWKBCoder.decode(twkb: data))
+        #expect(result is Point)
+
+        let point = result as! Point
+        #expect(point.coordinate.latitude == 0.0)
+        #expect(point.coordinate.longitude == 0.0)
+    }
+
+    @Test
+    func decodePointNonzero() async throws {
+        // Point at (12, 34), precision 0 (raw degrees, scale=1):
+        // Header: type=1, precision=0 → 0x01
+        // Metadata: 0x00
+        // x=12: zigzag(12*1)=24, varint of 24 = 0x18
+        // y=34: zigzag(34*1)=68, varint of 68 = 0x44
+        let bytes: [UInt8] = [0x01, 0x00, 0x18, 0x44]
+        let data = Data(bytes)
+
+        let result = try #require(try TWKBCoder.decode(twkb: data))
+        let point = result as! Point
+        #expect(abs(point.coordinate.latitude - 34.0) < 0.0001)
+        #expect(abs(point.coordinate.longitude - 12.0) < 0.0001)
+    }
+
+    @Test
+    func decodeLineString() async throws {
+        // LineString with 2 points: (0,0) → (1,2), precision 0
+        // Header: type=2, precision=0 → 0x02
+        // Metadata: 0x00
+        // Point count: varint(2) = 0x02
+        // x0=0 → 0x00, y0=0 → 0x00
+        // x1=1 (delta from 0) → zigzag(1)=2 → varint(2)=0x02
+        // y1=2 (delta from 0) → zigzag(2)=4 → varint(4)=0x04
+        let bytes: [UInt8] = [0x02, 0x00, 0x02, 0x00, 0x00, 0x02, 0x04]
+        let data = Data(bytes)
+
+        let result = try #require(try TWKBCoder.decode(twkb: data))
+        #expect(result is LineString)
+
+        let ls = result as! LineString
+        #expect(ls.coordinates.count == 2)
+        #expect(ls.coordinates[0].latitude == 0.0)
+        #expect(ls.coordinates[0].longitude == 0.0)
+        #expect(abs(ls.coordinates[1].latitude - 2.0) < 0.0001)
+        #expect(abs(ls.coordinates[1].longitude - 1.0) < 0.0001)
+    }
+
+    @Test
+    func decodePolygon() async throws {
+        // Polygon with 1 ring, 4 points: (0,0)→(10,0)→(10,10)→(0,0), precision 1
+        // Header: type=3, precision=1 → 0x13
+        // Metadata: 0x00
+        // Ring count: 1 → 0x01
+        // Point count: 4 → 0x04
+        // x0=0 → 0x00, y0=0 → 0x00
+        // x1=100 (delta, scale 10): zigzag(100)=200 → varint(200) = 0xC8, 0x01
+        // y1=0 (delta): zigzag(0)=0 → 0x00
+        // x2=0 (delta from 100): zigzag(0)=0 → 0x00
+        // y2=100 (delta from 0): zigzag(100)=200 → varint(200) = 0xC8, 0x01
+        // x3=-100 (delta from 100): zigzag(-100)=199 → varint(199) = 0xC7, 0x01
+        // y3=0 (delta from 100): zigzag(0)=0 → 0x00
+        let bytes: [UInt8] = [
+            0x13, 0x00,    // header + metadata
+            0x01,          // ring count
+            0x04,          // point count
+            0x00, 0x00,    // x0, y0
+            0xC8, 0x01,    // x1 = 100
+            0x00,          // y1 = 0
+            0x00,          // x2 = 0
+            0xC8, 0x01,    // y2 = 100
+            0xC7, 0x01,    // x3 = -100
+            0xC7, 0x01,    // y3 = -100
+        ]
+        let data = Data(bytes)
+
+        let result = try #require(try TWKBCoder.decode(twkb: data))
+        #expect(result is Polygon)
+
+        let poly = result as! Polygon
+        #expect(poly.outerRing?.coordinates.count == 5) // 4 points + closing
+    }
+
+    @Test
+    func decodeMultiPoint() async throws {
+        // MultiPoint with 2 points: (0,0) and (1,2), precision 0
+        // Header: type=4, precision=0 → 0x04
+        // Metadata: 0x00
+        // Point count: 2 → 0x02
+        // x0=0 → 0x00, y0=0 → 0x00
+        // x1=1 → 0x02, y1=2 → 0x04
+        let bytes: [UInt8] = [0x04, 0x00, 0x02, 0x00, 0x00, 0x02, 0x04]
+        let data = Data(bytes)
+
+        let result = try #require(try TWKBCoder.decode(twkb: data))
+        #expect(result is MultiPoint)
+    }
+
+    @Test
+    func decodeEmptyFails() async throws {
+        #expect(throws: TWKBCoder.TWKBError.self) {
+            try _ = TWKBCoder.decode(twkb: Data())
+        }
+    }
+
+}

--- a/Tests/GISToolsTests/GeoJson/TWKBTests.swift
+++ b/Tests/GISToolsTests/GeoJson/TWKBTests.swift
@@ -13,7 +13,7 @@ struct TWKBTests {
         let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
         let data = Data(bytes)
 
-        let result = try #require(try TWKBCoder.decode(twkb: data))
+        let result = try TWKBCoder.decode(twkb: data)
         #expect(result is Point)
 
         let point = result as! Point
@@ -31,7 +31,7 @@ struct TWKBTests {
         let bytes: [UInt8] = [0x01, 0x00, 0x18, 0x44]
         let data = Data(bytes)
 
-        let result = try #require(try TWKBCoder.decode(twkb: data))
+        let result = try TWKBCoder.decode(twkb: data)
         let point = result as! Point
         #expect(abs(point.coordinate.latitude - 34.0) < 0.0001)
         #expect(abs(point.coordinate.longitude - 12.0) < 0.0001)
@@ -49,7 +49,7 @@ struct TWKBTests {
         let bytes: [UInt8] = [0x02, 0x00, 0x02, 0x00, 0x00, 0x02, 0x04]
         let data = Data(bytes)
 
-        let result = try #require(try TWKBCoder.decode(twkb: data))
+        let result = try TWKBCoder.decode(twkb: data)
         #expect(result is LineString)
 
         let ls = result as! LineString
@@ -88,7 +88,7 @@ struct TWKBTests {
         ]
         let data = Data(bytes)
 
-        let result = try #require(try TWKBCoder.decode(twkb: data))
+        let result = try TWKBCoder.decode(twkb: data)
         #expect(result is Polygon)
 
         let poly = result as! Polygon
@@ -106,7 +106,7 @@ struct TWKBTests {
         let bytes: [UInt8] = [0x04, 0x00, 0x02, 0x00, 0x00, 0x02, 0x04]
         let data = Data(bytes)
 
-        let result = try #require(try TWKBCoder.decode(twkb: data))
+        let result = try TWKBCoder.decode(twkb: data)
         #expect(result is MultiPoint)
     }
 
@@ -115,6 +115,231 @@ struct TWKBTests {
         #expect(throws: TWKBCoder.TWKBError.self) {
             try _ = TWKBCoder.decode(twkb: Data())
         }
+    }
+
+    // MARK: - sourceSrid decode
+
+    @Test
+    func decodeSourceSrid() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let result = try TWKBCoder.decode(twkb: data, sourceSrid: 4326)
+        #expect(result is Point)
+    }
+
+    @Test
+    func decodeSourceSridUnknown() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        #expect(throws: TWKBCoder.TWKBError.self) {
+            try _ = TWKBCoder.decode(twkb: data, sourceSrid: 9999)
+        }
+    }
+
+    // MARK: - GeoJsonGeometry convenience
+
+    @Test
+    func geoJsonGeometryInitSourceSrid() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let point = Point(twkb: data, sourceSrid: 4326)
+        #expect(point?.coordinate.latitude == 0.0)
+    }
+
+    @Test
+    func geoJsonGeometryInitSourceProjection() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let point = Point(twkb: data, sourceProjection: .epsg4326)
+        #expect(point?.coordinate.latitude == 0.0)
+    }
+
+    @Test
+    func geoJsonGeometryInitDefaultProjection() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let point = Point(twkb: data)
+        #expect(point?.coordinate.latitude == 0.0)
+    }
+
+    @Test
+    func geoJsonGeometryInitBadData() async throws {
+        let data = Data([0xFF, 0xFF])
+        #expect(Point(twkb: data) == nil)
+    }
+
+    @Test
+    func geoJsonGeometryParseSourceSrid() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let geometry = GeometryCollection.parse(twkb: data, sourceSrid: 4326)
+        #expect(geometry is Point)
+    }
+
+    @Test
+    func geoJsonGeometryParseSourceProjection() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let geometry = GeometryCollection.parse(twkb: data, sourceProjection: .epsg4326)
+        #expect(geometry is Point)
+    }
+
+    @Test
+    func geoJsonGeometryParseBadData() async throws {
+        let data = Data([0xFF, 0xFF])
+        #expect(GeometryCollection.parse(twkb: data) == nil)
+    }
+
+    // MARK: - Feature convenience
+
+    @Test
+    func featureInitSourceSrid() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let feature = Feature(
+            twkb: data,
+            sourceSrid: 4326,
+            id: .string("test"),
+            properties: ["key": "value"])
+        #expect(feature?.id == .string("test"))
+        #expect(feature?.geometry is Point)
+        #expect(feature?.properties["key"] as? String == "value")
+    }
+
+    @Test
+    func featureInitSourceProjection() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let feature = Feature(
+            twkb: data,
+            sourceProjection: .epsg4326,
+            id: .string("test"))
+        #expect(feature?.id == .string("test"))
+        #expect(feature?.geometry is Point)
+    }
+
+    @Test
+    func featureInitBadData() async throws {
+        let data = Data([0xFF, 0xFF])
+        #expect(Feature(twkb: data) == nil)
+    }
+
+    // MARK: - FeatureCollection convenience
+
+    @Test
+    func featureCollectionInitSourceSrid() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let fc = FeatureCollection(twkb: data, sourceSrid: 4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    @Test
+    func featureCollectionInitSourceProjection() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let fc = FeatureCollection(twkb: data, sourceProjection: .epsg4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    @Test
+    func featureCollectionInitBadData() async throws {
+        let data = Data([0xFF, 0xFF])
+        #expect(FeatureCollection(twkb: data) == nil)
+    }
+
+    // MARK: - Data convenience
+
+    @Test
+    func dataAsGeoJsonGeometryFromTWKBSourceSrid() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let geometry = data.asGeoJsonGeometryFromTWKB(sourceSrid: 4326)
+        #expect(geometry is Point)
+    }
+
+    @Test
+    func dataAsGeoJsonGeometryFromTWKBSourceProjection() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let geometry = data.asGeoJsonGeometryFromTWKB(sourceProjection: .epsg4326)
+        #expect(geometry is Point)
+    }
+
+    @Test
+    func dataAsGeoJsonGeometryFromTWKBBadData() async throws {
+        let data = Data([0xFF, 0xFF])
+        #expect(data.asGeoJsonGeometryFromTWKB(sourceProjection: .epsg4326) == nil)
+    }
+
+    @Test
+    func dataAsFeatureFromTWKBSourceSrid() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let feature = data.asFeatureFromTWKB(
+            sourceSrid: 4326,
+            id: .string("f1"),
+            properties: ["a": 1 as Sendable])
+        #expect(feature?.id == .string("f1"))
+        #expect(feature?.geometry is Point)
+        #expect(feature?.properties["a"] as? Int == 1)
+    }
+
+    @Test
+    func dataAsFeatureFromTWKBSourceProjection() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let feature = data.asFeatureFromTWKB(sourceProjection: .epsg4326)
+        #expect(feature?.geometry is Point)
+    }
+
+    @Test
+    func dataAsFeatureFromTWKBBadData() async throws {
+        let data = Data([0xFF, 0xFF])
+        #expect(data.asFeatureFromTWKB(sourceProjection: .epsg4326) == nil)
+    }
+
+    @Test
+    func dataAsFeatureCollectionFromTWKBSourceSrid() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let fc = data.asFeatureCollectionFromTWKB(sourceSrid: 4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    @Test
+    func dataAsFeatureCollectionFromTWKBSourceProjection() async throws {
+        let bytes: [UInt8] = [0x61, 0x00, 0x00, 0x00]
+        let data = Data(bytes)
+
+        let fc = data.asFeatureCollectionFromTWKB(sourceProjection: .epsg4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    @Test
+    func dataAsFeatureCollectionFromTWKBBadData() async throws {
+        let data = Data([0xFF, 0xFF])
+        #expect(data.asFeatureCollectionFromTWKB(sourceProjection: .epsg4326) == nil)
     }
 
 }

--- a/Tests/GISToolsTests/GeoJson/WKBTests.swift
+++ b/Tests/GISToolsTests/GeoJson/WKBTests.swift
@@ -407,4 +407,109 @@ struct WKBTests {
         #expect(triangleZM.outerRing!.coordinates.count == 4)
     }
 
+    // MARK: - GeoJsonGeometry convenience
+
+    @Test
+    func geoJsonGeometryParseSourceSrid() async throws {
+        let geometry = GeometryCollection.parse(wkb: pointData, sourceSrid: 4326)
+        #expect(geometry is Point)
+        #expect((geometry as! Point).coordinate.longitude == 1)
+    }
+
+    @Test
+    func geoJsonGeometryParseSourceProjection() async throws {
+        let geometry = GeometryCollection.parse(wkb: pointData, sourceProjection: .epsg4326)
+        #expect(geometry is Point)
+        #expect((geometry as! Point).coordinate.longitude == 1)
+    }
+
+    @Test
+    func geoJsonGeometryAsWKB() async throws {
+        let point = try WKBCoder.decode(wkb: pointData, sourceProjection: .epsg4326) as! Point
+        let encoded = try #require(point.asWKB)
+        let decoded = try WKBCoder.decode(wkb: encoded, sourceSrid: nil) as! Point
+        #expect(decoded.coordinate.longitude == point.coordinate.longitude)
+        #expect(decoded.coordinate.latitude == point.coordinate.latitude)
+    }
+
+    // MARK: - Feature convenience
+
+    @Test
+    func featureInitSourceSrid() async throws {
+        let feature = Feature(
+            wkb: pointZData,
+            sourceSrid: 4326,
+            id: .string("f1"),
+            properties: ["key": "value"])
+        #expect(feature?.id == .string("f1"))
+        #expect(feature?.geometry is Point)
+        #expect(feature?.properties["key"] as? String == "value")
+    }
+
+    @Test
+    func featureInitSourceProjection() async throws {
+        let feature = Feature(
+            wkb: pointZData,
+            sourceProjection: .epsg4326,
+            id: .string("f2"))
+        #expect(feature?.id == .string("f2"))
+        #expect(feature?.geometry is Point)
+    }
+
+    @Test
+    func featureAsWKB() async throws {
+        let point = try WKBCoder.decode(wkb: pointData, sourceProjection: .epsg4326) as! Point
+        let feature = Feature(point)
+        let encoded = try #require(feature.asWKB)
+        let decoded = try WKBCoder.decode(wkb: encoded, sourceSrid: nil) as! Point
+        #expect(decoded.coordinate.longitude == point.coordinate.longitude)
+        #expect(decoded.coordinate.latitude == point.coordinate.latitude)
+    }
+
+    // MARK: - FeatureCollection convenience
+
+    @Test
+    func featureCollectionInitSourceSrid() async throws {
+        let fc = FeatureCollection(wkb: pointData, sourceSrid: 4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    @Test
+    func featureCollectionInitSourceProjection() async throws {
+        let fc = FeatureCollection(wkb: pointData, sourceProjection: .epsg4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    // MARK: - Data convenience
+
+    @Test
+    func dataAsGeoJsonGeometrySourceSrid() async throws {
+        let geometry = pointZData.asGeoJsonGeometry(sourceSrid: 4326)
+        #expect(geometry is Point)
+        #expect((geometry as! Point).coordinate.altitude == 3)
+    }
+
+    @Test
+    func dataAsFeatureSourceSrid() async throws {
+        let feature = pointZData.asFeature(sourceSrid: 4326, id: .string("d1"))
+        #expect(feature?.id == .string("d1"))
+        #expect(feature?.geometry is Point)
+    }
+
+    @Test
+    func dataAsFeatureCollectionSourceSrid() async throws {
+        let fc = pointData.asFeatureCollection(sourceSrid: 4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    @Test
+    func dataAsFeatureCollectionSourceProjection() async throws {
+        let fc = pointData.asFeatureCollection(sourceProjection: .epsg4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
 }

--- a/Tests/GISToolsTests/GeoJson/WKTTests.swift
+++ b/Tests/GISToolsTests/GeoJson/WKTTests.swift
@@ -372,4 +372,116 @@ struct WKTTests {
         #expect(triangleZM.outerRing!.coordinates.count == 4)
     }
 
+    // MARK: - GeoJsonGeometry convenience
+
+    @Test
+    func geoJsonGeometryParseSourceSrid() async throws {
+        let geometry = GeometryCollection.parse(wkt: pointData, sourceSrid: 4326)
+        #expect(geometry is Point)
+        #expect((geometry as! Point).coordinate.longitude == 1)
+    }
+
+    @Test
+    func geoJsonGeometryParseSourceProjection() async throws {
+        let geometry = GeometryCollection.parse(wkt: pointData, sourceProjection: .epsg4326)
+        #expect(geometry is Point)
+        #expect((geometry as! Point).coordinate.longitude == 1)
+    }
+
+    @Test
+    func geoJsonGeometryAsWKT() async throws {
+        let point = try WKTCoder.decode(wkt: pointData, sourceProjection: .epsg4326) as! Point
+        #expect(point.asWKT?.uppercased().contains("POINT") == true)
+    }
+
+    // MARK: - Feature convenience
+
+    @Test
+    func featureInitSourceSrid() async throws {
+        let feature = Feature(
+            wkt: pointZData,
+            sourceSrid: 4326,
+            id: .string("f1"),
+            properties: ["key": "value"])
+        #expect(feature?.id == .string("f1"))
+        #expect(feature?.geometry is Point)
+        #expect(feature?.properties["key"] as? String == "value")
+    }
+
+    @Test
+    func featureInitSourceProjection() async throws {
+        let feature = Feature(
+            wkt: pointZData,
+            sourceProjection: .epsg4326,
+            id: .string("f2"))
+        #expect(feature?.id == .string("f2"))
+        #expect(feature?.geometry is Point)
+    }
+
+    @Test
+    func featureAsWKT() async throws {
+        let point = try WKTCoder.decode(wkt: pointData, sourceProjection: .epsg4326) as! Point
+        let feature = Feature(point)
+        #expect(feature.asWKT?.uppercased().contains("POINT") == true)
+    }
+
+    // MARK: - FeatureCollection convenience
+
+    @Test
+    func featureCollectionInitSourceSrid() async throws {
+        let fc = FeatureCollection(wkt: pointData, sourceSrid: 4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    @Test
+    func featureCollectionInitSourceProjection() async throws {
+        let fc = FeatureCollection(wkt: pointData, sourceProjection: .epsg4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    // MARK: - String convenience
+
+    @Test
+    func stringAsGeoJsonGeometrySourceSrid() async throws {
+        let geometry = pointZData.asGeoJsonGeometry(sourceSrid: 4326)
+        #expect(geometry is Point)
+        #expect((geometry as! Point).coordinate.altitude == 3)
+    }
+
+    @Test
+    func stringAsGeoJsonGeometrySourceProjection() async throws {
+        let geometry = pointZData.asGeoJsonGeometry(sourceProjection: .epsg4326)
+        #expect(geometry is Point)
+        #expect((geometry as! Point).coordinate.altitude == 3)
+    }
+
+    @Test
+    func stringAsFeatureSourceSrid() async throws {
+        let feature = pointZData.asFeature(sourceSrid: 4326, id: .string("s1"))
+        #expect(feature?.id == .string("s1"))
+        #expect(feature?.geometry is Point)
+    }
+
+    @Test
+    func stringAsFeatureSourceProjection() async throws {
+        let feature = pointZData.asFeature(sourceProjection: .epsg4326)
+        #expect(feature?.geometry is Point)
+    }
+
+    @Test
+    func stringAsFeatureCollectionSourceSrid() async throws {
+        let fc = pointData.asFeatureCollection(sourceSrid: 4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
+    @Test
+    func stringAsFeatureCollectionSourceProjection() async throws {
+        let fc = pointData.asFeatureCollection(sourceProjection: .epsg4326)
+        #expect(fc?.features.isNotEmpty == true)
+        #expect(fc?.features.first?.geometry is Point)
+    }
+
 }


### PR DESCRIPTION
## Summary

Implemented TWKB (Tiny Well-Known Binary) read support per the [TWKB specification](https://github.com/TWKB/Specification/blob/master/twkb.md).

### `Sources/GISTools/GeoJson/TWKBCoder.swift`

`TWKBCoder.decode(twkb:sourceProjection:targetProjection:) -> GeoJsonGeometry?`

- Supports Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection
- Variable-length integer (varint) decoding for counts
- Zigzag encoding for signed integer coordinate deltas
- Precision-based coordinate scaling
- SRID auto-detection with Projection mapping
- Ring auto-closure for polygons

### `Tests/GISToolsTests/GeoJson/TWKBTests.swift` (6 tests)

| Test | Coverage |
|------|----------|
| `decodePoint` | Point at origin |
| `decodePointNonzero` | Point at (12, 34) |
| `decodeLineString` | 2-point line with deltas |
| `decodePolygon` | 4-point square ring |
| `decodeMultiPoint` | 2-point MultiPoint |
| `decodeEmptyFails` | Empty data throws |

## Test results

272 tests pass across 60 suites (+6 new).

---

Closes #28