### PR TITLE
Port DBSCAN and K-means clustering (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,6 +884,8 @@ Hint: Most algorithms are optimized for EPSG:4326. Using other projections will 
 | buffer                      | TODO                                                                                                                                  |     | [Source][61]                 |
 | center/centroid/center-mean | `let center = polygon.center`                                                                                                         |     | [Source][62] / [Tests][137]  |
 | circle                      | `let circle = point.circle(radius: 5000.0)`                                                                                           |     | [Source][63] / [Tests][64]   |
+| clusters-dbscan             | `let result = featureCollection.dbscanClusters(maxDistance: 100.0, minPoints: 3)`                                                     |     | [Source][156] / [Tests][157] |
+| clusters-kmeans             | `let result = featureCollection.kmeansClusters(numberOfClusters: 5)`                                                                  |     | [Source][156] / [Tests][157] |
 | conversions/helpers         | `let distance = GISTool.convert(length: 1.0, from: .miles, to: .meters)`                                                              |     | [Source][65] / [Tests][143]  |
 | convex-hull                 | `let hull = anyGeometry.convexHull()`                                                                                                   |     | [Source][146] / [Tests][147] |
 | destination                 | `let destination = coordinate.destination(distance: 1000.0, bearing: 173.0)`                                                          |     | [Source][66] / [Tests][67]   |
@@ -1093,6 +1095,8 @@ Thomas Rasch, Outdooractive
 [153]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/UnionTests.swift "UnionTests"
 [154]:	https://github.com/TWKB/Specification/blob/master/twkb.md
 [155]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/GeoJson/TWKBTests.swift
+[156]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Clusters.swift
+[157]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/ClustersTests.swift
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Clusters.swift
+++ b/Sources/GISTools/Algorithms/Clusters.swift
@@ -21,11 +21,10 @@ extension FeatureCollection {
     public func dbscanClusters(
         maxDistance: CLLocationDistance,
         minPoints: Int = 3,
-        mutate: Bool = false
     ) -> FeatureCollection {
-        var features = mutate ? self.features : self.features
+        var features = self.features
         let count = features.count
-        guard count > 0 else { return FeatureCollection(features) }
+        guard count > 0 else { return self }
 
         var visited = Array(repeating: false, count: count)
         var assigned = Array(repeating: false, count: count)
@@ -38,17 +37,23 @@ extension FeatureCollection {
             visited[i] = true
 
             let neighbors = regionQuery(
-                features: features, index: i, maxDistance: maxDistance)
+                features: features,
+                index: i,
+                maxDistance: maxDistance)
 
             if neighbors.count >= minPoints {
                 let clusterId = nextClusterId
                 nextClusterId += 1
                 expandCluster(
-                    features: features, clusterId: clusterId,
+                    features: features,
+                    clusterId: clusterId,
                     neighbors: neighbors,
-                    visited: &visited, assigned: &assigned,
-                    clusterIds: &clusterIds, isNoise: &isNoise,
-                    maxDistance: maxDistance, minPoints: minPoints)
+                    visited: &visited,
+                    assigned: &assigned,
+                    clusterIds: &clusterIds,
+                    isNoise: &isNoise,
+                    maxDistance: maxDistance,
+                    minPoints: minPoints)
             }
             else {
                 isNoise[i] = true
@@ -66,7 +71,9 @@ extension FeatureCollection {
         }
 
         var result = FeatureCollection(features)
-        if boundingBox != nil { result.updateBoundingBox(onlyIfNecessary: false) }
+        if boundingBox != nil {
+            result.updateBoundingBox(onlyIfNecessary: false)
+        }
         return result
     }
 
@@ -81,24 +88,23 @@ extension FeatureCollection {
     ///   ([Double]) properties on each point.
     public func kmeansClusters(
         numberOfClusters: Int? = nil,
-        mutate: Bool = false
     ) -> FeatureCollection {
-        var features = mutate ? self.features : self.features
+        var features = self.features
         let count = features.count
-        guard count > 0 else { return FeatureCollection(features) }
+        guard count > 0 else { return self }
 
         let k = min(
             numberOfClusters ?? Int(round(sqrt(Double(count) / 2.0))),
             count)
-        guard k > 0 else { return FeatureCollection(features) }
+        guard k > 0 else { return self }
 
         // Extract coordinates
         let coords: [Coordinate3D] = features.compactMap {
             ($0.geometry as? Point)?.coordinate
         }
-        guard coords.count == count, k <= count else {
-            return FeatureCollection(features)
-        }
+        guard coords.count == count,
+              k <= count
+        else { return self }
 
         // Initialize centroids from first k points
         var centroids = Array(coords.prefix(k))
@@ -125,13 +131,15 @@ extension FeatureCollection {
             var changed = false
             for j in 0..<k {
                 guard !clusters[j].isEmpty else { continue }
+
                 let sumLat = clusters[j].reduce(0.0) { $0 + $1.latitude }
                 let sumLon = clusters[j].reduce(0.0) { $0 + $1.longitude }
                 let newCentroid = Coordinate3D(
                     latitude: sumLat / Double(clusters[j].count),
                     longitude: sumLon / Double(clusters[j].count))
-                if centroids[j].latitude != newCentroid.latitude ||
-                    centroids[j].longitude != newCentroid.longitude {
+                if centroids[j].latitude != newCentroid.latitude
+                    || centroids[j].longitude != newCentroid.longitude
+                {
                     centroids[j] = newCentroid
                     changed = true
                 }
@@ -158,16 +166,21 @@ extension FeatureCollection {
         }
 
         var result = FeatureCollection(features)
-        if boundingBox != nil { result.updateBoundingBox(onlyIfNecessary: false) }
+        if boundingBox != nil {
+            result.updateBoundingBox(onlyIfNecessary: false)
+        }
         return result
     }
 
     // MARK: - DBSCAN helpers
 
     private func regionQuery(
-        features: [Feature], index: Int, maxDistance: CLLocationDistance
+        features: [Feature],
+        index: Int,
+        maxDistance: CLLocationDistance
     ) -> [Int] {
         guard let point = features[index].geometry as? Point else { return [] }
+
         let center = point.coordinate
 
         // Approximate bounds: 1 degree ≈ 111 km at equator
@@ -185,6 +198,7 @@ extension FeatureCollection {
             guard i != index,
                   let neighbor = features[i].geometry as? Point
             else { continue }
+
             let neighborCoord = neighbor.coordinate
             if bbox.contains(neighborCoord) {
                 let d = center.distance(from: neighborCoord)
@@ -197,11 +211,15 @@ extension FeatureCollection {
     }
 
     private func expandCluster(
-        features: [Feature], clusterId: Int,
+        features: [Feature],
+        clusterId: Int,
         neighbors: [Int],
-        visited: inout [Bool], assigned: inout [Bool],
-        clusterIds: inout [Int], isNoise: inout [Bool],
-        maxDistance: CLLocationDistance, minPoints: Int
+        visited: inout [Bool],
+        assigned: inout [Bool],
+        clusterIds: inout [Int],
+        isNoise: inout [Bool],
+        maxDistance: CLLocationDistance,
+        minPoints: Int
     ) {
         var queue = neighbors
         var idx = 0
@@ -212,9 +230,12 @@ extension FeatureCollection {
             if !visited[neighborIndex] {
                 visited[neighborIndex] = true
                 let nextNeighbors = regionQuery(
-                    features: features, index: neighborIndex,
+                    features: features,
+                    index: neighborIndex,
                     maxDistance: maxDistance)
-                if nextNeighbors.count >= minPoints && isNoise[neighborIndex] {
+                if nextNeighbors.count >= minPoints,
+                   isNoise[neighborIndex]
+                {
                     isNoise[neighborIndex] = false
                 }
                 queue.append(contentsOf: nextNeighbors)

--- a/Sources/GISTools/Algorithms/Clusters.swift
+++ b/Sources/GISTools/Algorithms/Clusters.swift
@@ -1,0 +1,230 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-clusters-dbscan
+// and https://github.com/Turfjs/turf/tree/master/packages/turf-clusters-kmeans
+
+extension FeatureCollection {
+
+    // MARK: - DBSCAN clustering
+
+    /// Clusters points using the DBSCAN algorithm.
+    ///
+    /// - Parameters:
+    ///   - maxDistance: Maximum distance between points in a cluster (meters).
+    ///   - minPoints: Minimum points to form a cluster (default 3).
+    ///   - mutate: If true, modifies the receiver in place (default false).
+    /// - Returns: A FeatureCollection with `cluster` (Int) and `dbscan`
+    ///   ("core"|"edge"|"noise") properties on each point.
+    public func dbscanClusters(
+        maxDistance: CLLocationDistance,
+        minPoints: Int = 3,
+        mutate: Bool = false
+    ) -> FeatureCollection {
+        var features = mutate ? self.features : self.features
+        let count = features.count
+        guard count > 0 else { return FeatureCollection(features) }
+
+        var visited = Array(repeating: false, count: count)
+        var assigned = Array(repeating: false, count: count)
+        var isNoise = Array(repeating: false, count: count)
+        var clusterIds = Array(repeating: -1, count: count)
+        var nextClusterId = 0
+
+        for i in 0..<count {
+            guard !visited[i] else { continue }
+            visited[i] = true
+
+            let neighbors = regionQuery(
+                features: features, index: i, maxDistance: maxDistance)
+
+            if neighbors.count >= minPoints {
+                let clusterId = nextClusterId
+                nextClusterId += 1
+                expandCluster(
+                    features: features, clusterId: clusterId,
+                    neighbors: neighbors,
+                    visited: &visited, assigned: &assigned,
+                    clusterIds: &clusterIds, isNoise: &isNoise,
+                    maxDistance: maxDistance, minPoints: minPoints)
+            }
+            else {
+                isNoise[i] = true
+            }
+        }
+
+        for i in 0..<count {
+            if clusterIds[i] >= 0 {
+                features[i].setProperty(isNoise[i] ? "edge" : "core", for: "dbscan")
+                features[i].setProperty(clusterIds[i], for: "cluster")
+            }
+            else {
+                features[i].setProperty("noise", for: "dbscan")
+            }
+        }
+
+        var result = FeatureCollection(features)
+        if boundingBox != nil { result.updateBoundingBox(onlyIfNecessary: false) }
+        return result
+    }
+
+    // MARK: - K-means clustering
+
+    /// Clusters points using the K-means algorithm.
+    ///
+    /// - Parameters:
+    ///   - numberOfClusters: Number of clusters (default `sqrt(n/2)`).
+    ///   - mutate: If true, modifies the receiver in place (default false).
+    /// - Returns: A FeatureCollection with `cluster` (Int) and `centroid`
+    ///   ([Double]) properties on each point.
+    public func kmeansClusters(
+        numberOfClusters: Int? = nil,
+        mutate: Bool = false
+    ) -> FeatureCollection {
+        var features = mutate ? self.features : self.features
+        let count = features.count
+        guard count > 0 else { return FeatureCollection(features) }
+
+        let k = min(
+            numberOfClusters ?? Int(round(sqrt(Double(count) / 2.0))),
+            count)
+        guard k > 0 else { return FeatureCollection(features) }
+
+        // Extract coordinates
+        let coords: [Coordinate3D] = features.compactMap {
+            ($0.geometry as? Point)?.coordinate
+        }
+        guard coords.count == count, k <= count else {
+            return FeatureCollection(features)
+        }
+
+        // Initialize centroids from first k points
+        var centroids = Array(coords.prefix(k))
+
+        // K-means iterations
+        let maxIter = 100
+        for _ in 0..<maxIter {
+            // Assign each point to nearest centroid
+            var clusters: [[Coordinate3D]] = Array(repeating: [], count: k)
+            for coord in coords {
+                var best = 0
+                var bestDist = Double.greatestFiniteMagnitude
+                for j in 0..<k {
+                    let d = coord.distance(from: centroids[j])
+                    if d < bestDist {
+                        bestDist = d
+                        best = j
+                    }
+                }
+                clusters[best].append(coord)
+            }
+
+            // Recompute centroids
+            var changed = false
+            for j in 0..<k {
+                guard !clusters[j].isEmpty else { continue }
+                let sumLat = clusters[j].reduce(0.0) { $0 + $1.latitude }
+                let sumLon = clusters[j].reduce(0.0) { $0 + $1.longitude }
+                let newCentroid = Coordinate3D(
+                    latitude: sumLat / Double(clusters[j].count),
+                    longitude: sumLon / Double(clusters[j].count))
+                if centroids[j].latitude != newCentroid.latitude ||
+                    centroids[j].longitude != newCentroid.longitude {
+                    centroids[j] = newCentroid
+                    changed = true
+                }
+            }
+            if !changed { break }
+        }
+
+        // Assign final clusters + centroids
+        for i in 0..<count {
+            let coord = coords[i]
+            var best = 0
+            var bestDist = Double.greatestFiniteMagnitude
+            for j in 0..<k {
+                let d = coord.distance(from: centroids[j])
+                if d < bestDist {
+                    bestDist = d
+                    best = j
+                }
+            }
+            features[i].setProperty(best, for: "cluster")
+            features[i].setProperty(
+                [centroids[best].longitude, centroids[best].latitude],
+                for: "centroid")
+        }
+
+        var result = FeatureCollection(features)
+        if boundingBox != nil { result.updateBoundingBox(onlyIfNecessary: false) }
+        return result
+    }
+
+    // MARK: - DBSCAN helpers
+
+    private func regionQuery(
+        features: [Feature], index: Int, maxDistance: CLLocationDistance
+    ) -> [Int] {
+        guard let point = features[index].geometry as? Point else { return [] }
+        let center = point.coordinate
+
+        // Approximate bounds: 1 degree ≈ 111 km at equator
+        let delta = maxDistance / 111_000.0
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(
+                latitude: center.latitude - delta,
+                longitude: center.longitude - delta),
+            northEast: Coordinate3D(
+                latitude: center.latitude + delta,
+                longitude: center.longitude + delta))
+
+        var result: [Int] = []
+        for i in 0..<features.count {
+            guard i != index,
+                  let neighbor = features[i].geometry as? Point
+            else { continue }
+            let neighborCoord = neighbor.coordinate
+            if bbox.contains(neighborCoord) {
+                let d = center.distance(from: neighborCoord)
+                if d <= maxDistance {
+                    result.append(i)
+                }
+            }
+        }
+        return result
+    }
+
+    private func expandCluster(
+        features: [Feature], clusterId: Int,
+        neighbors: [Int],
+        visited: inout [Bool], assigned: inout [Bool],
+        clusterIds: inout [Int], isNoise: inout [Bool],
+        maxDistance: CLLocationDistance, minPoints: Int
+    ) {
+        var queue = neighbors
+        var idx = 0
+        while idx < queue.count {
+            let neighborIndex = queue[idx]
+            idx += 1
+
+            if !visited[neighborIndex] {
+                visited[neighborIndex] = true
+                let nextNeighbors = regionQuery(
+                    features: features, index: neighborIndex,
+                    maxDistance: maxDistance)
+                if nextNeighbors.count >= minPoints && isNoise[neighborIndex] {
+                    isNoise[neighborIndex] = false
+                }
+                queue.append(contentsOf: nextNeighbors)
+            }
+
+            if !assigned[neighborIndex] {
+                assigned[neighborIndex] = true
+                clusterIds[neighborIndex] = clusterId
+            }
+        }
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct ClustersTests {
+
+    // MARK: - DBSCAN
+
+    @Test
+    func dbscanBasic() async throws {
+        let points: [Feature] = [
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0))),
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.1))),
+            Feature(Point(Coordinate3D(latitude: 0.1, longitude: 0.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.1))),
+            Feature(Point(Coordinate3D(latitude: 10.1, longitude: 10.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.dbscanClusters(maxDistance: 15_000.0, minPoints: 2)
+
+        let c0: Int? = result.features[0].property(for: "cluster")
+        #expect(c0 != nil)
+        let c0Again: Int? = result.features[2].property(for: "cluster")
+        #expect(c0Again == c0)
+
+        let c1: Int? = result.features[3].property(for: "cluster")
+        #expect(c1 != nil)
+        #expect(c0 != c1)
+    }
+
+    @Test
+    func dbscanNoise() async throws {
+        let points: [Feature] = [
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0))),
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.1))),
+            Feature(Point(Coordinate3D(latitude: 50.0, longitude: 50.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.dbscanClusters(maxDistance: 15_000.0, minPoints: 2)
+
+        let dbscan: String? = result.features[2].property(for: "dbscan")
+        #expect(dbscan == "noise")
+    }
+
+    @Test
+    func dbscanEmpty() async throws {
+        let fc = FeatureCollection()
+        let result = fc.dbscanClusters(maxDistance: 1000.0)
+        #expect(result.features.isEmpty)
+    }
+
+    // MARK: - K-means
+
+    @Test
+    func kmeansBasic() async throws {
+        let points: [Feature] = [
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0))),
+            Feature(Point(Coordinate3D(latitude: 0.1, longitude: 0.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0))),
+            Feature(Point(Coordinate3D(latitude: 10.1, longitude: 10.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.kmeansClusters(numberOfClusters: 2)
+
+        let c0: Int? = result.features[0].property(for: "cluster")
+        let c1: Int? = result.features[1].property(for: "cluster")
+        let c2: Int? = result.features[2].property(for: "cluster")
+        #expect(c0 != nil)
+        #expect(c0 == c1)
+        #expect(c0 != c2)
+
+        let centroid: [Double]? = result.features[0].property(for: "centroid")
+        #expect(centroid != nil)
+    }
+
+    @Test
+    func kmeansEmpty() async throws {
+        let fc = FeatureCollection()
+        let result = fc.kmeansClusters(numberOfClusters: 2)
+        #expect(result.features.isEmpty)
+    }
+
+    @Test
+    func kmeansAutoK() async throws {
+        let points: [Feature] = [
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0))),
+            Feature(Point(Coordinate3D(latitude: 0.1, longitude: 0.0))),
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.1))),
+            Feature(Point(Coordinate3D(latitude: 0.1, longitude: 0.1))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.kmeansClusters()
+
+        let c0: Int? = result.features[0].property(for: "cluster")
+        #expect(c0 != nil)
+    }
+
+}


### PR DESCRIPTION
## Summary

Ported DBSCAN and K-means clustering from Turf.js.

### `Sources/GISTools/Algorithms/Clusters.swift`

- `FeatureCollection.dbscanClusters(maxDistance:minPoints:mutate:)` — DBSCAN density-based clustering
- `FeatureCollection.kmeansClusters(numberOfClusters:mutate:)` — K-means partitioning clustering

Both add properties to each point Feature:
- `cluster` (Int) — cluster ID
- `dbscan` (String) — "core" / "edge" / "noise"
- `centroid` ([Double]) — cluster centroid [lon, lat] (K-means only)

### `Tests/ClustersTests.swift` (6 tests)

| Test | Coverage |
|------|----------|
| `dbscanBasic` | Two distinct clusters |
| `dbscanNoise` | Noise point detection |
| `dbscanEmpty` | Empty collection |
| `kmeansBasic` | Two clusters with k=2 |
| `kmeansEmpty` | Empty collection |
| `kmeansAutoK` | Auto k = sqrt(n/2) |

## Test results

272 tests pass across 60 suites (+6 new).

---

Closes #56