### PR TITLE
DocC documentation and algorithm correctness improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,128 @@
 ## Swift instructions
 - You are an expert software architect and senior Swift developer
 - DO USE idomatic Swift 6, at least version 6.2
-- DO write tests for everything you do, use the Swift Testing framework
+- DO write tests for everything you do, use Swift Testing (`import Testing`), not XCTest
 - DO ASK if anything is unclear, or you need a decision
 - DO add proper Swift DocC code documentation to your code
 - DO NOT introduce third-party frameworks without asking first
 - Avoid force unwraps and force `try` unless it is unrecoverable
 - Assume strict Swift concurrency rules are being applied
+
+## Code style conventions
+
+### Spacing
+
+- 4-space indentation, no tabs
+- Semicolons: A line with a semicolon is probably a two-liner.
+- Commas: Left-hugging, space follows. `x, y`
+- Generic parameters: Add spacing after the comma. `Type<T, U>`
+- Braces: Always with a space on the inside. `{ get set }`
+- Binary operators: add single-space padding before and after for all binary operators. `a + (b * c), a + b * c, or a + b * c`
+    - Extra note: Use parenthesis in mathematical expressions to ease understanding even if not necessary. `a + (b * c)`
+- Return arrow tokens: Spaces on both sides. `f() -> T`
+- Ranges: prefer spaces on both sides. `1 ... 3, 1 ..< 4`
+- Unterminated Ranges: Omit spacing. `1...`
+- Empty constructs: No internal spaces. `[], [:], {}, f()`
+- Trailing closure: Add a space before the opening brace. `function() { ... }`
+- Functional closure: Trim spaces before opening parenthesis. `compactMap({ $0 })`
+- Comments: Add single-space padding between comment delimiters and text. `// comment`, `/* comment */`
+- Trailing whitespace: Never. Ever.
+- Last file line: End each file with a single new line.
+
+### Colon style
+
+Use left-hugging colons, with a space after the colon:
+
+- `let dict = ["a": 1, "b": 2]`
+- `let x: [String: String] = ["key": "value"]`
+- `let y = foo(param1: value1, param2: value2)`
+- `func bar<T: Hashable>(a: T) -> Void {}`
+- `case a, b:`
+- `class DerivedClass: ParentClass ...`
+
+Don't use left-hugging colons in ternary expressions or in other places where they confuse the compiler:
+- `let result = booleanCondition ? value1 : value2`
+
+Skip spaces for empty constructors (see above):
+- `[]`, `[:]`
+
+## Ternary expressions
+
+- Keep where short ternary expressions on one line:
+`let result = booleanCondition ? value1 : value2`
+
+- Split longer ternary expressions into three lines:
+```swift
+let result = booleanCondition
+    ? value1
+    : value2
+```
+
+Note that `?` and `:` are aligned.
+
+### Attributes
+
+Always place attributes (like `@objc`, `@discardableResult`) on their own line before the function declaration:
+```swift
+@discardableResult
+func insert(...)
+```
+
+### Number Literals
+
+- Use three-place underscore chunking for decimal numbers. `1_000_000`
+- Use two-place underscore chunking for hex numbers. `FF_AB_01`
+- Always add the fraction for floating-point numbers. `1.0`, not `1`
+
+### Brace style
+
+Put `else` on an extra line.
+
+```swift
+if let value = key {
+    // ...do something
+}
+else {
+    // ...do something else
+}
+```
+
+### Code organization
+
+- `// MARK:` and `// MARK: -` to organize type extensions into logical groups
+- `PascalCase` for types and type aliases, `camelCase` for everything else (properties, methods, enum cases, constants)
+- `struct` by default, `class` only when needed (reference semantics)
+- `Sendable` conformance on all model types
+- `guard let` / `if let` with early returns for failable initializers and optional handling
+- Extensions to group related functionality per type (one extension per concern, e.g., `Equatable`, `Projection`, `JsonConvertible`)
+- One file per type/algorithm, named `TypeName.swift` or `FunctionName.swift`
+- One test struct per algorithm/type (e.g., `struct DistanceTests`)
+- Key path expressions (`\.property`) over closures where possible
+
+### Argument wrapping
+
+If a method has ≤3 parameters and no return value, or ≤2 parameters and a return value, put the entire signature on one line (exception: line exceeds 80 characters). Otherwise, split parameters one per line and put the opening brace `{` on its own line.
+
+  ```swift
+  // One line (≤2 params + return, ≤80 chars)
+  public func intersects(_ other: GeoJson) -> Bool {
+      !isDisjoint(with: other)
+  }
+
+  // Multi-line (>2 params + return → one per line, brace on own line)
+  public func buffered(
+      by distance: Double,
+      lineEndStyle: BufferLineEndStyle = .round,
+      unionType: BufferUnionType = .individual,
+      steps: Int = 64
+  ) -> MultiPolygon? {
+
+  // 80-char exception: one-line form too long → multi-line
+  public func contains(
+      _ coordinate: Coordinate3D,
+      ignoringBoundary: Bool = false
+  ) -> Bool {
+  ```
 
 ## General instructions
 - DO NOT take any shortcuts while implementing an algorithm. Correctness is the highest priority

--- a/Sources/GISTools/Algorithms/Along.swift
+++ b/Sources/GISTools/Algorithms/Along.swift
@@ -40,7 +40,7 @@ extension LineString {
 
     /// Returns a `Point` at a specified distance along the line.
     ///
-    /// - Parameter distance: The distance along the line
+    /// - Parameter distance: The distance along the line, in meters
     ///
     /// - Returns: A *Point* *distance* meters along the line.
     public func pointAlong(distance: CLLocationDistance) -> Point {

--- a/Sources/GISTools/Algorithms/AntimeridianCutting.swift
+++ b/Sources/GISTools/Algorithms/AntimeridianCutting.swift
@@ -398,6 +398,8 @@ extension Feature {
 extension FeatureCollection {
 
     /// Cuts each feature's geometry at the anti-meridian.
+    ///
+    /// - Returns: A new `FeatureCollection` with each feature cut at the anti-meridian.
     public func cutAtAntimeridian() -> FeatureCollection {
         var allFeatures: [Feature] = []
         for feature in features {

--- a/Sources/GISTools/Algorithms/Area.swift
+++ b/Sources/GISTools/Algorithms/Area.swift
@@ -1,5 +1,5 @@
 #if canImport(CoreLocation)
-    import CoreLocation
+import CoreLocation
 #endif
 import Foundation
 

--- a/Sources/GISTools/Algorithms/Bearing.swift
+++ b/Sources/GISTools/Algorithms/Bearing.swift
@@ -9,9 +9,8 @@ extension Coordinate3D {
 
     /// Finds the geographic bearing between the receiver and another coordinate, i.e. the angle measured in degrees from the north line (0 degrees).
     ///
-    /// - Parameters:
-    ///    - other: The end point
-    ///    - final: Calculates the final bearing (optional, default `false`)
+    /// - Parameter other: The end point
+    /// - Parameter final: Calculates the final bearing (optional, default `false`)
     ///
     /// - Returns: The bearing in decimal degrees, between -180 and 180 (positive clockwise).
     public func bearing(
@@ -60,10 +59,9 @@ extension Coordinate3D {
 
     /// Takes three coordinates and returns the angle between them, i.e. from the triangle *first* - *middle* - *last*.
     ///
-    /// - Parameters:
-    ///    - first: The first point in the triangle
-    ///    - middle: The middle point in the triangle
-    ///    - last: The last point in the trianle
+    /// - Parameter first: The first point in the triangle
+    /// - Parameter middle: The middle point in the triangle
+    /// - Parameter last: The last point in the trianle
     ///
     /// - Returns: The angle between the points, between -180 and 180.
     public static func angleBetween(
@@ -78,9 +76,8 @@ extension Coordinate3D {
 
     /// Takes two azimuth values in decimal degrees and returns the angle between them.
     ///
-    /// - Parameters:
-    ///    - firstAzimuth: The first angle
-    ///    - secondAzimuth: The second angle
+    /// - Parameter firstAzimuth: The first angle
+    /// - Parameter secondAzimuth: The second angle
     ///
     /// - Returns: The angle, between -180 and 180.
     public static func angleBetween(
@@ -104,9 +101,8 @@ extension Point {
 
     /// Finds the geographic bearing between the receiver and another Point, i.e. the angle measured in degrees from the north line (0 degrees).
     ///
-    /// - Parameters:
-    ///    - other: The end point
-    ///    - final: Calculates the final bearing (optional, default `false`)
+    /// - Parameter other: The end point
+    /// - Parameter final: Calculates the final bearing (optional, default `false`)
     ///
     /// - Returns: The bearing in decimal degrees, between -180 and 180 (positive clockwise).
     public func bearing(
@@ -118,10 +114,9 @@ extension Point {
 
     /// Takes three *Point*s and returns the angle between them, i.e. from the triangle *first* - *middle* - *last*.
     ///
-    /// - Parameters:
-    ///    - first: The first point in the triangle
-    ///    - middle: The middle point in the triangle
-    ///    - last: The last point in the trianle
+    /// - Parameter first: The first point in the triangle
+    /// - Parameter middle: The middle point in the triangle
+    /// - Parameter last: The last point in the trianle
     ///
     /// - Returns: The angle between the points, between -180 and 180.
     public static func angleBetween(

--- a/Sources/GISTools/Algorithms/Bearing.swift
+++ b/Sources/GISTools/Algorithms/Bearing.swift
@@ -24,8 +24,9 @@ extension Coordinate3D {
         case .epsg3857:
             return projected(to: .epsg4326)._bearing(to: other.projected(to: .epsg4326), final: final)
         case .noSRID:
-            // TODO
-            return Double.infinity
+            let dx = other.longitude - longitude
+            let dy = other.latitude - latitude
+            return atan2(dx, dy).radiansToDegrees
         }
     }
 

--- a/Sources/GISTools/Algorithms/BooleanCrosses.swift
+++ b/Sources/GISTools/Algorithms/BooleanCrosses.swift
@@ -89,17 +89,11 @@ extension GeoJson {
         var foundIntPoint = false
         var foundExtPoint = false
 
+        let segments = lineString.lineSegments
         for point in multiPoint.points {
             var isInterior = false
-            let coords = lineString.coordinates
-            for i in 0..<(coords.count - 1) {
-                let incEnd = (i != 0 && i != coords.count - 2)
-                if isPointOnLineSegment(
-                    start: coords[i],
-                    end: coords[i + 1],
-                    point: point.coordinate,
-                    incEnd: incEnd)
-                {
+            for segment in segments {
+                if segment.checkIsOnSegment(point.coordinate) {
                     isInterior = true
                     break
                 }
@@ -182,49 +176,6 @@ extension GeoJson {
             }
         }
         return false
-    }
-
-    // MARK: - isPointOnLineSegment
-
-    // TODO: We also have LineSegment.checkIsOnSegment()
-
-    /// Checks whether `point` lies on the line segment from `start` to `end`.
-    ///
-    /// - parameter incEnd: If `true` the point may coincide with `start` or `end`.
-    private func isPointOnLineSegment(
-        start: Coordinate3D,
-        end: Coordinate3D,
-        point: Coordinate3D,
-        incEnd: Bool
-    ) -> Bool {
-        let dxc = point.longitude - start.longitude
-        let dyc = point.latitude - start.latitude
-        let dxl = end.longitude - start.longitude
-        let dyl = end.latitude - start.latitude
-        let cross = dxc * dyl - dyc * dxl
-
-        guard cross == 0.0 else { return false }
-
-        if incEnd {
-            if abs(dxl) >= abs(dyl) {
-                return dxl > 0
-                    ? start.longitude <= point.longitude && point.longitude <= end.longitude
-                    : end.longitude <= point.longitude && point.longitude <= start.longitude
-            }
-            return dyl > 0
-                ? start.latitude <= point.latitude && point.latitude <= end.latitude
-                : end.latitude <= point.latitude && point.latitude <= start.latitude
-        }
-        else {
-            if abs(dxl) >= abs(dyl) {
-                return dxl > 0
-                    ? start.longitude < point.longitude && point.longitude < end.longitude
-                    : end.longitude < point.longitude && point.longitude < start.longitude
-            }
-            return dyl > 0
-                ? start.latitude < point.latitude && point.latitude < end.latitude
-                : end.latitude < point.latitude && point.latitude < start.latitude
-        }
     }
 
 }

--- a/Sources/GISTools/Algorithms/BooleanCrosses.swift
+++ b/Sources/GISTools/Algorithms/BooleanCrosses.swift
@@ -146,7 +146,7 @@ extension GeoJson {
         _ lineString1: LineString,
         _ lineString2: LineString
     ) -> Bool {
-        let intersectionPoints = lineString1.intersections(other: lineString2)
+        let intersectionPoints = lineString1.intersections(with: lineString2)
         guard intersectionPoints.isNotEmpty else { return false }
 
         guard let coords1 = lineString1.coordinates as [Coordinate3D]?,
@@ -176,7 +176,7 @@ extension GeoJson {
         for polygon in polygonGeometry.polygons {
             for ring in polygon.rings {
                 let ls = ring.lineString
-                if lineString.intersections(other: ls).isNotEmpty {
+                if lineString.intersections(with: ls).isNotEmpty {
                     return true
                 }
             }

--- a/Sources/GISTools/Algorithms/BooleanDisjoint.swift
+++ b/Sources/GISTools/Algorithms/BooleanDisjoint.swift
@@ -9,8 +9,7 @@ extension GeoJson {
 
     /// Compares two geometries and returns true if they are disjoint.
     ///
-    /// - Parameters:
-    ///    - other: The other geometry
+    /// - Parameter other: The other geometry
     ///
     /// - Returns: `true` if the geometries don't overlap, `false` otherwise.
     public func isDisjoint(with other: GeoJson) -> Bool {

--- a/Sources/GISTools/Algorithms/BooleanIntersects.swift
+++ b/Sources/GISTools/Algorithms/BooleanIntersects.swift
@@ -9,8 +9,7 @@ extension GeoJson {
 
     /// Compares two geometries and returns true if they intersect.
     ///
-    /// - Parameters:
-    ///    - other: The other geometry
+    /// - Parameter other: The other geometry
     ///
     /// - Returns: `true` if the geometries intersect, `false` otherwise.
     public func intersects(_ other: GeoJson) -> Bool {

--- a/Sources/GISTools/Algorithms/BooleanOverlap.swift
+++ b/Sources/GISTools/Algorithms/BooleanOverlap.swift
@@ -71,7 +71,7 @@ extension LineStringGeometry {
             guard let boundingBox = segment.boundingBox ?? segment.calculateBoundingBox() else { continue }
 
             for match in tree.search(inBoundingBox: boundingBox) {
-                if segment.compare(other: match, tolerance: tolerance) != .notEqual {
+                if segment.compare(match, tolerance: tolerance) != .notEqual {
                     return true
                 }
             }

--- a/Sources/GISTools/Algorithms/BooleanOverlap.swift
+++ b/Sources/GISTools/Algorithms/BooleanOverlap.swift
@@ -10,9 +10,8 @@ extension PointGeometry {
     /// Compares two Point|MultiPoint geometries and returns true if their intersection set results in a geometry
     /// different from both but of the same dimension.
     ///
-    /// - Parameters:
-    ///    - other: The other Point or MultiPoint
-    ///    - tolerance: The tolerance, in meters.
+    /// - Parameter other: The other Point or MultiPoint
+    /// - Parameter tolerance: The tolerance, in meters.
     ///
     /// - Returns: `true` if the points overlap, `false` otherwise.
     public func isOverlapping(
@@ -52,9 +51,8 @@ extension LineStringGeometry {
     /// Compares two LineString|MultiLineString geometries and returns true if their intersection set results in a geometry
     /// different from both but of the same dimension.
     ///
-    /// - Parameters:
-    ///    - other: The other LineString or MultiLineString
-    ///    - tolerance: The tolerance, in meters.
+    /// - Parameter other: The other LineString or MultiLineString
+    /// - Parameter tolerance: The tolerance, in meters.
     ///
     /// - Returns: `true` if the lines overlap, `false` otherwise.
     public func isOverlapping(
@@ -87,9 +85,8 @@ extension PolygonGeometry {
     /// Compares two Polygon|MultiPolygon geometries and returns true if their intersection set results in a geometry
     /// different from both but of the same dimension.
     ///
-    /// - Parameters:
-    ///    - other: The other Polygon or MultiPolygon
-    ///    - tolerance: The tolerance, in meters.
+    /// - Parameter other: The other Polygon or MultiPolygon
+    /// - Parameter tolerance: The tolerance, in meters.
     ///
     /// - Returns: `true` if the polygons overlap, `false` otherwise.
     public func isOverlapping(
@@ -122,9 +119,8 @@ extension Feature {
     /// Compares two Features and returns true if their geometry's intersection set results in a geometry
     /// different from both but of the same dimension.
     ///
-    /// - Parameters:
-    ///    - other: The other Feature
-    ///    - tolerance: The tolerance, in meters.
+    /// - Parameter other: The other Feature
+    /// - Parameter tolerance: The tolerance, in meters.
     ///
     /// - Returns: `true` if the features overlap, `false` otherwise.
     public func isOverlapping(

--- a/Sources/GISTools/Algorithms/BooleanOverlap.swift
+++ b/Sources/GISTools/Algorithms/BooleanOverlap.swift
@@ -53,10 +53,10 @@ extension LineStringGeometry {
     /// different from both but of the same dimension.
     ///
     /// - Parameters:
-    ///    - other: The other Point or MultiPoint
+    ///    - other: The other LineString or MultiLineString
     ///    - tolerance: The tolerance, in meters.
     ///
-    /// - Returns: `true` if the points overlap, `false` otherwise.
+    /// - Returns: `true` if the lines overlap, `false` otherwise.
     public func isOverlapping(
         with other: LineStringGeometry,
         tolerance: CLLocationDegrees = 0.0
@@ -88,10 +88,10 @@ extension PolygonGeometry {
     /// different from both but of the same dimension.
     ///
     /// - Parameters:
-    ///    - other: The other Point or MultiPoint
+    ///    - other: The other Polygon or MultiPolygon
     ///    - tolerance: The tolerance, in meters.
     ///
-    /// - Returns: `true` if the points overlap, `false` otherwise.
+    /// - Returns: `true` if the polygons overlap, `false` otherwise.
     public func isOverlapping(
         with other: PolygonGeometry,
         tolerance: CLLocationDegrees = 0.0
@@ -123,10 +123,10 @@ extension Feature {
     /// different from both but of the same dimension.
     ///
     /// - Parameters:
-    ///    - other: The other Point or MultiPoint
+    ///    - other: The other Feature
     ///    - tolerance: The tolerance, in meters.
     ///
-    /// - Returns: `true` if the points overlap, `false` otherwise.
+    /// - Returns: `true` if the features overlap, `false` otherwise.
     public func isOverlapping(
         with other: Feature,
         tolerance: CLLocationDegrees = 0.0

--- a/Sources/GISTools/Algorithms/BooleanParallel.swift
+++ b/Sources/GISTools/Algorithms/BooleanParallel.swift
@@ -9,10 +9,9 @@ extension LineSegment {
 
     /// Checks if the receiver is parallel to the other *LineSegment*.
     ///
-    /// - Parameters:
-    ///    - other: The other LineSegment
-    ///    - tolerance: The tolerance, in degrees
-    ///    - undirectedEdge: Whether the segment should be treated as an undirected edge
+    /// - Parameter other: The other LineSegment
+    /// - Parameter tolerance: The tolerance, in degrees
+    /// - Parameter undirectedEdge: Whether the segment should be treated as an undirected edge
     ///
     /// - Returns: `true` if the segments are parallel within the tolerance, `false` otherwise.
     public func isParallel(
@@ -20,18 +19,31 @@ extension LineSegment {
         tolerance: CLLocationDegrees = 0.0,
         undirectedEdge: Bool = false
     ) -> Bool {
-        var azimuth1 = first.rhumbBearing(to: second).bearingToAzimuth
+        let azimuth1 = first.rhumbBearing(to: second).bearingToAzimuth
         let azimuth2 = other.first.rhumbBearing(to: other.second).bearingToAzimuth
 
-        if abs(azimuth1 - azimuth2) <= tolerance {
+        // Normalise the angular difference to [0, 180] so the comparison
+        // correctly handles values that straddle the 0°/360° boundary.
+        var diff = abs(azimuth1 - azimuth2)
+        if diff > 180.0 {
+            diff = 360.0 - diff
+        }
+
+        if diff <= tolerance {
             return true
         }
-        else if undirectedEdge {
-            azimuth1 -= 180.0
-            if azimuth1 < 0.0 {
-                azimuth1 += 360.0
+
+        if undirectedEdge {
+            // Test the opposite direction: a line is parallel to its reversal.
+            var opposite = azimuth1 + 180.0
+            if opposite >= 360.0 {
+                opposite -= 360.0
             }
-            return abs(azimuth1 - azimuth2) <= tolerance
+            diff = abs(opposite - azimuth2)
+            if diff > 180.0 {
+                diff = 360.0 - diff
+            }
+            return diff <= tolerance
         }
 
         return false
@@ -43,9 +55,8 @@ extension LineString {
 
     /// Checks if each of the receiver's segment is parallel to the correspondent segment of the other *LineString*.
     ///
-    /// - Parameters:
-    ///    - other: The other LineString
-    ///    - tolerance: The tolerance for each pair of segments, in degrees
+    /// - Parameter other: The other LineString
+    /// - Parameter tolerance: The tolerance for each pair of segments, in degrees
     ///
     /// - Returns: `true` if the lines are parallel within the tolerance, `false` otherwise.
     public func isParallel(

--- a/Sources/GISTools/Algorithms/BooleanPointInPolygon.swift
+++ b/Sources/GISTools/Algorithms/BooleanPointInPolygon.swift
@@ -9,9 +9,8 @@ extension Ring {
 
     /// Determines if *Coordinate3D* resides inside the *Ring*. The ring can be convex or concave.
     ///
-    /// - Parameters:
-    ///    - coordinate: The coordinate to check
-    ///    - ignoringBoundary: `true` if the ring boundary should be ignored when determining if the coordinate is inside the ring (default `false`).
+    /// - Parameter coordinate: The coordinate to check
+    /// - Parameter ignoringBoundary: `true` if the ring boundary should be ignored when determining if the coordinate is inside the ring (default `false`).
     ///
     /// - Returns: `true` if the coordinate is inside the ring, `false` otherwise.
     public func contains(
@@ -57,9 +56,8 @@ extension Ring {
 
     /// Determines if *Point* resides inside the *Ring*. The ring can be convex or concave.
     ///
-    /// - Parameters:
-    ///    - point: The point to check
-    ///    - ignoringBoundary: `true` if the ring boundary should be ignored when determining if the point is inside the ring (default `false`).
+    /// - Parameter point: The point to check
+    /// - Parameter ignoringBoundary: `true` if the ring boundary should be ignored when determining if the point is inside the ring (default `false`).
     ///
     /// - Returns: `true` if the point is inside the ring, `false` otherwise.
     public func contains(
@@ -76,9 +74,8 @@ extension Polygon {
     /// Determines if *Coordinate3D* resides inside the *Polygon*. The polygon can be convex or concave.
     /// The function accounts for holes.
     ///
-    /// - Parameters:
-    ///    - coordinate: The coordinate to check
-    ///    - ignoringBoundary: `true` if the polygon boundary should be ignored when determining if the coordinate is inside the polygon (default `false`).
+    /// - Parameter coordinate: The coordinate to check
+    /// - Parameter ignoringBoundary: `true` if the polygon boundary should be ignored when determining if the coordinate is inside the polygon (default `false`).
     ///
     /// - Returns: `true` if the coordinate is inside the polygon, `false` otherwise.
     public func contains(
@@ -107,9 +104,8 @@ extension Polygon {
     /// Determines if *Point* resides inside the *Polygon*. The polygon can be convex or concave.
     /// The function accounts for holes.
     ///
-    /// - Parameters:
-    ///    - point: The point to check
-    ///    - ignoringBoundary: `true` if the polygon boundary should be ignored when determining if the point is inside the polygon (default `false`).
+    /// - Parameter point: The point to check
+    /// - Parameter ignoringBoundary: `true` if the polygon boundary should be ignored when determining if the point is inside the polygon (default `false`).
     ///
     /// - Returns: `true` if the point is inside the ring, `false` otherwise.
     public func contains(
@@ -126,9 +122,8 @@ extension MultiPolygon {
     /// Determines if *Coordinate3D* resides inside the *MultiPolygon*. The polygons can be convex or concave.
     /// The function accounts for holes.
     ///
-    /// - Parameters:
-    ///    - coordinate: The coordinate to check
-    ///    - ignoringBoundary: `true` if the polygon boundaries should be ignored when determining if the coordinate is inside of one of the polygons (default `false`).
+    /// - Parameter coordinate: The coordinate to check
+    /// - Parameter ignoringBoundary: `true` if the polygon boundaries should be ignored when determining if the coordinate is inside of one of the polygons (default `false`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the polygons, `false` otherwise.
     public func contains(
@@ -151,9 +146,8 @@ extension MultiPolygon {
     /// Determines if *Point* resides inside the *MultiPolygon*. The polygons can be convex or concave.
     /// The function accounts for holes.
     ///
-    /// - Parameters:
-    ///    - point: The coordinate to check
-    ///    - ignoringBoundary: `true` if the polygon boundaries should be ignored when determining if the coordinate is inside of one of the polygons (default `false`).
+    /// - Parameter point: The coordinate to check
+    /// - Parameter ignoringBoundary: `true` if the polygon boundaries should be ignored when determining if the coordinate is inside of one of the polygons (default `false`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the polygons, `false` otherwise.
     public func contains(
@@ -169,9 +163,8 @@ extension GeometryCollection {
 
     /// Determines if *Coordinate3D* resides inside the *GeometryCollection*.
     ///
-    /// - Parameters:
-    ///    - coordinate: The coordinate to check
-    ///    - ignoringBoundary: `true` if the boundaries should be ignored when determining if the coordinate is inside of one of the geometries (default `false`).
+    /// - Parameter coordinate: The coordinate to check
+    /// - Parameter ignoringBoundary: `true` if the boundaries should be ignored when determining if the coordinate is inside of one of the geometries (default `false`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the geometries, `false` otherwise.
     public func contains(
@@ -191,9 +184,8 @@ extension Feature {
 
     /// Determines if *Coordinate3D* resides inside the *Feature*.
     ///
-    /// - Parameters:
-    ///    - coordinate: The coordinate to check
-    ///    - ignoringBoundary: `true` if the boundaries should be ignored when determining if the coordinate is inside of the Feature's geometry (default `false`).
+    /// - Parameter coordinate: The coordinate to check
+    /// - Parameter ignoringBoundary: `true` if the boundaries should be ignored when determining if the coordinate is inside of the Feature's geometry (default `false`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the Feature's geometry, `false` otherwise.
     public func contains(
@@ -211,9 +203,8 @@ extension FeatureCollection {
 
     /// Determines if *Coordinate3D* resides inside the *FeatureCollection*.
     ///
-    /// - Parameters:
-    ///    - coordinate: The coordinate to check
-    ///    - ignoringBoundary: `true` if the boundaries should be ignored when determining if the coordinate is inside of one of the geometries (default `false`).
+    /// - Parameter coordinate: The coordinate to check
+    /// - Parameter ignoringBoundary: `true` if the boundaries should be ignored when determining if the coordinate is inside of one of the geometries (default `false`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the geometries, `false` otherwise.
     public func contains(

--- a/Sources/GISTools/Algorithms/BooleanPointInPolygon.swift
+++ b/Sources/GISTools/Algorithms/BooleanPointInPolygon.swift
@@ -80,7 +80,7 @@ extension Polygon {
     ///    - coordinate: The coordinate to check
     ///    - ignoringBoundary: `true` if the polygon boundary should be ignored when determining if the coordinate is inside the polygon (default `false`).
     ///
-    /// - Returns: `true` if the coordinate is inside the ring, `false` otherwise.
+    /// - Returns: `true` if the coordinate is inside the polygon, `false` otherwise.
     public func contains(
         _ coordinate: Coordinate3D,
         ignoringBoundary: Bool = false

--- a/Sources/GISTools/Algorithms/BoundingBoxPosition.swift
+++ b/Sources/GISTools/Algorithms/BoundingBoxPosition.swift
@@ -60,7 +60,7 @@ extension BoundingBox {
     }
 
     /// Returns the relative position of a point with regards to the bounding box.
-    public func postion(of point: Point) -> CoordinatePosition {
+    public func position(of point: Point) -> CoordinatePosition {
         position(of: point.coordinate)
     }
 
@@ -69,12 +69,12 @@ extension BoundingBox {
 #if canImport(CoreLocation)
 
     /// Returns the relative position of a coordinate with regards to the bounding box.
-    public func postion(of coordinate: CLLocationCoordinate2D) -> CoordinatePosition {
+    public func position(of coordinate: CLLocationCoordinate2D) -> CoordinatePosition {
         position(of: Coordinate3D(coordinate))
     }
 
     /// Returns the relative position of a location with regards to the bounding box.
-    public func postion(of coordinate: CLLocation) -> CoordinatePosition {
+    public func position(of coordinate: CLLocation) -> CoordinatePosition {
         position(of: Coordinate3D(coordinate))
     }
 

--- a/Sources/GISTools/Algorithms/BoundingBoxPosition.swift
+++ b/Sources/GISTools/Algorithms/BoundingBoxPosition.swift
@@ -9,6 +9,9 @@ extension BoundingBox {
     public struct CoordinatePosition: OptionSet, Sendable {
         public let rawValue: Int
 
+        /// Creates a coordinate position from its raw option-set value.
+        ///
+        /// - Parameter rawValue: The raw option-set value.
         public init(rawValue: Int) {
             self.rawValue = rawValue
         }

--- a/Sources/GISTools/Algorithms/BoundingBoxPosition.swift
+++ b/Sources/GISTools/Algorithms/BoundingBoxPosition.swift
@@ -13,11 +13,17 @@ extension BoundingBox {
             self.rawValue = rawValue
         }
 
+        /// The coordinate is at the center of the bounding box.
         public static let center = CoordinatePosition(rawValue: 1 << 0)
+        /// The coordinate is in the top region of the bounding box.
         public static let top = CoordinatePosition(rawValue: 1 << 1)
+        /// The coordinate is in the right region of the bounding box.
         public static let right = CoordinatePosition(rawValue: 1 << 2)
+        /// The coordinate is in the bottom region of the bounding box.
         public static let bottom = CoordinatePosition(rawValue: 1 << 3)
+        /// The coordinate is in the left region of the bounding box.
         public static let left = CoordinatePosition(rawValue: 1 << 4)
+        /// The coordinate is outside the bounding box.
         public static let outside = CoordinatePosition(rawValue: 1 << 5)
     }
 

--- a/Sources/GISTools/Algorithms/Buffer.swift
+++ b/Sources/GISTools/Algorithms/Buffer.swift
@@ -32,13 +32,14 @@ extension GeoJson {
 
     /// Returns the receiver with a buffer.
     ///
-    /// - Parameters:
-    ///    - distance: The buffer distance, in meters. A positive value expands
-    ///                the geometry; a negative value shrinks it (only supported
-    ///                for polygons and multi-polygons).
-    ///    - lineEndStyle: Controls how line ends will be drawn (default round)
-    ///    - unionType: How to combine buffered geometries (default individual)
-    ///    - steps: The number of steps for the circles (default 64)
+    /// - Parameter distance: The buffer distance, in meters. A positive value expands
+    ///                       the geometry; a negative value shrinks it (only supported
+    ///                       for polygons and multi-polygons).
+    /// - Parameter lineEndStyle: Controls how line ends will be drawn (default round)
+    /// - Parameter unionType: How to combine buffered geometries (default individual)
+    /// - Parameter steps: The number of steps for the circles (default 64)
+    ///
+    /// - Returns: The buffered geometry as a `MultiPolygon`, or `nil` if the buffer could not be computed.
     public func buffered(
         by distance: Double,
         lineEndStyle: BufferLineEndStyle = .round,
@@ -462,11 +463,12 @@ extension LineSegment {
 
     /// Returns the line segment with a buffer.
     ///
-    /// - Parameters:
-    ///    - distance: The buffer distance, in meters
-    ///    - lineEndStyle: Controls how line ends will be drawn (default round)
-    ///    - unionType: Whether to combine all overlapping buffers into one Polygon (default true)
-    ///    - steps: The number of steps for the circles (default 64)
+    /// - Parameter distance: The buffer distance, in meters
+    /// - Parameter lineEndStyle: Controls how line ends will be drawn (default round)
+    /// - Parameter unionType: Whether to combine all overlapping buffers into one Polygon (default true)
+    /// - Parameter steps: The number of steps for the circles (default 64)
+    ///
+    /// - Returns: The buffered line segment as a `MultiPolygon`, or `nil` if the buffer could not be computed.
     public func buffered(
         by distance: Double,
         lineEndStyle: BufferLineEndStyle = .round,

--- a/Sources/GISTools/Algorithms/Center.swift
+++ b/Sources/GISTools/Algorithms/Center.swift
@@ -54,6 +54,8 @@ extension FeatureCollection {
     /// Returns the mean center of the receiver. Can be weighted.
     ///
     /// - Parameter weightAttribute: The property name used to weight the center
+    ///
+    /// - Returns: The mean center, or `nil`.
     public func centerMean(weightAttribute: String? = nil) -> Point? {
         var sumLongitude: Double = 0.0
         var sumLatitude: Double = 0.0

--- a/Sources/GISTools/Algorithms/Circle.swift
+++ b/Sources/GISTools/Algorithms/Circle.swift
@@ -9,9 +9,10 @@ extension Coordinate3D {
 
     /// Calculates the circle polygon around a coordinate.
     ///
-    /// - Parameters:
-    ///    - radius: The radius of the circle, in meters
-    ///    - steps: The number of steps (default 64)
+    /// - Parameter radius: The radius of the circle, in meters
+    /// - Parameter steps: The number of steps (default 64)
+    ///
+    /// - Returns: The circle as a `Polygon`, or `nil` if the radius is zero or steps is less than 2.
     public func circle(
         radius: CLLocationDistance,
         steps: Int = 64
@@ -33,9 +34,10 @@ extension Point {
 
     /// Calculates the circle polygon around a point.
     ///
-    /// - Parameters:
-    ///    - radius: The radius of the circle, in meters
-    ///    - steps: The number of steps (default 64)
+    /// - Parameter radius: The radius of the circle, in meters
+    /// - Parameter steps: The number of steps (default 64)
+    ///
+    /// - Returns: The circle as a `Polygon`, or `nil` if the radius is zero or steps is less than 2.
     public func circle(
         radius: CLLocationDistance,
         steps: Int = 64

--- a/Sources/GISTools/Algorithms/Clusters.swift
+++ b/Sources/GISTools/Algorithms/Clusters.swift
@@ -15,12 +15,11 @@ extension FeatureCollection {
     /// - Parameters:
     ///   - maxDistance: Maximum distance between points in a cluster (meters).
     ///   - minPoints: Minimum points to form a cluster (default 3).
-    ///   - mutate: If true, modifies the receiver in place (default false).
     /// - Returns: A FeatureCollection with `cluster` (Int) and `dbscan`
     ///   ("core"|"edge"|"noise") properties on each point.
     public func dbscanClusters(
         maxDistance: CLLocationDistance,
-        minPoints: Int = 3,
+        minPoints: Int = 3
     ) -> FeatureCollection {
         var features = self.features
         let count = features.count
@@ -83,11 +82,10 @@ extension FeatureCollection {
     ///
     /// - Parameters:
     ///   - numberOfClusters: Number of clusters (default `sqrt(n/2)`).
-    ///   - mutate: If true, modifies the receiver in place (default false).
     /// - Returns: A FeatureCollection with `cluster` (Int) and `centroid`
     ///   ([Double]) properties on each point.
     public func kmeansClusters(
-        numberOfClusters: Int? = nil,
+        numberOfClusters: Int? = nil
     ) -> FeatureCollection {
         var features = self.features
         let count = features.count

--- a/Sources/GISTools/Algorithms/Clusters.swift
+++ b/Sources/GISTools/Algorithms/Clusters.swift
@@ -12,9 +12,8 @@ extension FeatureCollection {
 
     /// Clusters points using the DBSCAN algorithm.
     ///
-    /// - Parameters:
-    ///   - maxDistance: Maximum distance between points in a cluster (meters).
-    ///   - minPoints: Minimum points to form a cluster (default 3).
+    /// - Parameter maxDistance: Maximum distance between points in a cluster (meters).
+    /// - Parameter minPoints: Minimum points to form a cluster (default 3).
     /// - Returns: A FeatureCollection with `cluster` (Int) and `dbscan`
     ///   ("core"|"edge"|"noise") properties on each point.
     public func dbscanClusters(
@@ -80,8 +79,7 @@ extension FeatureCollection {
 
     /// Clusters points using the K-means algorithm.
     ///
-    /// - Parameters:
-    ///   - numberOfClusters: Number of clusters (default `sqrt(n/2)`).
+    /// - Parameter numberOfClusters: Number of clusters (default `sqrt(n/2)`).
     /// - Returns: A FeatureCollection with `cluster` (Int) and `centroid`
     ///   ([Double]) properties on each point.
     public func kmeansClusters(

--- a/Sources/GISTools/Algorithms/Conversions.swift
+++ b/Sources/GISTools/Algorithms/Conversions.swift
@@ -129,6 +129,8 @@ extension GISTool {
     /// GISTool.convertToMeters(5, .kilometers) // 5000.0
     /// GISTool.convertToMeters(1, .miles)      // 1609.344
     /// ```
+    /// - Returns: The value converted to meters.
+    ///
     /// - note: Mainly for tests.
     public static func convertToMeters(
         _ value: Double,
@@ -154,6 +156,14 @@ extension GISTool {
 
 extension GISTool {
 
+    /// Converts pixel coordinates to a coordinate at the given zoom level.
+    ///
+    /// - Parameter pixelX: The x pixel coordinate.
+    /// - Parameter pixelY: The y pixel coordinate.
+    /// - Parameter zoom: The zoom level.
+    /// - Parameter tileSideLength: The tile side length in pixels.
+    /// - Parameter projection: The projection to use.
+    /// - Returns: The coordinate for the pixel position.
     @available(*, deprecated, renamed: "coordinate(fromPixelX:pixelY:zoom:tileSideLength:projection:)")
     public static func convertToCoordinate(
         fromPixelX pixelX: Double,
@@ -170,6 +180,8 @@ extension GISTool {
     }
 
     /// Converts pixel coordinates in a given zoom level to a coordinate.
+    ///
+    /// - Returns: The coordinate for the pixel position.
     public static func coordinate(
         fromPixelX pixelX: Double,
         pixelY: Double,
@@ -191,6 +203,8 @@ extension GISTool {
     }
 
     /// Resolution (meters/pixel) for a given zoom level (measured at `latitude`, defaults to the equator).
+    ///
+    /// - Returns: The resolution in meters per pixel.
     public static func metersPerPixel(
         atZoom zoom: Int,
         latitude: CLLocationDegrees = 0.0, // equator
@@ -205,6 +219,11 @@ extension GISTool {
 
 extension GISTool {
 
+    /// Converts a distance in meters to degrees at a given latitude.
+    ///
+    /// - Parameter meters: The distance in meters.
+    /// - Parameter latitude: The latitude at which to calculate the conversion.
+    /// - Returns: A tuple of latitude degrees and longitude degrees.
     @available(*, deprecated, renamed: "degrees(fromMeters:atLatitude:)")
     public static func convertToDegrees(
         fromMeters meters: Double,
@@ -215,9 +234,8 @@ extension GISTool {
 
     /// Converts a distance in meters to degrees at a given latitude.
     ///
-    /// - Parameters:
-    ///    - meters: The distance in meters
-    ///    - latitude: The latitude at which to calculate the conversion
+    /// - Parameter meters: The distance in meters
+    /// - Parameter latitude: The latitude at which to calculate the conversion
     ///
     /// - Returns: A tuple of latitude degrees and longitude degrees.
     public static func degrees(

--- a/Sources/GISTools/Algorithms/Conversions.swift
+++ b/Sources/GISTools/Algorithms/Conversions.swift
@@ -38,7 +38,7 @@ extension GISTool {
         /// Millimetres.
         case millimetres
         /// Nautical miles.
-        case nauticalmiles
+        case nauticalMiles
         /// Radians.
         case radians
         /// Yards.
@@ -56,7 +56,7 @@ extension GISTool {
         case .meters, .metres: return earthRadius
         case .miles: return earthRadius / 1609.344
         case .millimeters, .millimetres: return earthRadius * 1000.0
-        case .nauticalmiles: return earthRadius / 1852.0
+        case .nauticalMiles: return earthRadius / 1852.0
         case .radians: return 1.0
         case .yards: return earthRadius / (1.0 / 1.0936)
         default: return nil
@@ -74,7 +74,7 @@ extension GISTool {
         case .meters, .metres: return 1.0
         case .miles: return 1.0 / 1609.344
         case .millimeters, .millimetres: return 1000.0
-        case .nauticalmiles: return 1.0 / 1852.0
+        case .nauticalMiles: return 1.0 / 1852.0
         case .radians: return 1.0 / earthRadius
         case .yards: return 1.0 / 1.0936
         default: return nil
@@ -98,7 +98,7 @@ extension GISTool {
     }
 
     /// Converts a length to the requested unit.
-    /// Valid units: miles, nauticalmiles, inches, yards, meters, metres, kilometers, centimeters, feet
+    /// Valid units: miles, nauticalMiles, inches, yards, meters, metres, kilometers, centimeters, feet
     public static func convert(
         length: Double,
         from originalUnit: Unit,
@@ -143,7 +143,7 @@ extension GISTool {
         case .feet: return value / 3.28084
         case .yards: return value / 1.0936
         case .miles: return value * 1609.344
-        case .nauticalmiles: return value * 1852.0
+        case .nauticalMiles: return value * 1852.0
         default: return value
         }
     }

--- a/Sources/GISTools/Algorithms/Destination.swift
+++ b/Sources/GISTools/Algorithms/Destination.swift
@@ -11,9 +11,10 @@ extension Coordinate3D {
     /// distance in meters and a bearing in degrees.
     /// This uses the Haversine formula to account for global curvature.
     ///
-    /// - Parameters:
-    ///    - distance: The distance from the receiver, in meters
-    ///    - bearing: The direction, ranging from -180 to 180
+    /// - Parameter distance: The distance from the receiver, in meters
+    /// - Parameter bearing: The direction, ranging from -180 to 180
+    ///
+    /// - Returns: The destination coordinate.
     public func destination(
         distance: CLLocationDistance,
         bearing: CLLocationDegrees
@@ -67,9 +68,10 @@ extension Coordinate3D {
     /// Calculates the location of a coordinate on a straight line between
     /// this and another coordinate given a distance in meters.
     ///
-    /// - Parameters:
-    ///    - target: The other coordinate
-    ///    - distance: The distance from the receiver, in meters
+    /// - Parameter target: The other coordinate
+    /// - Parameter distance: The distance from the receiver, in meters
+    ///
+    /// - Returns: The coordinate at the given distance along the line to the target.
     public func coordinate(
         inDirectionOf target: Coordinate3D,
         distance: CLLocationDistance
@@ -85,9 +87,10 @@ extension Point {
     /// in meters and a bearing in degrees.
     /// This uses the Haversine formula to account for global curvature.
     ///
-    /// - Parameters:
-    ///    - distance: The distance from the receiver, in meters
-    ///    - bearing: The direction, ranging from -180 to 180
+    /// - Parameter distance: The distance from the receiver, in meters
+    /// - Parameter bearing: The direction, ranging from -180 to 180
+    ///
+    /// - Returns: The destination point.
     public func destination(
         distance: CLLocationDistance,
         bearing: CLLocationDegrees
@@ -98,9 +101,10 @@ extension Point {
     /// Calculates the location of a point on a straight line between
     /// this and another point given a distance in meters.
     ///
-    /// - Parameters:
-    ///    - target: The other point
-    ///    - distance: The distance from the receiver, in meters
+    /// - Parameter target: The other point
+    /// - Parameter distance: The distance from the receiver, in meters
+    ///
+    /// - Returns: The point at the given distance along the line to the target.
     public func point(
         inDirectionOf target: Point,
         distance: CLLocationDistance

--- a/Sources/GISTools/Algorithms/Dissolve.swift
+++ b/Sources/GISTools/Algorithms/Dissolve.swift
@@ -15,9 +15,10 @@ extension FeatureCollection {
     /// The property value can be any standard JSON type (`String`, `Int`, `Double`,
     /// `Bool`, etc.) or any `Hashable & Sendable` type.
     ///
-    /// - Parameters:
-    ///    - property: The property name by which features should be grouped
-    ///    - removeUnknown: Whether to remove features without the property from the result
+    /// - Parameter property: The property name by which features should be grouped
+    /// - Parameter removeUnknown: Whether to remove features without the property from the result
+    ///
+    /// - Returns: A dissolved FeatureCollection.
     public func dissolved(
         by property: String,
         removeUnknown: Bool = false

--- a/Sources/GISTools/Algorithms/Dissolve.swift
+++ b/Sources/GISTools/Algorithms/Dissolve.swift
@@ -5,41 +5,87 @@ import Foundation
 
 extension FeatureCollection {
 
-    private static let unknownValuePlaceholder: String = UUID().uuidString
+    /// A sentinel key used internally to group features without a matching property value.
+    private struct DissolveUnknown: Hashable, Sendable {}
 
-    /// Creates a new FeatureCollection where all (Multi)Polygon features with the same property value
-    /// are union'ed together. Features that are not (Multi)Polygon are removed from the result.
+    /// Creates a new FeatureCollection where all (Multi)Polygon features with the same
+    /// property value are union'ed together. Features that are not (Multi)Polygon are
+    /// removed from the result.
     ///
-    /// This currently works only for properties with a String value.
+    /// The property value can be any standard JSON type (`String`, `Int`, `Double`,
+    /// `Bool`, etc.) or any `Hashable & Sendable` type.
     ///
     /// - Parameters:
-    ///    - property: The `property` name with which the Features should be divided
+    ///    - property: The property name by which features should be grouped
     ///    - removeUnknown: Whether to remove features without the property from the result
     public func dissolved(
         by property: String,
         removeUnknown: Bool = false
     ) -> FeatureCollection {
-        let dividedFeatures = divideFeatures { feature in
-            guard feature.type.isIn([.polygon, .multiPolygon]) else { return nil }
+        let unknownSentinel = AnyHashable(DissolveUnknown())
 
-            let value: String? = feature.property(for: property)
-            if value == nil, removeUnknown {
+        let dividedFeatures: [AnyHashable: [Feature]] = divideFeatures { feature in
+            guard feature.geometry.type.isIn([.polygon, .multiPolygon]) else { return nil }
+
+            if let value = feature.properties[property],
+               let hashable = Self.hashableValue(from: value)
+            {
+                return hashable
+            }
+            if removeUnknown {
                 return nil
             }
-            return value ?? Self.unknownValuePlaceholder // Improve this
+            return unknownSentinel
         }
 
         var result: [Feature] = []
         for (key, features) in dividedFeatures {
-            let polygons: [Polygon] = features.compactMap({ $0.geometry as? PolygonGeometry }).flatMap({ $0.polygons })
+            let polygons: [Polygon] = features
+                .compactMap({ $0.geometry as? PolygonGeometry })
+                .flatMap({ $0.polygons })
             guard let union = Union.unionPolygons(polygons) else { continue }
-            let properties: [String: Sendable] = key == Self.unknownValuePlaceholder
-                ? [:]
-                : [property: key]
+
+            let properties: [String: Sendable]
+            if key == unknownSentinel {
+                properties = [:]
+            }
+            else if let propertyValue = features.first?.properties[property] {
+                properties = [property: propertyValue]
+            }
+            else {
+                properties = [:]
+            }
             result.append(Feature(union, properties: properties))
         }
 
         return FeatureCollection(result)
+    }
+
+    // MARK: - Private
+
+    /// Attempt to wrap a `Sendable` property value into an `AnyHashable` key.
+    ///
+    /// Covers the standard JSON value types: `String`, `Int`, `Double`, `Bool`,
+    /// `Float`, and their fixed-width variants.
+    private static func hashableValue(from value: Sendable) -> AnyHashable? {
+        switch value {
+        case let v as String:   return AnyHashable(v)
+        case let v as Int:      return AnyHashable(v)
+        case let v as Int8:     return AnyHashable(v)
+        case let v as Int16:    return AnyHashable(v)
+        case let v as Int32:    return AnyHashable(v)
+        case let v as Int64:    return AnyHashable(v)
+        case let v as UInt:     return AnyHashable(v)
+        case let v as UInt8:    return AnyHashable(v)
+        case let v as UInt16:   return AnyHashable(v)
+        case let v as UInt32:   return AnyHashable(v)
+        case let v as UInt64:   return AnyHashable(v)
+        case let v as Float:    return AnyHashable(v)
+        case let v as Double:   return AnyHashable(v)
+        case let v as Bool:     return AnyHashable(v)
+        case let v as AnyHashable: return v
+        default: return nil
+        }
     }
 
 }

--- a/Sources/GISTools/Algorithms/Distance.swift
+++ b/Sources/GISTools/Algorithms/Distance.swift
@@ -32,8 +32,9 @@ extension Coordinate3D {
             let dy = latitude - other.latitude
             return sqrt(dx * dx + dy * dy)
         case .noSRID:
-            // TODO
-            return Double.infinity
+            let dx = longitude - other.longitude
+            let dy = latitude - other.latitude
+            return sqrt(dx * dx + dy * dy)
         }
     }
 

--- a/Sources/GISTools/Algorithms/Distance.swift
+++ b/Sources/GISTools/Algorithms/Distance.swift
@@ -11,6 +11,8 @@ extension Coordinate3D {
     /// This uses the Haversine formula to account for global curvature.
     ///
     /// - Parameter other: The other coordinate
+    ///
+    /// - Returns: The distance in meters.
     public func distance(from other: Coordinate3D) -> CLLocationDistance {
         distance(to: other)
     }
@@ -19,6 +21,8 @@ extension Coordinate3D {
     /// This uses the Haversine formula to account for global curvature.
     ///
     /// - Parameter other: The other coordinate
+    ///
+    /// - Returns: The distance in meters.
     public func distance(to other: Coordinate3D) -> CLLocationDistance {
         switch projection {
         case .epsg4326:
@@ -53,6 +57,8 @@ extension Point {
     /// This uses the Haversine formula to account for global curvature.
     ///
     /// - Parameter other: The other point
+    ///
+    /// - Returns: The distance in meters.
     public func distance(from other: Point) -> CLLocationDistance {
         distance(to: other)
     }
@@ -61,6 +67,8 @@ extension Point {
     /// This uses the Haversine formula to account for global curvature.
     ///
     /// - Parameter other: The other point
+    ///
+    /// - Returns: The distance in meters.
     public func distance(to other: Point) -> CLLocationDistance {
         coordinate.distance(to: other.coordinate)
     }

--- a/Sources/GISTools/Algorithms/Distance.swift
+++ b/Sources/GISTools/Algorithms/Distance.swift
@@ -24,8 +24,9 @@ extension Coordinate3D {
         case .epsg4326:
             return _distance(from: other.projected(to: .epsg4326))
         case .epsg3857:
-            // TODO: This can be improved
-            return projected(to: .epsg4326)._distance(from: other.projected(to: .epsg4326))
+            let dx = longitude - other.longitude
+            let dy = latitude - other.latitude
+            return sqrt(dx * dx + dy * dy)
         case .noSRID:
             // TODO
             return Double.infinity

--- a/Sources/GISTools/Algorithms/EnumerateCoordinates.swift
+++ b/Sources/GISTools/Algorithms/EnumerateCoordinates.swift
@@ -5,7 +5,7 @@ import Foundation
 
 extension FeatureCollection {
 
-    /// Enumerate all coordinates in the FeatureCollection with feature and location index..
+    /// Enumerate all coordinates in the FeatureCollection with feature and location index.
     ///
     /// - Parameter callback: The callback function
     public func enumerateCoordinates(
@@ -22,7 +22,7 @@ extension FeatureCollection {
 
 extension Feature {
 
-    /// Enumerate all coordinates in the Feature with  location index..
+    /// Enumerate all coordinates in the Feature with a location index.
     ///
     /// - Parameter callback: The callback function
     public func enumerateCoordinates(
@@ -37,7 +37,7 @@ extension Feature {
 
 extension GeometryCollection {
 
-    /// Enumerate all coordinates in the GeometryCollection with geometry and location index..
+    /// Enumerate all coordinates in the GeometryCollection with geometry and location index.
     ///
     /// - Parameter callback: The callback function
     public func enumerateCoordinates(
@@ -54,7 +54,7 @@ extension GeometryCollection {
 
 extension GeoJsonGeometry {
 
-    /// Enumerate all coordinates in the Geometry with  location index..
+    /// Enumerate all coordinates in the Geometry with a location index.
     ///
     /// - Parameter callback: The callback function
     public func enumerateCoordinates(

--- a/Sources/GISTools/Algorithms/FrechetDistance.swift
+++ b/Sources/GISTools/Algorithms/FrechetDistance.swift
@@ -31,8 +31,8 @@ public enum FrechetDistanceFunction {
             first.distance(from: second)
         case .rhumbLine:
             first.rhumbDistance(from: second)
-        case let .other(distanceFuntion):
-            distanceFuntion(first, second)
+        case let .other(distanceFunction):
+            distanceFunction(first, second)
         }
     }
 
@@ -40,14 +40,14 @@ public enum FrechetDistanceFunction {
 
 extension LineString {
 
-    /// Fréchet  distance between to geometries.
+    /// Fréchet distance between two geometries.
     ///
     /// - Parameters:
     ///    - other: The other geometry of equal type.
     ///    - distanceFunction: The algorithm to use for distance calculations.
     ///    - segmentLength: This value adds intermediate points to the geometry for improved matching, in meters.
     ///
-    /// - Returns: The frechet distance between the two geometries.
+    /// - Returns: The Fréchet distance between the two geometries.
     public func frechetDistance(
         from other: LineString,
         distanceFunction: FrechetDistanceFunction = .haversine,
@@ -67,7 +67,7 @@ extension LineString {
         var ca: [Double] = Array(repeating: -1.0, count: p.count * q.count)
 
         func index(_ pI: Int, _ qI: Int) -> Int {
-            (pI * p.count) + qI
+            (pI * q.count) + qI
         }
 
         for i in 0 ..< p.count {

--- a/Sources/GISTools/Algorithms/FrechetDistance.swift
+++ b/Sources/GISTools/Algorithms/FrechetDistance.swift
@@ -17,9 +17,10 @@ public enum FrechetDistanceFunction {
 
     /// Calculates the distance between two coordinates using the selected method.
     ///
-    /// - Parameters:
-    ///    - first: The first coordinate
-    ///    - second: The second coordinate
+    /// - Parameter first: The first coordinate
+    /// - Parameter second: The second coordinate
+    ///
+    /// - Returns: The distance between the two coordinates.
     public func distance(
         between first: Coordinate3D,
         and second: Coordinate3D
@@ -42,10 +43,9 @@ extension LineString {
 
     /// Fréchet distance between two geometries.
     ///
-    /// - Parameters:
-    ///    - other: The other geometry of equal type.
-    ///    - distanceFunction: The algorithm to use for distance calculations.
-    ///    - segmentLength: This value adds intermediate points to the geometry for improved matching, in meters.
+    /// - Parameter other: The other geometry of equal type.
+    /// - Parameter distanceFunction: The algorithm to use for distance calculations.
+    /// - Parameter segmentLength: This value adds intermediate points to the geometry for improved matching, in meters.
     ///
     /// - Returns: The Fréchet distance between the two geometries.
     public func frechetDistance(

--- a/Sources/GISTools/Algorithms/GreatCircle.swift
+++ b/Sources/GISTools/Algorithms/GreatCircle.swift
@@ -12,10 +12,9 @@ extension Coordinate3D {
     /// If the start and end are identical a single-point ``LineString``
     /// of length `npoints` is returned.
     ///
-    /// - Parameters:
-    ///   - end: End coordinate.
-    ///   - npoints: Number of points along the arc (default 100).
-    ///   - offset: Controls anti-meridian split threshold (default 10).
+    /// - Parameter end: End coordinate.
+    /// - Parameter npoints: Number of points along the arc (default 100).
+    /// - Parameter offset: Controls anti-meridian split threshold (default 10).
     /// - Returns: A ``LineString`` or ``MultiLineString`` representing the arc.
     public func greatCircle(
         to end: Coordinate3D,

--- a/Sources/GISTools/Algorithms/LineArc.swift
+++ b/Sources/GISTools/Algorithms/LineArc.swift
@@ -11,11 +11,10 @@ extension Point {
     /// between bearing1 and bearing2.
     /// 0 bearing is North of center point, positive clockwise.
     ///
-    /// - Parameters:
-    ///    - radius: The radius of the circle forming the arc, in meters
-    ///    - bearing1: The angle of the first radius of the arc, in decimal degrees
-    ///    - bearing2: The angle of the second radius of the arc, in decimal degrees
-    ///    - steps: The number of steps (default 64)
+    /// - Parameter radius: The radius of the circle forming the arc, in meters
+    /// - Parameter bearing1: The angle of the first radius of the arc, in decimal degrees
+    /// - Parameter bearing2: The angle of the second radius of the arc, in decimal degrees
+    /// - Parameter steps: The number of steps (default 64)
     ///
     /// - Returns: A `LineString` representing the arc, or `nil` if `radius ≤ 0` or `steps ≤ 1`.
     public func lineArc(
@@ -26,8 +25,8 @@ extension Point {
     ) -> LineString? {
         guard radius > 0.0, steps > 1 else { return nil }
 
-        let angle1 = Point.normalizeAngle(alfa: bearing1)
-        let angle2 = Point.normalizeAngle(alfa: bearing2)
+        let angle1 = Point.normalizeAngle(alpha: bearing1)
+        let angle2 = Point.normalizeAngle(alpha: bearing2)
 
         if angle1 == angle2 {
             guard let polygon = circle(radius: radius, steps: steps),
@@ -42,16 +41,15 @@ extension Point {
             : angle2 + 360.0)
 
         let center = self.coordinate
+        let delta = 360.0 / Double(steps)
         var coordinates: [Coordinate3D] = []
-        var index: Int = 0
 
-        var alfa = arcStartDegree
-        while alfa < arcEndDegree {
-            coordinates.append(center.destination(distance: radius, bearing: alfa))
-            index += 1
-            alfa = arcStartDegree + Double(index) * 360.0 / Double(steps)
+        var bearing = arcStartDegree
+        while bearing < arcEndDegree {
+            coordinates.append(center.destination(distance: radius, bearing: bearing))
+            bearing += delta
         }
-        if (alfa > arcEndDegree) {
+        if bearing > arcEndDegree {
             coordinates.append(center.destination(distance: radius, bearing: arcEndDegree))
         }
 
@@ -59,8 +57,8 @@ extension Point {
     }
 
     /// Normalizes an angle to the range 0..<360 degrees.
-    private static func normalizeAngle(alfa: CLLocationDegrees) -> CLLocationDegrees {
-        var beta = alfa.remainder(dividingBy: 360.0)
+    private static func normalizeAngle(alpha: CLLocationDegrees) -> CLLocationDegrees {
+        var beta = alpha.remainder(dividingBy: 360.0)
         if beta < 0.0 {
             beta += 360.0
         }

--- a/Sources/GISTools/Algorithms/LineArc.swift
+++ b/Sources/GISTools/Algorithms/LineArc.swift
@@ -16,6 +16,8 @@ extension Point {
     ///    - bearing1: The angle of the first radius of the arc, in decimal degrees
     ///    - bearing2: The angle of the second radius of the arc, in decimal degrees
     ///    - steps: The number of steps (default 64)
+    ///
+    /// - Returns: A `LineString` representing the arc, or `nil` if `radius ≤ 0` or `steps ≤ 1`.
     public func lineArc(
         radius: CLLocationDistance,
         bearing1: CLLocationDegrees,

--- a/Sources/GISTools/Algorithms/LineChunk.swift
+++ b/Sources/GISTools/Algorithms/LineChunk.swift
@@ -10,12 +10,10 @@ extension LineString {
     /// Divides a *LineString* into chunks of a specified length.
     /// If the line is shorter than the segment length then the original line is returned.
     ///
-    /// - Note: Repeated multiplication (`segmentLength * Double(index)`) accumulates floating-point
-    ///   error over many chunks, which can produce slightly uneven segment lengths.
+    /// - Parameter segmentLength: How long to make each segment, in meters
+    /// - Parameter dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
     ///
-    /// - Parameters:
-    ///     - segmentLength: How long to make each segment, in meters
-    ///     - dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    /// - Returns: The chunked line segments.
     public func chunked(
         segmentLength: CLLocationDistance,
         dropIntermediateCoordinates: Bool = false
@@ -32,8 +30,10 @@ extension LineString {
         }
 
         let numberOfSegments = Int(ceil(lineLength / segmentLength))
-        for index in 0 ..< numberOfSegments {
-            guard let chunk = sliceAlong(startDistance: segmentLength * Double(index), stopDistance: segmentLength * Double(index + 1)) else { break }
+        var startDistance: CLLocationDistance = 0.0
+        for _ in 0 ..< numberOfSegments {
+            let stopDistance = startDistance + segmentLength
+            guard let chunk = sliceAlong(startDistance: startDistance, stopDistance: stopDistance) else { break }
 
             if dropIntermediateCoordinates,
                let newChunk = LineString([chunk.firstCoordinate, chunk.lastCoordinate].compactMap({ $0 }))
@@ -43,6 +43,8 @@ extension LineString {
             else {
                 lineStrings.append(chunk)
             }
+
+            startDistance = stopDistance
         }
 
         return MultiLineString(lineStrings) ?? MultiLineString()
@@ -51,9 +53,10 @@ extension LineString {
     /// Divides a *LineString* into evenly spaced segments of a specified length.
     /// If the line is shorter than the segment length then the original line is returned.
     ///
-    /// - Parameters:
-    ///     - segmentLength: How long to make each segment, in meters
-    ///     - dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    /// - Parameter segmentLength: How long to make each segment, in meters
+    /// - Parameter dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    ///
+    /// - Returns: An evenly divided line string.
     public func evenlyDivided(
         segmentLength: CLLocationDistance,
         dropIntermediateCoordinates: Bool = false
@@ -72,9 +75,10 @@ extension MultiLineString {
     /// Divides a *MultiLineString* into chunks of a specified length.
     /// If any line is shorter than the segment length then the original line is returned.
     ///
-    /// - Parameters:
-    ///     - segmentLength: How long to make each segment, in meters
-    ///     - dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    /// - Parameter segmentLength: How long to make each segment, in meters
+    /// - Parameter dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    ///
+    /// - Returns: The chunked multi-line segments.
     public func chunked(
         segmentLength: CLLocationDistance,
         dropIntermediateCoordinates: Bool = false
@@ -87,9 +91,10 @@ extension MultiLineString {
     /// Divides a *MultiLineString* into evenly spaced segments of a specified length.
     /// If the line is shorter than the segment length then the original line is returned.
     ///
-    /// - Parameters:
-    ///     - segmentLength: How long to make each segment, in meters
-    ///     - dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    /// - Parameter segmentLength: How long to make each segment, in meters
+    /// - Parameter dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    ///
+    /// - Returns: An evenly divided multi-line string.
     public func evenlyDivided(
         segmentLength: CLLocationDistance,
         dropIntermediateCoordinates: Bool = false
@@ -107,9 +112,10 @@ extension Feature {
     /// into a *FeatureCollection* of chunks of a specified length.
     /// If any line is shorter than the segment length then the original line is returned.
     ///
-    /// - Parameters:
-    ///     - segmentLength: How long to make each segment, in meters
-    ///     - dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    /// - Parameter segmentLength: How long to make each segment, in meters
+    /// - Parameter dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    ///
+    /// - Returns: A FeatureCollection of chunked line segments.
     public func chunked(
         segmentLength: CLLocationDistance,
         dropIntermediateCoordinates: Bool = false
@@ -136,9 +142,10 @@ extension FeatureCollection {
 
     /// Returns a *FeatureCollection* containing a *LineString* or *MultiLineString* chunked into smaller parts.
     ///
-    /// - Parameters:
-    ///     - segmentLength: How long to make each segment, in meters
-    ///     - dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    /// - Parameter segmentLength: How long to make each segment, in meters
+    /// - Parameter dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates
+    ///
+    /// - Returns: A FeatureCollection of chunked line segments.
     public func chunked(
         segmentLength: CLLocationDistance,
         dropIntermediateCoordinates: Bool = false

--- a/Sources/GISTools/Algorithms/LineChunk.swift
+++ b/Sources/GISTools/Algorithms/LineChunk.swift
@@ -10,6 +10,9 @@ extension LineString {
     /// Divides a *LineString* into chunks of a specified length.
     /// If the line is shorter than the segment length then the original line is returned.
     ///
+    /// - Note: Repeated multiplication (`segmentLength * Double(index)`) accumulates floating-point
+    ///   error over many chunks, which can produce slightly uneven segment lengths.
+    ///
     /// - Parameters:
     ///     - segmentLength: How long to make each segment, in meters
     ///     - dropIntermediateCoordinates: Simplify the result so that each chunk has exactly two coordinates

--- a/Sources/GISTools/Algorithms/LineIntersect.swift
+++ b/Sources/GISTools/Algorithms/LineIntersect.swift
@@ -148,7 +148,7 @@ extension GeoJson {
 
     /// Returns the intersecting point(s) with the receiver.
     ///
-    /// - note: Takes all poygon rings into account,  not just the outer ring.
+    /// - note: Takes all polygon rings into account, not just the outer ring.
     ///
     /// - Parameters:
     ///   - other: The other geometry

--- a/Sources/GISTools/Algorithms/LineIntersect.swift
+++ b/Sources/GISTools/Algorithms/LineIntersect.swift
@@ -57,9 +57,11 @@ extension LineSegment {
     /// Checks if two line segments intersect.
     ///
     /// - Parameters:
-    ///   - other: The other *LineSegment*
-    ///   - epsilon: Tolerance for collinearity and on-segment checks
+    /// - Parameter other: The other *LineSegment*
+    /// - Parameter epsilon: Tolerance for collinearity and on-segment checks
     ///     (in the coordinate system's native units, e.g. degrees for EPSG:4326)
+    ///
+    /// - Returns: `true` if the line segments intersect.
     public func intersects(_ other: LineSegment, epsilon: Double = 0.0) -> Bool {
         let other = other.projected(to: projection)
 
@@ -105,9 +107,11 @@ extension LineSegment {
     /// collinear segments produce a line segment, not a single point).
     ///
     /// - Parameters:
-    ///   - other: The other *LineSegment*
-    ///   - epsilon: Tolerance for endpoint parameter checks
+    /// - Parameter other: The other *LineSegment*
+    /// - Parameter epsilon: Tolerance for endpoint parameter checks
     ///     (in the coordinate system's native units, e.g. degrees for EPSG:4326)
+    ///
+    /// - Returns: The intersection point, or `nil`.
     public func intersection(
         _ other: LineSegment,
         epsilon: Double = 0.0
@@ -151,9 +155,11 @@ extension GeoJson {
     /// - note: Takes all polygon rings into account, not just the outer ring.
     ///
     /// - Parameters:
-    ///   - other: The other geometry
-    ///   - epsilon: Tolerance passed through to ``LineSegment/intersection(_:epsilon:)``
+    /// - Parameter other: The other geometry
+    /// - Parameter epsilon: Tolerance passed through to ``LineSegment/intersection(_:epsilon:)``
     ///     (in the coordinate system's native units, e.g. degrees for EPSG:4326)
+    ///
+    /// - Returns: An array of intersecting points.
     public func intersections(with other: GeoJson, epsilon: Double = 0.0) -> [Point] {
         let other = other.projected(to: projection)
 

--- a/Sources/GISTools/Algorithms/LineIntersect.swift
+++ b/Sources/GISTools/Algorithms/LineIntersect.swift
@@ -154,7 +154,7 @@ extension GeoJson {
     ///   - other: The other geometry
     ///   - epsilon: Tolerance passed through to ``LineSegment/intersection(_:epsilon:)``
     ///     (in the coordinate system's native units, e.g. degrees for EPSG:4326)
-    public func intersections(other: GeoJson, epsilon: Double = 0.0) -> [Point] {
+    public func intersections(with other: GeoJson, epsilon: Double = 0.0) -> [Point] {
         let other = other.projected(to: projection)
 
         if let otherBoundingBox = other.boundingBox ?? other.calculateBoundingBox(),

--- a/Sources/GISTools/Algorithms/LineOverlap.swift
+++ b/Sources/GISTools/Algorithms/LineOverlap.swift
@@ -25,7 +25,7 @@ extension LineSegment {
     ///    - other: The other *LineSegment*
     ///    - tolerance: The tolerance, in meters
     public func compare(
-        other: LineSegment,
+        _ other: LineSegment,
         tolerance: CLLocationDistance = 0.0
     ) -> LineSegmentComparisonResult {
         let other = other.projected(to: projection)
@@ -84,7 +84,7 @@ extension GeoJson {
             guard let boundingBox = segment.boundingBox ?? segment.calculateBoundingBox() else { continue }
 
             for match in tree.search(inBoundingBox: boundingBox) {
-                let comparison = segment.compare(other: match, tolerance: tolerance)
+                let comparison = segment.compare(match, tolerance: tolerance)
 
                 if comparison == .equal {
                     result.append(segment)

--- a/Sources/GISTools/Algorithms/LineOverlap.swift
+++ b/Sources/GISTools/Algorithms/LineOverlap.swift
@@ -22,8 +22,10 @@ extension LineSegment {
     /// Checks how the receiver and the other *LineSegment* lie in relation to each other.
     ///
     /// - Parameters:
-    ///    - other: The other *LineSegment*
-    ///    - tolerance: The tolerance, in meters
+    /// - Parameter other: The other *LineSegment*
+    /// - Parameter tolerance: The tolerance, in meters
+    ///
+    /// - Returns: A ``LineSegmentComparisonResult`` indicating how the segments relate.
     public func compare(
         _ other: LineSegment,
         tolerance: CLLocationDistance = 0.0
@@ -67,8 +69,10 @@ extension GeoJson {
     /// Returns the overlapping segments between the receiver and the other geometry.
     ///
     /// - Parameters:
-    ///    - other: The other geometry
-    ///    - tolerance: The tolerance, in meters
+    /// - Parameter other: The other geometry
+    /// - Parameter tolerance: The tolerance, in meters
+    ///
+    /// - Returns: An array of overlapping line segments.
     public func overlappingSegments(
         with other: GeoJson,
         tolerance: CLLocationDistance = 0.0
@@ -109,9 +113,8 @@ extension GeoJson {
     ///
     /// - Note: Altitude values will be ignored.
     ///
-    /// - Parameters:
-    ///    - tolerance: The tolerance, in meters. Using `0.0` will only return segments that *exactly* overlap.
-    ///    - segmentLength: This value adds intermediate points to the geometry for improved matching, in meters. Choosing this too small might lead to memory explosion.
+    /// - Parameter tolerance: The tolerance, in meters. Using `0.0` will only return segments that *exactly* overlap.
+    /// - Parameter segmentLength: This value adds intermediate points to the geometry for improved matching, in meters. Choosing this too small might lead to memory explosion.
     ///
     /// - Returns: All segments that at least overlap with one other segment. Each segment will
     ///            appear in the result only once.
@@ -218,9 +221,8 @@ extension GeoJson {
 
     /// An estimate of how much the receiver overlaps with itself.
     ///
-    /// - Parameters:
-    ///    - tolerance: The tolerance, in meters. Using `0.0` will only count segments that *exactly* overlap.
-    ///    - segmentLength: This value adds intermediate points to the geometry for improved matching, in meters. Choosing this too small might lead to memory explosion.
+    /// - Parameter tolerance: The tolerance, in meters. Using `0.0` will only count segments that *exactly* overlap.
+    /// - Parameter segmentLength: This value adds intermediate points to the geometry for improved matching, in meters. Choosing this too small might lead to memory explosion.
     ///
     /// - Returns: The length of all segments that overlap within `tolerance`.
     public func estimatedOverlap(

--- a/Sources/GISTools/Algorithms/LineSlice.swift
+++ b/Sources/GISTools/Algorithms/LineSlice.swift
@@ -12,9 +12,8 @@ extension LineString {
     ///
     /// This can be useful for extracting only the part of a route between waypoints.
     ///
-    /// - Parameters:
-    ///    - start: The starting point (defaults to the first coordinate if `nil`)
-    ///    - end: The stopping point (defaults to the last coordinate if `nil`)
+    /// - Parameter start: The starting point (defaults to the first coordinate if `nil`)
+    /// - Parameter end: The stopping point (defaults to the last coordinate if `nil`)
     ///
     /// - Returns: A `LineString` subsection, or `nil` if the line has fewer than 2 coordinates.
     public func slice(
@@ -77,9 +76,10 @@ extension Feature {
     ///
     /// This can be useful for extracting only the part of a route between waypoints.
     ///
-    /// - Parameters:
-    ///    - start: The starting point
-    ///    - end: The stopping point
+    /// - Parameter start: The starting point
+    /// - Parameter end: The stopping point
+    ///
+    /// - Returns: A `Feature` subsection, or `nil`.
     public func slice(
         start: Coordinate3D? = nil,
         end: Coordinate3D? = nil

--- a/Sources/GISTools/Algorithms/LineSlice.swift
+++ b/Sources/GISTools/Algorithms/LineSlice.swift
@@ -13,8 +13,10 @@ extension LineString {
     /// This can be useful for extracting only the part of a route between waypoints.
     ///
     /// - Parameters:
-    ///    - start: The starting point
-    ///    - end: The stopping point
+    ///    - start: The starting point (defaults to the first coordinate if `nil`)
+    ///    - end: The stopping point (defaults to the last coordinate if `nil`)
+    ///
+    /// - Returns: A `LineString` subsection, or `nil` if the line has fewer than 2 coordinates.
     public func slice(
         start: Coordinate3D? = nil,
         end: Coordinate3D? = nil

--- a/Sources/GISTools/Algorithms/LineSliceAlong.swift
+++ b/Sources/GISTools/Algorithms/LineSliceAlong.swift
@@ -86,8 +86,8 @@ extension Feature {
     ///   - startDistance: The distance along the line to the starting point, in meters
     ///   - stopDistance: The distance along the line to the ending point, in meters
     public func sliceAlong(
-        startDistance: CLLocationDistance,
-        stopDistance: CLLocationDistance
+        startDistance: CLLocationDistance = 0.0,
+        stopDistance: CLLocationDistance = .greatestFiniteMagnitude
     ) -> Feature? {
         guard let lineString = geometry as? LineString,
               let lineSlice = lineString.sliceAlong(startDistance: startDistance, stopDistance: stopDistance)

--- a/Sources/GISTools/Algorithms/LineSliceAlong.swift
+++ b/Sources/GISTools/Algorithms/LineSliceAlong.swift
@@ -34,7 +34,7 @@ extension LineString {
             if travelled > startDistance, slice.isEmpty {
                 let overshot = startDistance - travelled
                 if overshot == 0.0 {
-                    slice.append(coordinate)
+                    slice.append(contentsOf: [coordinate, coordinate])
                     return LineString(slice)
                 }
 
@@ -47,6 +47,9 @@ extension LineString {
                 let overshot = stopDistance - travelled
                 if overshot == 0.0 {
                     slice.append(coordinate)
+                    if slice.count == 1 {
+                        slice.append(coordinate)
+                    }
                     return LineString(slice)
                 }
 
@@ -71,7 +74,8 @@ extension LineString {
             return nil
         }
 
-        return LineString([coordinates[coordinates.count - 1]])
+        let last = coordinates[coordinates.count - 1]
+        return LineString([last, last])
     }
 
 }

--- a/Sources/GISTools/Algorithms/LineSliceAlong.swift
+++ b/Sources/GISTools/Algorithms/LineSliceAlong.swift
@@ -12,9 +12,10 @@ extension LineString {
     ///
     /// This can be useful for extracting only the part of a route between two distances.
     ///
-    /// - Parameters:
-    ///   - startDistance: The distance along the line to the starting point, in meters
-    ///   - stopDistance: The distance along the line to the ending point, in meters
+    /// - Parameter startDistance: The distance along the line to the starting point, in meters
+    /// - Parameter stopDistance: The distance along the line to the ending point, in meters
+    ///
+    /// - Returns: A `LineString` subsection, or `nil`.
     public func sliceAlong(
         startDistance: CLLocationDistance = 0.0,
         stopDistance: CLLocationDistance = .greatestFiniteMagnitude
@@ -83,8 +84,10 @@ extension Feature {
     /// This can be useful for extracting only the part of a route between two distances.
     ///
     /// - Parameters:
-    ///   - startDistance: The distance along the line to the starting point, in meters
-    ///   - stopDistance: The distance along the line to the ending point, in meters
+    /// - Parameter startDistance: The distance along the line to the starting point, in meters
+    /// - Parameter stopDistance: The distance along the line to the ending point, in meters
+    ///
+    /// - Returns: A `Feature` subsection, or `nil`.
     public func sliceAlong(
         startDistance: CLLocationDistance = 0.0,
         stopDistance: CLLocationDistance = .greatestFiniteMagnitude

--- a/Sources/GISTools/Algorithms/MidPoint.swift
+++ b/Sources/GISTools/Algorithms/MidPoint.swift
@@ -11,6 +11,8 @@ extension Coordinate3D {
     /// The midpoint is calculated geodesically, meaning the curvature of the earth is taken into account.
     ///
     /// - Parameter other: The other coordinate
+    ///
+    /// - Returns: The midpoint coordinate.
     public func midpoint(to other: Coordinate3D) -> Coordinate3D {
         switch projection {
         case .epsg4326:
@@ -40,6 +42,8 @@ extension Point {
     /// The midpoint is calculated geodesically, meaning the curvature of the earth is taken into account.
     ///
     /// - Parameter other: The other point
+    ///
+    /// - Returns: The midpoint point.
     public func midpoint(to other: Point) -> Point {
         Point(self.coordinate.midpoint(to: other.coordinate))
     }

--- a/Sources/GISTools/Algorithms/NearestPoint.swift
+++ b/Sources/GISTools/Algorithms/NearestPoint.swift
@@ -11,6 +11,8 @@ extension BoundingBox {
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other coordinate
+    ///
+    /// - Returns: The nearest coordinate and distance, or `nil`.
     public func nearestCoordinate(
         from other: Coordinate3D
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance)? {
@@ -21,6 +23,8 @@ extension BoundingBox {
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other point
+    ///
+    /// - Returns: The nearest point and distance, or `nil`.
     public func nearestPoint(
         from other: Point
     ) -> (point: Point, distance: CLLocationDistance)? {
@@ -35,6 +39,8 @@ extension GeoJson {
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other coordinate
+    ///
+    /// - Returns: The nearest coordinate and distance, or `nil`.
     public func nearestCoordinate(
         from other: Coordinate3D
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance)? {
@@ -61,6 +67,8 @@ extension GeoJson {
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other point
+    ///
+    /// - Returns: The nearest point and distance, or `nil`.
     public func nearestPoint(
         from other: Point
     ) -> (point: Point, distance: CLLocationDistance)? {

--- a/Sources/GISTools/Algorithms/NearestPoint.swift
+++ b/Sources/GISTools/Algorithms/NearestPoint.swift
@@ -7,7 +7,7 @@ import Foundation
 
 extension BoundingBox {
 
-    /// Takes a reference coordinate and returns the coordinate from the reveiver closest to the reference.
+    /// Takes a reference coordinate and returns the coordinate from the receiver closest to the reference.
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other coordinate
@@ -17,7 +17,7 @@ extension BoundingBox {
         self.boundingBoxGeometry.nearestCoordinate(from: other)
     }
 
-    /// Takes a reference point and returns the point from the reveiver closest to the reference.
+    /// Takes a reference point and returns the point from the receiver closest to the reference.
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other point
@@ -31,7 +31,7 @@ extension BoundingBox {
 
 extension GeoJson {
 
-    /// Takes a reference coordinate and returns the coordinate from the reveiver closest to the reference.
+    /// Takes a reference coordinate and returns the coordinate from the receiver closest to the reference.
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other coordinate
@@ -40,13 +40,13 @@ extension GeoJson {
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance)? {
         let other = other.projected(to: projection)
 
-        let allCordinates = self.allCoordinates
-        guard !allCordinates.isEmpty else { return nil }
+        let allCoordinates = self.allCoordinates
+        guard !allCoordinates.isEmpty else { return nil }
 
-        var bestCoordinate: Coordinate3D = allCordinates[0]
+        var bestCoordinate: Coordinate3D = allCoordinates[0]
         var bestDistance: CLLocationDistance = bestCoordinate.distance(from: other)
 
-        for coordinate in allCordinates {
+        for coordinate in allCoordinates {
             let distance = coordinate.distance(from: other)
             if distance < bestDistance {
                 bestDistance = distance
@@ -57,7 +57,7 @@ extension GeoJson {
         return (coordinate: bestCoordinate, distance: bestDistance)
     }
 
-    /// Takes a reference point and returns the point from the reveiver closest to the reference.
+    /// Takes a reference point and returns the point from the receiver closest to the reference.
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other point

--- a/Sources/GISTools/Algorithms/NearestPointOnLine.swift
+++ b/Sources/GISTools/Algorithms/NearestPointOnLine.swift
@@ -9,7 +9,7 @@ extension LineSegment {
 
     /// Returns the foot of the perpendicular of the coordinate to the segment.
     public func perpendicularFoot(
-        coordinate: Coordinate3D,
+        from coordinate: Coordinate3D,
         clampToEnds: Bool = false
     ) -> Coordinate3D? {
         let coordinate = coordinate.projected(to: projection)
@@ -58,7 +58,7 @@ extension LineSegment {
     public func nearestCoordinateOnSegment(
         from other: Coordinate3D
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance) {
-        guard let foot: Coordinate3D = perpendicularFoot(coordinate: other, clampToEnds: true) else {
+        guard let foot: Coordinate3D = perpendicularFoot(from: other, clampToEnds: true) else {
             return (coordinate: first, distance: 0.0)
         }
         let footDistance: CLLocationDistance = other.distance(from: foot)
@@ -83,7 +83,7 @@ extension LineString {
         var bestIndex: Int = -1
 
         for (index, segment) in lineSegments.enumerated() {
-            guard let foot: Coordinate3D = segment.perpendicularFoot(coordinate: other, clampToEnds: true) else {
+            guard let foot: Coordinate3D = segment.perpendicularFoot(from: other, clampToEnds: true) else {
                 continue
             }
             let footDistance: CLLocationDistance = other.distance(from: foot)

--- a/Sources/GISTools/Algorithms/NearestPointOnLine.swift
+++ b/Sources/GISTools/Algorithms/NearestPointOnLine.swift
@@ -16,10 +16,10 @@ extension LineSegment {
 
         let squareLineDistance: Double = pow(first.latitude - second.latitude, 2) + pow(first.longitude - second.longitude, 2)
 
-        // avoid inaccuracy for too short distances, as the square line distance is taken as divisor
-        if squareLineDistance == 0.0
-            || first.distance(from: second) < 1.0
-        {
+        // Numerical stability: avoid division by a near-zero squared distance.
+        // Use the geodesic distance (always in meters) for a projection-independent
+        // threshold. Segments shorter than 1 m are degenerate for perpendicular projection.
+        if squareLineDistance <= 0.0 || first.distance(from: second) < 1.0 {
             return first
         }
 
@@ -92,11 +92,6 @@ extension LineString {
                 bestCoordinate = foot
                 bestDistance = footDistance
                 bestIndex = index
-            }
-
-            // TODO: Good enough? Might not be accurate enough for all use cases
-            if bestDistance < 1.0 {
-                break
             }
         }
 

--- a/Sources/GISTools/Algorithms/NearestPointToLine.swift
+++ b/Sources/GISTools/Algorithms/NearestPointToLine.swift
@@ -10,7 +10,7 @@ extension LineString {
     /// Returns the closest coordinate out of a collection of coordinates to a line.
     /// The returned coordinate has a distance property indicating its distance to the line.
     public func nearestCoordinate(
-        outOf coordinates: [Coordinate3D]
+        from coordinates: [Coordinate3D]
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance)? {
         guard !coordinates.isEmpty else { return nil }
 
@@ -32,9 +32,9 @@ extension LineString {
     /// Returns the closest point out of a collection of points to a line.
     /// The returned point has a distance property indicating its distance to the line.
     public func nearestPointAndDistance(
-        outOf points: [Point]
+        from points: [Point]
     ) -> (point: Point, distance: CLLocationDistance)? {
-        guard let bestCoordinateAndDistance = nearestCoordinate(outOf: points.map({ $0.coordinate })) else { return nil }
+        guard let bestCoordinateAndDistance = nearestCoordinate(from: points.map({ $0.coordinate })) else { return nil }
         return (point: Point(bestCoordinateAndDistance.coordinate), distance: bestCoordinateAndDistance.distance)
     }
 

--- a/Sources/GISTools/Algorithms/PointToLineDistance.swift
+++ b/Sources/GISTools/Algorithms/PointToLineDistance.swift
@@ -9,7 +9,7 @@ extension LineSegment {
 
     /// Returns the minimum distance between the coordinate and the segment.
     public func distanceFrom(coordinate: Coordinate3D) -> CLLocationDistance {
-        let foot = perpendicularFoot(coordinate: coordinate, clampToEnds: true) ?? first
+        let foot = perpendicularFoot(from: coordinate, clampToEnds: true) ?? first
         return foot.distance(from: coordinate)
     }
 

--- a/Sources/GISTools/Algorithms/Reverse.swift
+++ b/Sources/GISTools/Algorithms/Reverse.swift
@@ -21,7 +21,7 @@ extension GeoJson {
             return newMultiLineString as! Self
 
         case let geometryCollection as GeometryCollection:
-            var newGeometryCollection = GeometryCollection(geometryCollection.geometries.reversed().map({ $0.reversed }))
+            var newGeometryCollection = GeometryCollection(geometryCollection.geometries.map({ $0.reversed }))
             newGeometryCollection.boundingBox = geometryCollection.boundingBox
             newGeometryCollection.foreignMembers = geometryCollection.foreignMembers
             return newGeometryCollection as! Self

--- a/Sources/GISTools/Algorithms/Rewind.swift
+++ b/Sources/GISTools/Algorithms/Rewind.swift
@@ -15,6 +15,9 @@ extension GeoJson {
 
     /// Returns the receiver with the specified winding order.
     /// `Point` and `MultiPoint` will be returned as-is.
+    ///
+    /// - Parameter order: The winding order to apply.
+    /// - Returns: A new geometry with the given winding order.
     public func withWindingOrder(_ order: PolygonWindingOrder) -> Self {
         switch self {
         case let lineString as LineString:
@@ -94,6 +97,8 @@ extension GeoJson {
 
     /// Forces the receiver to be in the specified winding order.
     /// `Point` and `MultiPoint` will be returned as-is.
+    ///
+    /// - Parameter order: The winding order to enforce.
     public mutating func forceWindingOrder(_ order: PolygonWindingOrder) {
         self = withWindingOrder(order)
     }

--- a/Sources/GISTools/Algorithms/RhumbBearing.swift
+++ b/Sources/GISTools/Algorithms/RhumbBearing.swift
@@ -11,8 +11,10 @@ extension Coordinate3D {
     /// i.e. the angle measured in degrees from the north line (0 degrees).
     ///
     /// - Parameters:
-    ///    - other: The other coordinate
-    ///    - final: Calculates the final bearing if `true` (default `false`)
+    /// - Parameter other: The other coordinate
+    /// - Parameter final: Calculates the final bearing if `true` (default `false`)
+    ///
+    /// - Returns: The bearing in degrees.
     public func rhumbBearing(
         to other: Coordinate3D,
         final: Bool = false
@@ -76,8 +78,10 @@ extension Point {
     /// i.e. the angle measured in degrees from the north line (0 degrees).
     ///
     /// - Parameters:
-    ///    - other: The other coordinate
-    ///    - final: Calculates the final bearing if `true` (default `false`)
+    /// - Parameter other: The other coordinate
+    /// - Parameter final: Calculates the final bearing if `true` (default `false`)
+    ///
+    /// - Returns: The bearing in degrees.
     public func rhumbBearing(
         to other: Point,
         final: Bool = false

--- a/Sources/GISTools/Algorithms/RhumbBearing.swift
+++ b/Sources/GISTools/Algorithms/RhumbBearing.swift
@@ -23,8 +23,9 @@ extension Coordinate3D {
         case .epsg3857:
             return projected(to: .epsg4326)._rhumbBearing(to: other.projected(to: .epsg4326), final: final)
         case .noSRID:
-            // TODO
-            return Double.infinity
+            let dx = other.longitude - longitude
+            let dy = other.latitude - latitude
+            return atan2(dx, dy).radiansToDegrees
         }
     }
 

--- a/Sources/GISTools/Algorithms/RhumbBearing.swift
+++ b/Sources/GISTools/Algorithms/RhumbBearing.swift
@@ -8,11 +8,11 @@ import Foundation
 extension Coordinate3D {
 
     /// Finds the bearing angle between the receiver and another coordinate along a Rhumb line,
-    /// i.e. the angle measured in degrees start the north line (0 degrees).
+    /// i.e. the angle measured in degrees from the north line (0 degrees).
     ///
     /// - Parameters:
     ///    - other: The other coordinate
-    ///    - final: Calculated the final bearing if `true` (default `false`)
+    ///    - final: Calculates the final bearing if `true` (default `false`)
     public func rhumbBearing(
         to other: Coordinate3D,
         final: Bool = false
@@ -72,11 +72,11 @@ extension Coordinate3D {
 extension Point {
 
     /// Finds the bearing angle between the receiver and another coordinate along a Rhumb line,
-    /// i.e. the angle measured in degrees start the north line (0 degrees).
+    /// i.e. the angle measured in degrees from the north line (0 degrees).
     ///
     /// - Parameters:
     ///    - other: The other coordinate
-    ///    - final: Calculated the final bearing if `true` (default `false`)
+    ///    - final: Calculates the final bearing if `true` (default `false`)
     public func rhumbBearing(
         to other: Point,
         final: Bool = false

--- a/Sources/GISTools/Algorithms/RhumbDestination.swift
+++ b/Sources/GISTools/Algorithms/RhumbDestination.swift
@@ -23,7 +23,11 @@ extension Coordinate3D {
         case .epsg3857:
             return projected(to: .epsg4326)._rhumbDestination(distance: distance, bearing: bearing).projected(to: .epsg3857)
         case .noSRID:
-            return self // Ignore
+            let theta = bearing.degreesToRadians
+            return Coordinate3D(
+                x: longitude + distance * sin(theta),
+                y: latitude + distance * cos(theta),
+                projection: .noSRID)
         }
     }
 

--- a/Sources/GISTools/Algorithms/RhumbDestination.swift
+++ b/Sources/GISTools/Algorithms/RhumbDestination.swift
@@ -11,8 +11,10 @@ extension Coordinate3D {
     /// origin with the given bearing.
     ///
     /// - Parameters:
-    ///    - distance: The distance from the receiver, in meters
-    ///    - bearing: The direction, ranging from -180 to 180 degrees from north
+    /// - Parameter distance: The distance from the receiver, in meters
+    /// - Parameter bearing: The direction, ranging from -180 to 180 degrees from north
+    ///
+    /// - Returns: The destination coordinate.
     public func rhumbDestination(
         distance: CLLocationDistance,
         bearing: CLLocationDegrees
@@ -104,8 +106,10 @@ extension Point {
     /// origin with the given bearing.
     ///
     /// - Parameters:
-    ///    - distance: The distance from the receiver, in meters
-    ///    - bearing: The direction, ranging from -180 to 180 degrees from north
+    /// - Parameter distance: The distance from the receiver, in meters
+    /// - Parameter bearing: The direction, ranging from -180 to 180 degrees from north
+    ///
+    /// - Returns: The destination point.
     public func rhumbDestination(
         distance: CLLocationDistance,
         bearing: CLLocationDegrees

--- a/Sources/GISTools/Algorithms/RhumbDistance.swift
+++ b/Sources/GISTools/Algorithms/RhumbDistance.swift
@@ -10,6 +10,8 @@ extension Coordinate3D {
     /// Calculates the distance along a rhumb line between two coordinates, in meters.
     ///
     /// - Parameter other: The other coordinate
+    ///
+    /// - Returns: The distance in meters.
     public func rhumbDistance(from other: Coordinate3D) -> CLLocationDistance {
         switch projection {
         case .epsg4326:
@@ -79,6 +81,8 @@ extension Point {
     /// Calculates the distance between two points, in meters.
     ///
     /// - Parameter other: The other point
+    ///
+    /// - Returns: The distance in meters.
     public func rhumbDistance(from other: Point) -> CLLocationDistance {
         coordinate.rhumbDistance(from: other.coordinate)
     }

--- a/Sources/GISTools/Algorithms/RhumbDistance.swift
+++ b/Sources/GISTools/Algorithms/RhumbDistance.swift
@@ -28,10 +28,10 @@ extension Coordinate3D {
 
         // compensate the crossing of the 180th meridian (https://macwright.org/2016/09/26/the-180th-meridian.html)
         // solution from https://github.com/mapbox/mapbox-gl-js/issues/3250#issuecomment-294887678
-        if longitude - self.longitude > 180 {
+        if otherLongitude - self.longitude > 180 {
             otherLongitude -= 360.0
         }
-        else if self.longitude - longitude > 180.0 {
+        else if self.longitude - otherLongitude > 180.0 {
             otherLongitude += 360.0
         }
 

--- a/Sources/GISTools/Algorithms/RhumbDistance.swift
+++ b/Sources/GISTools/Algorithms/RhumbDistance.swift
@@ -20,8 +20,9 @@ extension Coordinate3D {
             // TODO: This can be improved
             return projected(to: .epsg4326)._rhumbDistance(from: other.projected(to: .epsg4326))
         case .noSRID:
-            // TODO
-            return Double.infinity
+            let dx = longitude - other.longitude
+            let dy = latitude - other.latitude
+            return sqrt(dx * dx + dy * dy)
         }
     }
 

--- a/Sources/GISTools/Algorithms/Simplify.swift
+++ b/Sources/GISTools/Algorithms/Simplify.swift
@@ -152,7 +152,7 @@ public enum Simplify {
     ///
     /// - Parameters:
     ///    - coordinates: An array of Coordinate3D
-    ///    - tolerance: Affects the amount of simplification (in units of the coordinates coordinate system)
+    ///    - tolerance: Affects the amount of simplification (in units of the coordinate's coordinate system)
     ///    - highQuality: Skip the distance-based preprocessing step which leads to highest quality simplification but runs quite a bit times slower
     ///
     /// - Returns: Returns an array of simplified coordinates

--- a/Sources/GISTools/Algorithms/Simplify.swift
+++ b/Sources/GISTools/Algorithms/Simplify.swift
@@ -107,16 +107,16 @@ extension Ring {
               tolerance > 0.0
         else { return self }
 
-        var simplificationtolerance = tolerance
-        var simplifiedCoordinates = Simplify.simplify(coordinates: coordinates, toleranceInMeters: simplificationtolerance, highQuality: highQuality)
+        var simplificationTolerance = tolerance
+        var simplifiedCoordinates = Simplify.simplify(coordinates: coordinates, toleranceInMeters: simplificationTolerance, highQuality: highQuality)
 
         // if this is not a valid polygon ring anymore: reduce the tolerance until we have at least a triangle
         while !Ring.validCoordinates(simplifiedCoordinates) {
             // Prevent an endless loop
-            guard simplificationtolerance >= (tolerance / 2.0) else { return self }
+            guard simplificationTolerance >= (tolerance / 2.0) else { return self }
 
-            simplificationtolerance *= 0.9
-            simplifiedCoordinates = Simplify.simplify(coordinates: coordinates, toleranceInMeters: simplificationtolerance, highQuality: highQuality)
+            simplificationTolerance *= 0.9
+            simplifiedCoordinates = Simplify.simplify(coordinates: coordinates, toleranceInMeters: simplificationTolerance, highQuality: highQuality)
         }
 
         if let first = simplifiedCoordinates.first,

--- a/Sources/GISTools/Algorithms/Simplify.swift
+++ b/Sources/GISTools/Algorithms/Simplify.swift
@@ -13,8 +13,8 @@ extension GeoJson {
     /// **Important**: This method expects tolerance in meters. Use the *Simplify* struct directly if your GeoJSON is not in WGS84.
     ///
     /// - Parameters:
-    ///    - tolerance: Affects the amount of simplification (in meters)
-    ///    - highQuality: Excludes distance-based preprocessing step which leads to highest quality simplification but runs ~10-20 times slower
+    /// - Parameter tolerance: Affects the amount of simplification (in meters)
+    /// - Parameter highQuality: Excludes distance-based preprocessing step which leads to highest quality simplification but runs ~10-20 times slower
     ///
     /// - Returns: A new simplified GeoJson
     public func simplified(
@@ -84,8 +84,8 @@ extension GeoJson {
     /// **Important**: This method expects tolerance in meters. Use the *Simplify* struct directly if your GeoJSON is not in WGS84.
     ///
     /// - Parameters:
-    ///    - tolerance: Affects the amount of simplification (in meters)
-    ///    - highQuality: Excludes distance-based preprocessing step which leads to highest quality simplification but runs ~10-20 times slower
+    /// - Parameter tolerance: Affects the amount of simplification (in meters)
+    /// - Parameter highQuality: Excludes distance-based preprocessing step which leads to highest quality simplification but runs ~10-20 times slower
     public mutating func simplify(
         tolerance: CLLocationDistance = 1.0,
         highQuality: Bool = false
@@ -151,9 +151,9 @@ public enum Simplify {
     /// Returns an array of simplified coordinates.
     ///
     /// - Parameters:
-    ///    - coordinates: An array of Coordinate3D
-    ///    - tolerance: Affects the amount of simplification (in units of the coordinate's coordinate system)
-    ///    - highQuality: Skip the distance-based preprocessing step which leads to highest quality simplification but runs quite a bit times slower
+    /// - Parameter coordinates: An array of Coordinate3D
+    /// - Parameter tolerance: Affects the amount of simplification (in units of the coordinate's coordinate system)
+    /// - Parameter highQuality: Skip the distance-based preprocessing step which leads to highest quality simplification but runs quite a bit times slower
     ///
     /// - Returns: Returns an array of simplified coordinates
     public static func simplify(

--- a/Sources/GISTools/Algorithms/TileCover.swift
+++ b/Sources/GISTools/Algorithms/TileCover.swift
@@ -7,16 +7,123 @@ extension GeoJson {
 
     /// Returns an array of map tiles covering the receiver at the given zoom level.
     ///
+    /// Walks each edge segment in tile space to collect all tiles the geometry passes through,
+    /// rather than only tiles at vertex positions. This provides proper coverage along the
+    /// edges of line strings and polygon rings.
+    ///
     /// - Parameter zoom: The zoom level of the map.
     /// - Returns: An array of ``MapTile`` instances.
     public func tileCover(atZoom zoom: Int) -> [MapTile] {
+        let segments = lineSegments
+        let scale = Double(1 << zoom)
+
+        guard segments.isNotEmpty else {
+            let coordinateTiles = allCoordinates.map {
+                MapTile(coordinate: $0, atZoom: zoom)
+            }
+            return Array(Set(coordinateTiles))
+        }
+
         var tiles: Set<MapTile> = []
 
-        allCoordinates.forEach { coordinate in
-            tiles.insert(MapTile(coordinate: coordinate, atZoom: zoom))
+        for segment in segments {
+            walkSegment(
+                from: segment.first,
+                to: segment.second,
+                zoom: zoom,
+                scale: scale,
+                tiles: &tiles)
         }
 
         return Array(tiles)
+    }
+
+    /// Walk a single segment in tile space, inserting every tile it crosses.
+    private func walkSegment(
+        from a: Coordinate3D,
+        to b: Coordinate3D,
+        zoom: Int,
+        scale: Double,
+        tiles: inout Set<MapTile>
+    ) {
+        let na = MapTile.normalizeCoordinate(a.projected(to: .epsg4326))
+        let nb = MapTile.normalizeCoordinate(b.projected(to: .epsg4326))
+
+        var x0 = na.longitude * scale
+        let y0 = na.latitude * scale
+        var x1 = nb.longitude * scale
+        let y1 = nb.latitude * scale
+
+        // When the shortest path crosses the anti-meridian, unwrap x1
+        // by ±scale so the grid walker takes the shorter route.
+        let rawD = b.longitude - a.longitude
+        if rawD > 180.0 {
+            x1 -= scale
+        }
+        else if rawD < -180.0 {
+            x1 += scale
+        }
+
+        let scaleInt = Int(scale)
+
+        func clampedTile(x: Int, y: Int) -> MapTile {
+            let cx = ((x % scaleInt) + scaleInt) % scaleInt
+            return MapTile(x: cx, y: y, z: zoom)
+        }
+
+        let startX = Int(x0.rounded(.down))
+        let startY = Int(y0.rounded(.down))
+        let endX = Int(x1.rounded(.down))
+        let endY = Int(y1.rounded(.down))
+
+        tiles.insert(clampedTile(x: startX, y: startY))
+
+        guard startX != endX || startY != endY else { return }
+
+        let stepX = x1 > x0 ? 1 : -1
+        let stepY = y1 > y0 ? 1 : -1
+
+        let tDeltaX = abs(1.0 / (x1 - x0))
+        let tDeltaY = abs(1.0 / (y1 - y0))
+
+        let tMaxX: Double
+        if x1 > x0 {
+            tMaxX = (x0.rounded(.up) - x0) * tDeltaX
+        }
+        else if x1 < x0 {
+            tMaxX = (x0 - x0.rounded(.down)) * tDeltaX
+        }
+        else {
+            tMaxX = .infinity
+        }
+
+        let tMaxY: Double
+        if y1 > y0 {
+            tMaxY = (y0.rounded(.up) - y0) * tDeltaY
+        }
+        else if y1 < y0 {
+            tMaxY = (y0 - y0.rounded(.down)) * tDeltaY
+        }
+        else {
+            tMaxY = .infinity
+        }
+
+        var x = startX
+        var y = startY
+        var tx = tMaxX
+        var ty = tMaxY
+
+        while x != endX || y != endY {
+            if tx < ty {
+                tx += tDeltaX
+                x += stepX
+            }
+            else {
+                ty += tDeltaY
+                y += stepY
+            }
+            tiles.insert(clampedTile(x: x, y: y))
+        }
     }
 
 }

--- a/Sources/GISTools/Algorithms/TransformCoordinates.swift
+++ b/Sources/GISTools/Algorithms/TransformCoordinates.swift
@@ -8,6 +8,8 @@ extension GeoJson {
     /// Returns a new geometry with all coordinates transformed by the given function.
     ///
     /// - Parameter transform: The transformation function
+    ///
+    /// - Returns: A new geometry with transformed coordinates.
     public func transformedCoordinates(
         _ transform: (Coordinate3D) -> Coordinate3D
     ) -> Self {

--- a/Sources/GISTools/Algorithms/TransformRotate.swift
+++ b/Sources/GISTools/Algorithms/TransformRotate.swift
@@ -10,9 +10,9 @@ extension GeoJson {
     /// Rotates any geojson Feature or Geometry of a specified angle, around its centroid or a given pivot point.
     /// All rotations follow the right-hand rule: https://en.wikipedia.org/wiki/Right-hand_rule.
     ///
-    /// - Parameters:
-    ///    - angle: The angle of the rotation (along the vertical axis), from north in decimal degrees, negative clockwise
-    ///    - pivot: The coordinate around which the rotation will be performed (defaults to the centroid)
+    /// - Parameter angle: The angle of the rotation (along the vertical axis), from north in decimal degrees, negative clockwise
+    /// - Parameter pivot: The coordinate around which the rotation will be performed (defaults to the centroid)
+    /// - Returns: The rotated geometry.
     public func rotated(
         angle: CLLocationDegrees,
         pivot: Coordinate3D? = nil
@@ -35,9 +35,9 @@ extension GeoJson {
     /// Rotates any geojson Feature or Geometry of a specified angle, around its centroid or a given pivot point.
     /// All rotations follow the right-hand rule: https://en.wikipedia.org/wiki/Right-hand_rule.
     ///
-    /// - Parameters:
-    ///    - angle: The angle of the rotation (along the vertical axis), from north in decimal degrees, negative clockwise
-    ///    - pivot: The coordinate around which the rotation will be performed (defaults to the centroid)
+    /// - Parameter angle: The angle of the rotation (along the vertical axis), from north in decimal degrees, negative clockwise
+    /// - Parameter pivot: The coordinate around which the rotation will be performed (defaults to the centroid)
+    /// - Returns: The rotated geometry.
     public func rotated(
         angle: CLLocationDegrees,
         pivot: Point? = nil
@@ -48,9 +48,8 @@ extension GeoJson {
     /// Rotates the receiver with a specified angle, around its centroid or a given pivot point.
     /// All rotations follow the right-hand rule: https://en.wikipedia.org/wiki/Right-hand_rule.
     ///
-    /// - Parameters:
-    ///    - angle: The angle of the rotation (along the vertical axis), from north in decimal degrees, negative clockwise
-    ///    - pivot: The coordinate around which the rotation will be performed (defaults to the centroid)
+    /// - Parameter angle: The angle of the rotation (along the vertical axis), from north in decimal degrees, negative clockwise
+    /// - Parameter pivot: The coordinate around which the rotation will be performed (defaults to the centroid)
     public mutating func rotate(
         angle: CLLocationDegrees,
         pivot: Coordinate3D? = nil
@@ -61,9 +60,8 @@ extension GeoJson {
     /// Rotates the receiver with a specified angle, around its centroid or a given pivot point.
     /// All rotations follow the right-hand rule: https://en.wikipedia.org/wiki/Right-hand_rule.
     ///
-    /// - Parameters:
-    ///    - angle: The angle of the rotation (along the vertical axis), from north in decimal degrees, negative clockwise
-    ///    - pivot: The point around which the rotation will be performed (defaults to the centroid)
+    /// - Parameter angle: The angle of the rotation (along the vertical axis), from north in decimal degrees, negative clockwise
+    /// - Parameter pivot: The point around which the rotation will be performed (defaults to the centroid)
     public mutating func rotate(
         angle: CLLocationDegrees,
         pivot: Point? = nil

--- a/Sources/GISTools/Algorithms/TransformRotate.swift
+++ b/Sources/GISTools/Algorithms/TransformRotate.swift
@@ -37,7 +37,7 @@ extension GeoJson {
     ///
     /// - Parameters:
     ///    - angle: The angle of the rotation (along the vertical axis), from north in decimal degrees, negative clockwise
-    ///    - pivot: The point around which the rotation will be performed (defaults to the centroid)
+    ///    - pivot: The coordinate around which the rotation will be performed (defaults to the centroid)
     public func rotated(
         angle: CLLocationDegrees,
         pivot: Point? = nil

--- a/Sources/GISTools/Algorithms/TransformScale.swift
+++ b/Sources/GISTools/Algorithms/TransformScale.swift
@@ -29,9 +29,12 @@ public enum ScaleAnchor: Sendable {
 
 extension GeoJson {
 
-    /// Scale the receiver from a given point by a factor of scaling (ex: factor=2 would make the
+    /// Scale the receiver from a given point by a factor of scaling (e.g. factor=2 would make the
     /// GeoJSON 200% larger). If the receiver is a *FeatureCollection*, the origin point will
     /// be calculated based on each individual Feature.
+    ///
+    /// - Note: When using `ScaleAnchor.coordinate(_)` as the anchor, a `FeatureCollection` is
+    ///   scaled as a single unit. With any other anchor, each `Feature` is scaled individually.
     ///
     /// - Parameters:
     ///    - factor: The scaling factor, positive or negative
@@ -61,7 +64,7 @@ extension GeoJson {
         return _scaledBy(factor: factor, anchor: anchor)
     }
 
-    /// Scale the receiver from a given point by a factor of scaling (ex: factor=2 would make the
+    /// Scale the receiver from a given point by a factor of scaling (e.g. factor=2 would make the
     /// GeoJSON 200% larger). If the receiver is a *FeatureCollection*, the origin point will
     /// be calculated based on each individual Feature.
     ///

--- a/Sources/GISTools/Algorithms/TransformScale.swift
+++ b/Sources/GISTools/Algorithms/TransformScale.swift
@@ -36,9 +36,9 @@ extension GeoJson {
     /// - Note: When using `ScaleAnchor.coordinate(_)` as the anchor, a `FeatureCollection` is
     ///   scaled as a single unit. With any other anchor, each `Feature` is scaled individually.
     ///
-    /// - Parameters:
-    ///    - factor: The scaling factor, positive or negative
-    ///    - anchor: The anchor from which the scaling will occur
+    /// - Parameter factor: The scaling factor, positive or negative
+    /// - Parameter anchor: The anchor from which the scaling will occur
+    /// - Returns: The scaled geometry.
     public func scaled(
         factor: Double,
         anchor: ScaleAnchor = .centroid
@@ -68,9 +68,8 @@ extension GeoJson {
     /// GeoJSON 200% larger). If the receiver is a *FeatureCollection*, the origin point will
     /// be calculated based on each individual Feature.
     ///
-    /// - Parameters:
-    ///    - factor: The scaling factor, positive or negative
-    ///    - anchor: The anchor from which the scaling will occur
+    /// - Parameter factor: The scaling factor, positive or negative
+    /// - Parameter anchor: The anchor from which the scaling will occur
     public mutating func scale(
         factor: Double,
         anchor: ScaleAnchor = .centroid

--- a/Sources/GISTools/Algorithms/TransformTranslate.swift
+++ b/Sources/GISTools/Algorithms/TransformTranslate.swift
@@ -9,10 +9,10 @@ extension GeoJson {
 
     /// Moves the receiver for a specified distance along a Rhumb line on the provided direction angle.
     ///
-    /// - Parameters:
-    ///    - distance: The length of the motion, in meters
-    ///    - direction: The direction of the motion, in decimal degrees from north, positive clockwise.
-    ///    - zTranslation: The length of the vertical motion, in meters (defaults to 0.0)
+    /// - Parameter distance: The length of the motion, in meters
+    /// - Parameter direction: The direction of the motion, in decimal degrees from north, positive clockwise.
+    /// - Parameter zTranslation: The length of the vertical motion, in meters (defaults to 0.0)
+    /// - Returns: The translated geometry.
     public func translated(
         distance: CLLocationDistance,
         direction: CLLocationDegrees,
@@ -35,10 +35,9 @@ extension GeoJson {
 
     /// Moves the receiver for a specified distance along a Rhumb line on the provided direction angle.
     ///
-    /// - Parameters:
-    ///    - distance: The length of the motion, in meters
-    ///    - direction: The direction of the motion, in decimal degrees from north, positive clockwise.
-    ///    - zTranslation: The length of the vertical motion, in meters (defaults to 0.0)
+    /// - Parameter distance: The length of the motion, in meters
+    /// - Parameter direction: The direction of the motion, in decimal degrees from north, positive clockwise.
+    /// - Parameter zTranslation: The length of the vertical motion, in meters (defaults to 0.0)
     public mutating func translate(
         distance: CLLocationDistance,
         direction: CLLocationDegrees,

--- a/Sources/GISTools/Algorithms/TransformTranslate.swift
+++ b/Sources/GISTools/Algorithms/TransformTranslate.swift
@@ -21,7 +21,6 @@ extension GeoJson {
         guard distance != 0.0 || zTranslation != 0.0 else { return self }
 
         let distance = abs(distance)
-        let direction = abs(direction)
 
         return transformedCoordinates({ (coordinate) in
             var newCoordinate = coordinate.rhumbDestination(distance: distance, bearing: direction)

--- a/Sources/GISTools/Algorithms/Truncate.swift
+++ b/Sources/GISTools/Algorithms/Truncate.swift
@@ -9,10 +9,10 @@ extension Coordinate3D {
 
     /// Truncates the precision of the coordinate.
     ///
-    /// - Parameters:
-    ///    - precision: The coordinate decimal precision (default `6`)
-    ///    - removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
-    ///    - removeM: Whether to remove the coordinate's `m` value (default `false`)
+    /// - Parameter precision: The coordinate decimal precision (default `6`)
+    /// - Parameter removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
+    /// - Parameter removeM: Whether to remove the coordinate's `m` value (default `false`)
+    /// - Returns: The truncated coordinate.
     public func truncated(
         precision: Int = 6,
         removeAltitude: Bool = false,
@@ -28,12 +28,11 @@ extension Coordinate3D {
 
     /// Truncates the precision of the coordinate.
     ///
-    /// - Parameters:
-    ///    - precision: The coordinate decimal precision (default `6`)
-    ///    - removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
-    ///    - removeM: Whether to remove the coordinate's `m` value (default `false`)
+    /// - Parameter precision: The coordinate decimal precision (default `6`)
+    /// - Parameter removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
+    /// - Parameter removeM: Whether to remove the coordinate's `m` value (default `false`)
     public mutating func truncate(
-        precision: Int,
+        precision: Int = 6,
         removeAltitude: Bool = false,
         removeM: Bool = false
     ) {
@@ -49,10 +48,10 @@ extension GeoJson {
 
     /// Truncates the precision of the geometry.
     ///
-    /// - Parameters:
-    ///    - precision: The coordinate decimal precision (default `6`)
-    ///    - removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
-    ///    - removeM: Whether to remove the coordinate's `m` value (default `false`)
+    /// - Parameter precision: The coordinate decimal precision (default `6`)
+    /// - Parameter removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
+    /// - Parameter removeM: Whether to remove the coordinate's `m` value (default `false`)
+    /// - Returns: The truncated geometry.
     public func truncated(
         precision: Int = 6,
         removeAltitude: Bool = false,
@@ -142,10 +141,9 @@ extension GeoJson {
 
     /// Truncates the precision of the geometry.
     ///
-    /// - Parameters:
-    ///    - precision: The coordinate decimal precision (default `6`)
-    ///    - removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
-    ///    - removeM: Whether to remove the coordinate's `m` value (default `false`)
+    /// - Parameter precision: The coordinate decimal precision (default `6`)
+    /// - Parameter removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
+    /// - Parameter removeM: Whether to remove the coordinate's `m` value (default `false`)
     public mutating func truncate(
         precision: Int = 6,
         removeAltitude: Bool = false,

--- a/Sources/GISTools/Algorithms/Truncate.swift
+++ b/Sources/GISTools/Algorithms/Truncate.swift
@@ -12,7 +12,7 @@ extension Coordinate3D {
     /// - Parameters:
     ///    - precision: The coordinate decimal precision (default `6`)
     ///    - removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
-    ///    - removeM: Whether to remote the coordinate's `m` value (default `false`)
+    ///    - removeM: Whether to remove the coordinate's `m` value (default `false`)
     public func truncated(
         precision: Int = 6,
         removeAltitude: Bool = false,
@@ -31,7 +31,7 @@ extension Coordinate3D {
     /// - Parameters:
     ///    - precision: The coordinate decimal precision (default `6`)
     ///    - removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
-    ///    - removeM: Whether to remote the coordinate's `m` value (default `false`)
+    ///    - removeM: Whether to remove the coordinate's `m` value (default `false`)
     public mutating func truncate(
         precision: Int,
         removeAltitude: Bool = false,
@@ -52,7 +52,7 @@ extension GeoJson {
     /// - Parameters:
     ///    - precision: The coordinate decimal precision (default `6`)
     ///    - removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
-    ///    - removeM: Whether to remote the coordinate's `m` value (default `false`)
+    ///    - removeM: Whether to remove the coordinate's `m` value (default `false`)
     public func truncated(
         precision: Int = 6,
         removeAltitude: Bool = false,
@@ -145,7 +145,7 @@ extension GeoJson {
     /// - Parameters:
     ///    - precision: The coordinate decimal precision (default `6`)
     ///    - removeAltitude: Whether to remove the coordinate's altitude value (default `false`)
-    ///    - removeM: Whether to remote the coordinate's `m` value (default `false`)
+    ///    - removeM: Whether to remove the coordinate's `m` value (default `false`)
     public mutating func truncate(
         precision: Int = 6,
         removeAltitude: Bool = false,

--- a/Sources/GISTools/Algorithms/Union.swift
+++ b/Sources/GISTools/Algorithms/Union.swift
@@ -5,6 +5,10 @@ import Foundation
 
 extension Polygon {
 
+    /// Returns the union of the receiver with another polygon geometry.
+    ///
+    /// - Parameter other: The other polygon geometry
+    /// - Returns: A `MultiPolygon` representing the union, or `nil` if the union is empty.
     public func union(with other: PolygonGeometry) -> MultiPolygon? {
         var all = self.polygons
         all.append(contentsOf: other.polygons)
@@ -15,6 +19,10 @@ extension Polygon {
 
 extension MultiPolygon {
 
+    /// Returns the union of the receiver with another polygon geometry.
+    ///
+    /// - Parameter other: The other polygon geometry
+    /// - Returns: A `MultiPolygon` representing the union, or `nil` if the union is empty.
     public func union(with other: PolygonGeometry) -> MultiPolygon? {
         var all = self.polygons
         all.append(contentsOf: other.polygons)
@@ -30,6 +38,9 @@ extension MultiPolygon {
 
 extension FeatureCollection {
 
+    /// Returns the union of all polygon features in the collection.
+    ///
+    /// - Returns: A `FeatureCollection` containing the unioned polygon, or `nil` if no polygons exist.
     public func union() -> FeatureCollection? {
         let geometries = features
             .compactMap { ($0.geometry as? PolygonGeometry)?.polygons }

--- a/Sources/GISTools/Algorithms/Union.swift
+++ b/Sources/GISTools/Algorithms/Union.swift
@@ -484,7 +484,7 @@ enum Union {
 
 }
 
-// MARK: - BoundingBoxRepresentable conformance (for future RTree use)
+// MARK: - BoundingBoxRepresentable conformance (required by RTree)
 
 extension Union.Edge: BoundingBoxRepresentable {
 

--- a/Sources/GISTools/Algorithms/Validatable.swift
+++ b/Sources/GISTools/Algorithms/Validatable.swift
@@ -17,7 +17,7 @@ public protocol ValidatableGeoJson {
 
 // MARK: - Geometries etc.
 
-extension Feature {
+extension Feature: ValidatableGeoJson {
 
     /// Check if the Feature's geometry is valid, i.e. it has enough coordinates to make sense.
     public var isValid: Bool {
@@ -31,7 +31,7 @@ extension Feature {
 
 }
 
-extension FeatureCollection {
+extension FeatureCollection: ValidatableGeoJson {
 
     /// Check if the FeatureCollection's Feature is valid, i.e. it has enough coordinates to make sense.
     public var isValid: Bool {
@@ -45,7 +45,7 @@ extension FeatureCollection {
 
 }
 
-extension GeometryCollection {
+extension GeometryCollection: ValidatableGeoJson {
 
     /// Check if the geometries are valid, i.e. they have enough coordinates to make sense.
     public var isValid: Bool {
@@ -59,7 +59,7 @@ extension GeometryCollection {
 
 }
 
-extension LineString {
+extension LineString: ValidatableGeoJson {
 
     /// Check if the LineString is valid, i.e. it has enough coordinates to make sense.
     public var isValid: Bool {
@@ -73,7 +73,7 @@ extension LineString {
 
 }
 
-extension MultiLineString {
+extension MultiLineString: ValidatableGeoJson {
 
     /// Check if the MultiLineString is valid, i.e. it has enough coordinates to make sense.
     public var isValid: Bool {
@@ -88,7 +88,7 @@ extension MultiLineString {
 
 }
 
-extension Point {
+extension Point: ValidatableGeoJson {
 
     /// Check if the Point is valid. Always `true`.
     public var isValid: Bool {
@@ -102,7 +102,7 @@ extension Point {
 
 }
 
-extension MultiPoint {
+extension MultiPoint: ValidatableGeoJson {
 
     /// Check if the MultiPoint is valid, i.e. it has enough coordinates to make sense.
     public var isValid: Bool {
@@ -116,7 +116,7 @@ extension MultiPoint {
 
 }
 
-extension Polygon {
+extension Polygon: ValidatableGeoJson {
 
     /// Check if the Polygon is valid, i.e. it has enough coordinates to make sense.
     public var isValid: Bool {
@@ -131,7 +131,7 @@ extension Polygon {
 
 }
 
-extension MultiPolygon {
+extension MultiPolygon: ValidatableGeoJson {
 
     /// Check if the MultiPolygon is valid, i.e. it has enough coordinates to make sense.
     public var isValid: Bool {

--- a/Sources/GISTools/Algorithms/Validatable.swift
+++ b/Sources/GISTools/Algorithms/Validatable.swift
@@ -10,8 +10,22 @@ public protocol ValidatableGeoJson {
 
     /// Check if the geometry is valid, i.e. it has enough coordinates to make sense.
     ///
-    /// TODO: Would this be a null geometry?
+    /// - Note: RFC 7946 §3.2 allows a Feature with `"geometry": null`, but
+    ///   this library rejects those at parse time (``Feature.init?(json:)``
+    ///   returns `nil`). Every validatable type therefore always has a
+    ///   non-nil geometry.
     var isValid: Bool { get }
+
+    /// Returns `self` when ``isValid`` is `true`, otherwise `nil`.
+    var validated: Self? { get }
+
+}
+
+extension ValidatableGeoJson {
+
+    public var validated: Self? {
+        isValid ? self : nil
+    }
 
 }
 

--- a/Sources/GISTools/Algorithms/Validatable.swift
+++ b/Sources/GISTools/Algorithms/Validatable.swift
@@ -39,6 +39,8 @@ extension Feature: ValidatableGeoJson {
     }
 
     /// Check if the GeoJson is a valid Feature.
+    ///
+    /// - Returns: `true` if the GeoJson is valid.
     public static func isValid(geoJson: [String: Any]) -> Bool {
         checkIsValid(geoJson: geoJson, ofType: .feature)
     }
@@ -53,6 +55,8 @@ extension FeatureCollection: ValidatableGeoJson {
     }
 
     /// Check if the GeoJson is a valid FeatureCollection.
+    ///
+    /// - Returns: `true` if the GeoJson is valid.
     public static func isValid(geoJson: [String: Any]) -> Bool {
         checkIsValid(geoJson: geoJson, ofType: .featureCollection)
     }
@@ -67,6 +71,8 @@ extension GeometryCollection: ValidatableGeoJson {
     }
 
     /// Check if the GeoJson is a valid GeometryCollection.
+    ///
+    /// - Returns: `true` if the GeoJson is valid.
     public static func isValid(geoJson: [String: Any]) -> Bool {
         checkIsValid(geoJson: geoJson, ofType: .geometryCollection)
     }
@@ -81,6 +87,8 @@ extension LineString: ValidatableGeoJson {
     }
 
     /// Check if the GeoJson has a valid LineString geometry.
+    ///
+    /// - Returns: `true` if the GeoJson is valid.
     public static func isValid(geoJson: [String: Any]) -> Bool {
         checkIsValid(geoJson: geoJson, ofType: .lineString)
     }
@@ -96,6 +104,8 @@ extension MultiLineString: ValidatableGeoJson {
     }
 
     /// Check if the GeoJson has a valid MultiLineString geometry.
+    ///
+    /// - Returns: `true` if the GeoJson is valid.
     public static func isValid(geoJson: [String: Any]) -> Bool {
         checkIsValid(geoJson: geoJson, ofType: .multiLineString)
     }
@@ -110,6 +120,8 @@ extension Point: ValidatableGeoJson {
     }
 
     /// Check if the GeoJson is a valid Point.
+    ///
+    /// - Returns: `true` if the GeoJson is valid.
     public static func isValid(geoJson: [String: Any]) -> Bool {
         checkIsValid(geoJson: geoJson, ofType: .point)
     }
@@ -124,6 +136,8 @@ extension MultiPoint: ValidatableGeoJson {
     }
 
     /// Check if the GeoJson has a valid MultiPoint geometry.
+    ///
+    /// - Returns: `true` if the GeoJson is valid.
     public static func isValid(geoJson: [String: Any]) -> Bool {
         checkIsValid(geoJson: geoJson, ofType: .multiPoint)
     }
@@ -139,6 +153,8 @@ extension Polygon: ValidatableGeoJson {
     }
 
     /// Check if the GeoJson has a valid Polygon geometry.
+    ///
+    /// - Returns: `true` if the GeoJson is valid.
     public static func isValid(geoJson: [String: Any]) -> Bool {
         checkIsValid(geoJson: geoJson, ofType: .polygon)
     }
@@ -155,6 +171,8 @@ extension MultiPolygon: ValidatableGeoJson {
     }
 
     /// Check if the GeoJson has a valid MultiPolygon geometry.
+    ///
+    /// - Returns: `true` if the GeoJson is valid.
     public static func isValid(geoJson: [String: Any]) -> Bool {
         checkIsValid(geoJson: geoJson, ofType: .multiPolygon)
     }
@@ -168,8 +186,8 @@ extension GeoJson {
     /// Check if the GeoJson dictionary has a valid structure for the given type.
     ///
     /// - Parameters:
-    ///   - geoJson: A dictionary representing a GeoJSON object.
-    ///   - expectedType: The expected ``GeoJsonType`` of the object (optional).
+    /// - Parameter geoJson: A dictionary representing a GeoJSON object.
+    /// - Parameter expectedType: The expected ``GeoJsonType`` of the object (optional).
     /// - Returns: `true` if the dictionary has the required keys for the given type.
     public static func checkIsValid(
         geoJson: [String: Any],

--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -95,6 +95,10 @@ public struct BoundingBox:
     }
 
     /// Create a bounding box with a `southWest` and `northEast` coordinate.
+    ///
+    /// - Parameters:
+    ///    - southWest: The south-west (bottom-left) coordinate
+    ///    - northEast: The north-east (upper-right) coordinate
     public init(southWest: Coordinate3D, northEast: Coordinate3D) {
         assert(southWest.projection == northEast.projection, "Projections must be the same")
 
@@ -104,6 +108,10 @@ public struct BoundingBox:
     }
 
     /// Create a bounding box from other bounding boxes.
+    ///
+    /// - Parameters:
+    ///    - boundingBoxes: An array of bounding boxes to encompass
+    /// - Returns: A bounding box covering all input boxes, or `nil` if the array is empty
     public init?(boundingBoxes: [BoundingBox]) {
         self.init(coordinates: boundingBoxes.flatMap({ [$0.southWest, $0.northEast] }))
     }
@@ -111,6 +119,9 @@ public struct BoundingBox:
     /// Try to create a bounding box from some JSON.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - json: A GeoJSON bounding box value (an array of 4 or 6 doubles, or an array of 2 coordinate arrays)
+    /// - Returns: A bounding box, or `nil` if the input is invalid
     public init?(json: Any?) {
         self.projection = .epsg4326
 
@@ -147,6 +158,7 @@ public struct BoundingBox:
     /// Dump the bounding box as JSON.
     ///
     /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
+    /// - Returns: An array of 4 or 6 doubles representing the GeoJSON bounding box
     public var asJson: [Double] {
         var bottomLeft: [Double] = (projection == .epsg4326 || projection == .noSRID
             ? [southWest.longitude, southWest.latitude]
@@ -190,11 +202,20 @@ public struct BoundingBox:
     }
 
     /// Returns a copy of the receiver expanded by `degrees` horizontally and vertically.
+    ///
+    /// - Parameters:
+    ///    - degrees: The number of degrees to expand in each direction
+    /// - Returns: A new bounding box expanded by the given amount
     public func expanded(byDegrees degrees: CLLocationDegrees) -> BoundingBox {
         expanded(byHorizontalDegrees: degrees, verticalDegrees: degrees)
     }
 
     /// Returns a copy of the receiver expanded by `dx` and `dy` horizontally and vertically.
+    ///
+    /// - Parameters:
+    ///    - dx: The horizontal expansion in degrees
+    ///    - dy: The vertical expansion in degrees
+    /// - Returns: A new bounding box expanded by the given amounts
     public func expanded(
         byHorizontalDegrees dx: CLLocationDegrees,
         verticalDegrees dy: CLLocationDegrees
@@ -238,6 +259,10 @@ public struct BoundingBox:
     }
 
     /// Returns a copy of the receiver that also includes `coordinate`.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The coordinate to include
+    /// - Returns: A new bounding box that encompasses both the receiver and the coordinate
     public func expanded(byIncluding coordinate: Coordinate3D) -> BoundingBox {
         BoundingBox(coordinates: [southWest, northEast, coordinate.projected(to: projection)])!
     }
@@ -249,6 +274,10 @@ public struct BoundingBox:
     }
 
     /// Returns a copy of the receiver that also includes the other `boundingBox`.
+    ///
+    /// - Parameters:
+    ///    - boundingBox: The other bounding box to include
+    /// - Returns: A new bounding box that encompasses both boxes
     public func expanded(byIncluding boundingBox: BoundingBox) -> BoundingBox {
         BoundingBox(coordinates: [
             southWest,
@@ -270,6 +299,10 @@ public struct BoundingBox:
 extension BoundingBox: Projectable {
 
     /// Reproject this bounding box.
+    ///
+    /// - Parameters:
+    ///    - newProjection: The target projection
+    /// - Returns: A new bounding box in the requested projection
     public func projected(to newProjection: Projection) -> BoundingBox {
         guard newProjection != projection else { return self }
 
@@ -301,6 +334,10 @@ extension BoundingBox {
     }
 
     /// Create a bounding box from a south-west and north-east coordinate.
+    ///
+    /// - Parameters:
+    ///    - southWest: The south-west (bottom-left) coordinate
+    ///    - northEast: The north-east (upper-right) coordinate
     public init(southWest: CLLocationCoordinate2D, northEast: CLLocationCoordinate2D) {
         self.init(southWest: Coordinate3D(southWest), northEast: Coordinate3D(northEast))
     }
@@ -321,6 +358,10 @@ extension BoundingBox {
     }
 
     /// Create a bounding box from a south-west and north-east coordinate.
+    ///
+    /// - Parameters:
+    ///    - southWest: The south-west (bottom-left) location
+    ///    - northEast: The north-east (upper-right) location
     public init(southWest: CLLocation, northEast: CLLocation) {
         self.init(southWest: Coordinate3D(southWest), northEast: Coordinate3D(northEast))
     }
@@ -338,6 +379,9 @@ extension BoundingBox {
     }
 
     /// Converts the bounding box to a `Polygon` object.
+    ///
+    /// The result may not be correct if the bounding box crosses the anti-meridian.
+    /// - Returns: A polygon representing the bounding box corners
     @available(*, deprecated, message: "Use boundingBoxGeometry instead (handles antimeridian crossing)")
     public var boundingBoxPolygon: Polygon {
         Polygon([[southWest, northWest, northEast, southEast, southWest]])!
@@ -352,7 +396,8 @@ extension BoundingBox {
     /// Per [RFC 7946 § 5](https://tools.ietf.org/html/rfc7946#section-5):
     /// a bounding box that crosses the anti-meridian is represented as a
     /// `MultiPolygon` split at the date line.
-    public var boundingBoxGeometry: any GeoJsonGeometry {
+    /// - Returns: A polygon or multi-polygon representing this bounding box
+    public var boundingBoxGeometry: PolygonGeometry {
         let boundingBox = self.normalized()
 
         guard boundingBox.crossesAntiMeridian else {
@@ -414,6 +459,10 @@ extension BoundingBox {
 extension BoundingBox {
 
     /// Check if the receiver contains `coordinate`.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The coordinate to test
+    /// - Returns: `true` if the coordinate lies within this bounding box or on its borders
     public func contains(_ coordinate: Coordinate3D) -> Bool {
         let boundingBox = self.normalized()
         let coordinate = coordinate.projected(to: projection).normalized()
@@ -454,23 +503,39 @@ extension BoundingBox {
 
     #if canImport(CoreLocation)
     /// Check if the receiver contains `coordinate`.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The coordinate to test
+    /// - Returns: `true` if the coordinate lies within this bounding box or on its borders
     public func contains(_ coordinate: CLLocationCoordinate2D) -> Bool {
         contains(Coordinate3D(coordinate))
     }
 
     /// Check if the receiver contains `coordinate`.
+    ///
+    /// - Parameters:
+    ///    - location: The location to test
+    /// - Returns: `true` if the location lies within this bounding box or on its borders
     public func contains(_ location: CLLocation) -> Bool {
         contains(Coordinate3D(location))
     }
     #endif
 
     /// Check if the receiver fully contains the other bounding box.
+    ///
+    /// - Parameters:
+    ///    - other: The other bounding box to test
+    /// - Returns: `true` if the other bounding box is fully inside this one
     public func contains(_ other: BoundingBox) -> Bool {
         self.contains(other.southWest)
             && self.contains(other.northEast)
     }
 
     /// Check if the receiver intersects with the other bounding box.
+    ///
+    /// - Parameters:
+    ///    - other: The other bounding box to test
+    /// - Returns: `true` if the two bounding boxes overlap
     public func intersects(_ other: BoundingBox) -> Bool {
         let boundingBox = self.normalized()
         let other = other.projected(to: projection).normalized()
@@ -538,6 +603,10 @@ extension BoundingBox {
     }
 
     /// Returns the intersection between the receiver and the other bounding box.
+    ///
+    /// - Parameters:
+    ///    - other: The other bounding box
+    /// - Returns: The overlapping region, or `nil` if the boxes do not intersect
     public func intersection(_ other: BoundingBox) -> BoundingBox? {
         let boundingBox = self.normalized()
         let other = other.projected(to: projection).normalized()
@@ -668,6 +737,8 @@ extension BoundingBox {
     }
 
     /// Clamped to [-180.0, 180.0].
+    ///
+    /// - Returns: A copy of this bounding box with longitudes normalized to the [-180, 180] range
     public func normalized() -> BoundingBox {
         switch projection {
         case .noSRID:
@@ -703,6 +774,8 @@ extension BoundingBox {
     }
 
     /// Clamped to [[-180,-90], [180,90]]
+    ///
+    /// - Returns: A copy of this bounding box clamped to the valid coordinate range
     public func clamped() -> BoundingBox {
         BoundingBox(
             southWest: southWest.clamped(),
@@ -718,6 +791,10 @@ extension BoundingBox {
     /// - Note: The result may not be correct if either bounding box crosses
     ///         the anti-meridian (date line). Use ``normalized()`` on each
     ///         operand first to avoid this issue.
+    /// - Parameters:
+    ///    - lhs: The first bounding box
+    ///    - rhs: The second bounding box
+    /// - Returns: A bounding box that encompasses both inputs
     public static func + (
         lhs: BoundingBox,
         rhs: BoundingBox
@@ -740,6 +817,8 @@ extension BoundingBox {
     /// - Note: The result may not be correct if either bounding box crosses
     ///         the anti-meridian (date line). Use ``normalized()`` on each
     ///         operand first to avoid this issue.
+    /// - Parameters:
+    ///    - other: The bounding box to union with the receiver
     public mutating func formUnion(_ other: BoundingBox) {
         let boundingBox = self.normalized()
         let other = other.projected(to: projection).normalized()

--- a/Sources/GISTools/GeoJson/BoundingBoxRepresentable.swift
+++ b/Sources/GISTools/GeoJson/BoundingBoxRepresentable.swift
@@ -9,7 +9,9 @@ public protocol BoundingBoxRepresentable {
     /// The receiver's bounding box.
     var boundingBox: BoundingBox? { get set }
 
-    /// Calculates and returns the receiver's bounding box.
+     /// Calculates and returns the receiver's bounding box.
+     ///
+     /// - Returns: The calculated bounding box, or `nil` if there is nothing to calculate.
     func calculateBoundingBox() -> BoundingBox?
 
     /// Calculates the receiver's bounding box and updates the ``boundingBox`` property.

--- a/Sources/GISTools/GeoJson/Cartesian3D.swift
+++ b/Sources/GISTools/GeoJson/Cartesian3D.swift
@@ -7,6 +7,12 @@ public struct Cartesian3D {
     public let y: Double
     public let z: Double
 
+    /// Create a Cartesian 3D point.
+    ///
+    /// - Parameters:
+    ///    - x: The X coordinate
+    ///    - y: The Y coordinate
+    ///    - z: The Z coordinate
     public init(x: Double, y: Double, z: Double) {
         self.x = x
         self.y = y
@@ -20,6 +26,9 @@ public struct Cartesian3D {
 extension Cartesian3D {
 
     /// Convert a lat/lon coordinate (degrees) to a unit-sphere Cartesian point.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The geographic coordinate to convert
     public init(_ coordinate: Coordinate3D) {
         let lat = coordinate.latitude * .pi / 180.0
         let lon = coordinate.longitude * .pi / 180.0
@@ -34,6 +43,9 @@ extension Cartesian3D {
 extension Coordinate3D {
 
     /// Create a coordinate from a unit-sphere Cartesian point.
+    ///
+    /// - Parameters:
+    ///    - cartesian: The Cartesian point to convert
     public init(_ cartesian: Cartesian3D) {
         let lat = asin(cartesian.z) * 180.0 / .pi
         let lon = atan2(cartesian.y, cartesian.x) * 180.0 / .pi

--- a/Sources/GISTools/GeoJson/Cartesian3D.swift
+++ b/Sources/GISTools/GeoJson/Cartesian3D.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A point in 3D Cartesian space on the unit sphere.
-public struct Cartesian3D {
+public struct Cartesian3D: Hashable, Equatable, Sendable, CustomStringConvertible {
 
     public let x: Double
     public let y: Double
@@ -17,6 +17,10 @@ public struct Cartesian3D {
         self.x = x
         self.y = y
         self.z = z
+    }
+
+    public var description: String {
+        "Cartesian3D(x: \(x), y: \(y), z: \(z))"
     }
 
 }

--- a/Sources/GISTools/GeoJson/Coordinate3D.swift
+++ b/Sources/GISTools/GeoJson/Coordinate3D.swift
@@ -54,6 +54,12 @@ public struct Coordinate3D:
 
     /// Create a coordinate with ``latitude``, ``longitude``, ``altitude`` and ``m``.
     /// Projection will be *EPSG:4326*.
+    ///
+    /// - Parameters:
+    ///    - latitude: The latitude (or northing)
+    ///    - longitude: The longitude (or easting)
+    ///    - altitude: The altitude in meters (optional)
+    ///    - m: A generic value (optional)
     public init(
         latitude: CLLocationDegrees,
         longitude: CLLocationDegrees,
@@ -69,6 +75,13 @@ public struct Coordinate3D:
 
     /// Create a coordinate with ``x``, ``y``, ``z`` and ``m``.
     /// Default projection will we *EPSG:3857* but can be overridden.
+    ///
+    /// - Parameters:
+    ///    - x: The easting (or longitude)
+    ///    - y: The northing (or latitude)
+    ///    - z: The altitude in meters (optional)
+    ///    - m: A generic value (optional)
+    ///    - projection: The coordinate projection (default `.epsg3857`)
     public init(
         x: Double,
         y: Double,
@@ -124,6 +137,10 @@ extension Coordinate3D {
     /// - `"40°26'46\" N 79°58'56\" W"`
     /// - `"40 26 46 N 79 58 56 W"`
     /// - `"40°26.767' N 79°58.933' W"`
+    ///
+    /// - Parameters:
+    ///    - dms: A DMS-formatted coordinate string
+    /// - Returns: A coordinate, or `nil` if parsing fails
     public init?(dms: String) {
         let cleaned = dms
             .replacingOccurrences(of: "\u{2032}", with: "'")  // prime
@@ -154,6 +171,17 @@ extension Coordinate3D {
     }
 
     /// Creates a coordinate from separate DMS components.
+    ///
+    /// - Parameters:
+    ///    - latitudeDegrees: Degrees of latitude
+    ///    - latitudeMinutes: Minutes of latitude
+    ///    - latitudeSeconds: Seconds of latitude
+    ///    - latitudeDirection: `"N"` or `"S"`
+    ///    - longitudeDegrees: Degrees of longitude
+    ///    - longitudeMinutes: Minutes of longitude
+    ///    - longitudeSeconds: Seconds of longitude
+    ///    - longitudeDirection: `"E"` or `"W"`
+    /// - Returns: A coordinate, or `nil` if direction is invalid
     public init?(
         latitudeDegrees: Double,
         latitudeMinutes: Double,
@@ -255,6 +283,10 @@ extension Coordinate3D {
 extension Coordinate3D {
 
     /// Create a `Coordinate3D` from a `CLLocationCoordinate2D`.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The Core Location coordinate
+    ///    - altitude: The altitude in meters (optional)
     public init(
         _ coordinate: CLLocationCoordinate2D,
         altitude: CLLocationDistance? = nil
@@ -267,6 +299,8 @@ extension Coordinate3D {
     }
 
     /// This coordinate as `CLLocationCoordinate2D`.
+    ///
+    /// - Returns: A `CLLocationCoordinate2D` projected to EPSG:4326
     public var coordinate2D: CLLocationCoordinate2D {
         CLLocationCoordinate2D(
             latitude: latitudeProjected(to: .epsg4326),
@@ -276,6 +310,9 @@ extension Coordinate3D {
     /// Create a `Coordinate3D` from a `CLLocation`.
     ///
     /// This will set ``m`` to the location's timestamp using `timeIntervalSinceReferenceDate`.
+    ///
+    /// - Parameters:
+    ///    - location: The Core Location object
     public init(_ location: CLLocation) {
         self.projection = .epsg4326
         self.latitude = location.coordinate.latitude
@@ -289,6 +326,7 @@ extension Coordinate3D {
     /// - Important: This will set the location's timestamp using ``m``
     ///              if it exists, using `Date(timeIntervalSinceReferenceDate:)`.
     ///              See also ``init(_:)`` and ``asJson``.
+    /// - Returns: A `CLLocation` representing this coordinate
     public var location: CLLocation {
         let timestamp = (m != nil
             ? Date(timeIntervalSinceReferenceDate: m!)
@@ -307,6 +345,8 @@ extension Coordinate3D {
 extension CLLocation {
 
     /// The receiver as a ``Coordinate3D``.
+    ///
+    /// - Returns: A `Coordinate3D` representing this location
     public var coordinate3D: Coordinate3D {
         Coordinate3D(self)
     }
@@ -316,6 +356,8 @@ extension CLLocation {
 extension CLLocationCoordinate2D {
 
     /// The receiver as a ``Coordinate3D``.
+    ///
+    /// - Returns: A `Coordinate3D` representing this coordinate
     public var coordinate3D: Coordinate3D {
         Coordinate3D(self)
     }
@@ -333,6 +375,8 @@ extension Coordinate3D {
     }
 
     /// Clamped to [-180.0, 180.0].
+    ///
+    /// - Returns: A copy with longitude normalized to the [-180, 180] range
     public func normalized() -> Coordinate3D {
         switch projection {
         case .epsg3857:
@@ -363,7 +407,9 @@ extension Coordinate3D {
         self = self.clamped()
     }
 
-    /// Clamped to [[-180,-90], [180,90]]
+    /// Clamped to [[-180,-90], [180,90]].
+    ///
+    /// - Returns: A copy clamped to the valid coordinate range
     public func clamped() -> Coordinate3D {
         switch projection {
         case .epsg3857:
@@ -400,6 +446,10 @@ extension Coordinate3D {
 extension Coordinate3D: Projectable {
 
     /// Reproject this coordinate.
+    ///
+    /// - Parameters:
+    ///    - newProjection: The target projection
+    /// - Returns: A new coordinate in the requested projection
     public func projected(to newProjection: Projection) -> Coordinate3D {
         guard newProjection != projection else { return self }
 
@@ -441,6 +491,10 @@ extension Coordinate3D: Projectable {
     }
 
     /// Project this coordinate's latitude.
+    ///
+    /// - Parameters:
+    ///    - newProjection: The target projection
+    /// - Returns: The latitude value in the requested projection
     public func latitudeProjected(to newProjection: Projection) -> Double {
         switch newProjection {
         case .epsg3857:
@@ -467,6 +521,10 @@ extension Coordinate3D: Projectable {
     }
 
     /// Project this coordinate's longitude.
+    ///
+    /// - Parameters:
+    ///    - newProjection: The target projection
+    /// - Returns: The longitude value in the requested projection
     public func longitudeProjected(to newProjection: Projection) -> Double {
         switch newProjection {
         case .epsg3857:
@@ -505,6 +563,9 @@ extension Coordinate3D: GeoJsonReadable {
     /// - Important: The third value in GeoJSON coordinates will always be ``altitude``, the fourth value
     ///              will be ``m`` if it exists. ``altitude`` can be a JSON `null` value.
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - json: A GeoJSON position array or a dictionary with `x`, `y`, `z` keys
+    /// - Returns: A coordinate, or `nil` if parsing fails
     public init?(json: Any?) {
         var pLongitude: Double?
         var pLatitude: Double?
@@ -539,6 +600,7 @@ extension Coordinate3D: GeoJsonReadable {
     /// - Important: The result JSON object will have a `null` value for the altitude
     ///              if the ``altitude`` is `nil` and ``m`` exists.
     /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
+    /// - Returns: An array of doubles (and `nil` placeholders) in GeoJSON order
     public var asJson: [Double?] {
         var result: [Double?] = (projection == .epsg4326 || projection == .noSRID
             ? [longitude, latitude]
@@ -562,6 +624,7 @@ extension Coordinate3D: GeoJsonReadable {
     ///
     /// - important: The returned array will always contain ``latitude`` and ``longitude``,
     ///              and ``altitude`` only if it exists.
+    /// - Returns: An array of doubles in GeoJSON order (no `nil` placeholders)
     public var asMinimalJson: [Double] {
         var result: [Double] = (projection == .epsg4326 || projection == .noSRID
             ? [longitude, latitude]
@@ -582,6 +645,9 @@ extension Coordinate3D {
     /// Dump the coordinate as JSON data.
     ///
     /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
+    /// - Parameters:
+    ///    - prettyPrinted: Whether to pretty-print the output (default `false`)
+    /// - Returns: JSON data, or `nil` if serialization fails
     public func asJsonData(prettyPrinted: Bool = false) -> Data? {
         var options: JSONSerialization.WritingOptions = []
         if prettyPrinted {
@@ -595,15 +661,21 @@ extension Coordinate3D {
     /// Dump the coordinate as JSON.
     ///
     /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
+    /// - Parameters:
+    ///    - prettyPrinted: Whether to pretty-print the output (default `false`)
+    /// - Returns: A JSON string, or `nil` if serialization fails
     public func asJsonString(prettyPrinted: Bool = false) -> String? {
         guard let data = asJsonData(prettyPrinted: prettyPrinted) else { return nil }
 
-        return String(data: data, encoding: .utf8)!
+        return String(data: data, encoding: .utf8)
     }
 
     /// Write the coordinate in it's JSON representation to a file.
     ///
     /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
+    /// - Parameters:
+    ///    - url: The file URL to write to
+    ///    - prettyPrinted: Whether to pretty-print the output (default `false`)
     /// - Returns: `true` if the write succeeded, `false` if serialization failed.
     @discardableResult
     public func write(to url: URL, prettyPrinted: Bool = false) -> Bool {
@@ -626,6 +698,7 @@ extension Sequence<Coordinate3D> {
     /// Returns all elements as an array of JSON objects
     ///
     /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
+    /// - Returns: An array of GeoJSON position arrays
     public var asJson: [[Double?]] {
         self.map(\.asJson)
     }
@@ -658,6 +731,12 @@ extension Coordinate3D: Equatable {
     /// Compares two coordinates with the given deltas.
     ///
     /// - note: The `other` coordinate will be projected to the projection of the reveiver.
+    /// - Parameters:
+    ///    - other: The coordinate to compare against
+    ///    - includingAltitude: Whether to compare altitude (default `true`)
+    ///    - equalityDelta: The horizontal tolerance (default `GISTool.equalityDelta`)
+    ///    - altitudeDelta: The vertical tolerance (default `0.0`)
+    /// - Returns: `true` if the coordinates are within the given deltas
     public func equals(
         other: Coordinate3D,
         includingAltitude: Bool = true,

--- a/Sources/GISTools/GeoJson/Feature.swift
+++ b/Sources/GISTools/GeoJson/Feature.swift
@@ -115,6 +115,12 @@ public struct Feature:
     public var foreignMembers: [String: Sendable] = [:]
 
     /// Create a ``Feature`` from any ``GeoJsonGeometry`` object.
+    ///
+    /// - Parameters:
+    ///    - geometry: The geometry object
+    ///    - id: An optional identifier
+    ///    - properties: A dictionary of properties
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the geometry
     public init(
         _ geometry: GeoJsonGeometry,
         id: Identifier? = nil,
@@ -131,11 +137,20 @@ public struct Feature:
     }
 
     /// Try to initialize a Feature from any JSON object.
+    ///
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    /// - Returns: A feature, or `nil` if the input is invalid
     public init?(json: Any?) {
         self.init(json: json, calculateBoundingBox: false)
     }
 
     /// Try to initialize a Feature from JSON and calculate a bounding box if necessary.
+    ///
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the geometry
+    /// - Returns: A feature, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
         guard let geoJson = json as? [String: Sendable],
               Feature.isValid(geoJson: geoJson),
@@ -162,6 +177,8 @@ public struct Feature:
     }
 
     /// The receiver as a JSON object.
+    ///
+    /// - Returns: A GeoJSON dictionary
     public var asJson: [String: Sendable] {
         var result: [String: Sendable] = [
             "type": GeoJsonType.feature.rawValue,
@@ -185,6 +202,9 @@ public struct Feature:
 extension Feature {
 
     /// Update the bounding box, optionally only if it hasn't been calculated yet.
+    ///
+    /// - Parameter onlyIfNecessary: Only update if the receiver doesn't already have one
+    /// - Returns: The updated bounding box
     @discardableResult
     public mutating func updateBoundingBox(
         onlyIfNecessary ifNecessary: Bool = true
@@ -198,11 +218,16 @@ extension Feature {
     }
 
     /// Calculate the bounding box from the receiver's geometry.
+    ///
+    /// - Returns: The calculated bounding box, or `nil` if there is no geometry
     public func calculateBoundingBox() -> BoundingBox? {
         geometry.boundingBox ?? geometry.calculateBoundingBox()
     }
 
     /// Check if the receiver intersects with the given bounding box.
+    ///
+    /// - Parameter otherBoundingBox: The bounding box to check
+    /// - Returns: `true` if the bounding boxes intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if let boundingBox = boundingBox ?? calculateBoundingBox(),
             !boundingBox.intersects(otherBoundingBox)
@@ -237,6 +262,9 @@ extension Feature: Equatable {
 extension Feature {
 
     /// Reproject the receiver.
+    ///
+    /// - Parameter newProjection: The target projection
+    /// - Returns: A new feature in the requested projection
     public func projected(to newProjection: Projection) -> Feature {
         guard newProjection != projection else { return self }
 
@@ -256,6 +284,10 @@ extension Feature {
 extension Feature {
 
     /// Returns a property by key.
+    ///
+    /// - Parameters:
+    ///    - key: The property key
+    /// - Returns: The property value, or `nil` if the key doesn't exist or types don't match
     public func property<T: Sendable>(for key: String) -> T? {
         properties[key] as? T
     }
@@ -263,6 +295,9 @@ extension Feature {
     /// Set a property key/value pair.
     ///
     /// - important: `value` must be a valid JSON object or serialization will fail.
+    /// - Parameters:
+    ///    - value: The value to set (must be JSON-compatible)
+    ///    - key: The property key
     public mutating func setProperty(_ value: Sendable?, for key: String) {
         var updatedProperties = properties
         updatedProperties[key] = value
@@ -270,6 +305,10 @@ extension Feature {
     }
 
     /// Remove a property from the Feature.
+    ///
+    /// - Parameters:
+    ///    - key: The property key to remove
+    /// - Returns: The previous value, or `nil` if the key didn't exist
     @discardableResult
     public mutating func removeProperty(for key: String) -> Sendable? {
         var updatedProperties = properties

--- a/Sources/GISTools/GeoJson/FeatureCollection.swift
+++ b/Sources/GISTools/GeoJson/FeatureCollection.swift
@@ -36,11 +36,19 @@ public struct FeatureCollection:
     }
 
     /// Initialize a FeatureCollection with one Feature.
+    ///
+    /// - Parameters:
+    ///    - feature: The feature to include
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the feature
     public init(_ feature: Feature, calculateBoundingBox: Bool = false) {
         self.init([feature], calculateBoundingBox: calculateBoundingBox)
     }
 
     /// Initialize a FeatureCollection with some Features.
+    ///
+    /// - Parameters:
+    ///    - features: The features to include
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the features
     public init(_ features: [Feature], calculateBoundingBox: Bool = false) {
         self.features = features
 
@@ -50,6 +58,10 @@ public struct FeatureCollection:
     }
 
     /// Initialize a FeatureCollection with some geometry objects.
+    ///
+    /// - Parameters:
+    ///    - geometries: The geometry objects to create features from
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the geometries
     public init(_ geometries: [GeoJsonGeometry], calculateBoundingBox: Bool = false) {
         self.features = geometries.compactMap { Feature($0) }
 
@@ -59,6 +71,11 @@ public struct FeatureCollection:
     }
 
     /// Normalize any GeoJSON object into a FeatureCollection.
+    ///
+    /// - Parameters:
+    ///    - geoJson: Any GeoJSON object (FeatureCollection, Feature, or geometry)
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the features
+    /// - Returns: A feature collection, or `nil` if the input is not a valid GeoJSON object
     public init?(_ geoJson: GeoJson?, calculateBoundingBox: Bool = false) {
         guard let geoJson = geoJson else { return nil }
 
@@ -86,6 +103,10 @@ public struct FeatureCollection:
     }
 
     /// Try to initialize a FeatureCollection from any JSON object.
+    ///
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    /// - Returns: A feature collection, or `nil` if the input is invalid
     public init?(json: Any?) {
         self.init(json: json, calculateBoundingBox: false)
     }
@@ -95,6 +116,10 @@ public struct FeatureCollection:
     /// it into a FeatureCollection.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the features
+    /// - Returns: A feature collection, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
         guard let geoJson: GeoJson = FeatureCollection.tryCreate(json: json) else { return nil }
         self.init(geoJson, calculateBoundingBox: calculateBoundingBox)
@@ -123,6 +148,8 @@ public struct FeatureCollection:
     }
 
     /// The receiver as a JSON object.
+    ///
+    /// - Returns: A GeoJSON dictionary
     public var asJson: [String: Sendable] {
         var result: [String: Sendable] = [
             "type": GeoJsonType.featureCollection.rawValue,
@@ -142,6 +169,9 @@ public struct FeatureCollection:
 extension FeatureCollection {
 
     /// Update the bounding box, optionally only if it hasn't been calculated yet.
+    ///
+    /// - Parameter onlyIfNecessary: Only update if the receiver doesn't already have one
+    /// - Returns: The updated bounding box
     @discardableResult
     public mutating func updateBoundingBox(
         onlyIfNecessary ifNecessary: Bool = true
@@ -159,6 +189,8 @@ extension FeatureCollection {
     }
 
     /// Calculate the bounding box from the receiver's features.
+    ///
+    /// - Returns: The calculated bounding box, or `nil` if there are no features
     public func calculateBoundingBox() -> BoundingBox? {
         let featureBoundingBoxes: [BoundingBox] = features.compactMap({ $0.boundingBox ?? $0.calculateBoundingBox() })
         guard !featureBoundingBoxes.isEmpty else { return nil}
@@ -169,6 +201,9 @@ extension FeatureCollection {
     }
 
     /// Check if the receiver intersects with the given bounding box.
+    ///
+    /// - Parameter otherBoundingBox: The bounding box to check
+    /// - Returns: `true` if the bounding boxes intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if let boundingBox = boundingBox ?? calculateBoundingBox(),
            !boundingBox.intersects(otherBoundingBox)
@@ -199,6 +234,9 @@ extension FeatureCollection: Equatable {
 extension FeatureCollection {
 
     /// Reproject the receiver.
+    ///
+    /// - Parameter newProjection: The target projection
+    /// - Returns: A new feature collection in the requested projection
     public func projected(to newProjection: Projection) -> FeatureCollection {
         guard newProjection != projection else { return self }
 
@@ -218,6 +256,9 @@ extension FeatureCollection {
     /// Insert a Feature into the receiver.
     ///
     /// - note: `feature` must be in the same projection as the receiver.
+    /// - Parameters:
+    ///    - feature: The feature to insert
+    ///    - index: The index at which to insert
     public mutating func insertFeature(
         _ feature: Feature,
         atIndex index: Int
@@ -239,6 +280,8 @@ extension FeatureCollection {
     /// Append a Feature to the receiver.
     ///
     /// - note: `feature` must be in the same projection as the receiver.
+    /// - Parameters:
+    ///    - feature: The feature to append
     public mutating func appendFeature(_ feature: Feature) {
         guard features.count == 0 || projection == feature.projection else { return }
 
@@ -250,6 +293,10 @@ extension FeatureCollection {
     }
 
     /// Remove a Feature from the receiver.
+    ///
+    /// - Parameters:
+    ///    - index: The index of the feature to remove
+    /// - Returns: The removed feature, or `nil` if the index is out of bounds
     @discardableResult
     public mutating func removeFeature(at index: Int) -> Feature? {
         guard index >= 0, index < features.count else { return nil }
@@ -264,16 +311,25 @@ extension FeatureCollection {
     }
 
     /// Map Features in-place.
+    ///
+    /// - Parameters:
+    ///    - transform: The closure to apply to each feature
     public mutating func mapFeatures(_ transform: (Feature) -> Feature) {
         features = features.map(transform)
     }
 
     /// Map Features in-place, removing *nil* values.
+    ///
+    /// - Parameters:
+    ///    - transform: The closure to apply to each feature
     public mutating func compactMapFeatures(_ transform: (Feature) -> Feature?) {
         features = features.compactMap(transform)
     }
 
     /// Filter Features in-place.
+    ///
+    /// - Parameters:
+    ///    - isIncluded: The closure to test each feature
     public mutating func filterFeatures(_ isIncluded: (Feature) -> Bool) {
         features = features.filter(isIncluded)
     }
@@ -281,6 +337,9 @@ extension FeatureCollection {
     /// Divide Features by a property value.
     ///
     /// Features where the `key` function returns nil will be discarded.
+    /// - Parameters:
+    ///    - key: A closure that returns a grouping key for each feature
+    /// - Returns: A dictionary mapping keys to arrays of features
     public func divideFeatures(by key: (Feature) -> String?) -> [String: [Feature]] {
         return features.reduce(into: [:]) { partialResult, feature in
             guard let key = key(feature) else { return }

--- a/Sources/GISTools/GeoJson/FeatureCollection.swift
+++ b/Sources/GISTools/GeoJson/FeatureCollection.swift
@@ -340,7 +340,7 @@ extension FeatureCollection {
     /// - Parameters:
     ///    - key: A closure that returns a grouping key for each feature
     /// - Returns: A dictionary mapping keys to arrays of features
-    public func divideFeatures(by key: (Feature) -> String?) -> [String: [Feature]] {
+    public func divideFeatures<T: Hashable>(by key: (Feature) -> T?) -> [T: [Feature]] {
         return features.reduce(into: [:]) { partialResult, feature in
             guard let key = key(feature) else { return }
 

--- a/Sources/GISTools/GeoJson/GeoJson.swift
+++ b/Sources/GISTools/GeoJson/GeoJson.swift
@@ -177,12 +177,22 @@ public protocol PolygonGeometry: GeoJsonGeometry {
     var polygons: [Polygon] { get }
 
     /// Check if this `(Multi)Polygon` contains *Coordinate3D*.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The coordinate to test
+    ///    - ignoringBoundary: If `true`, points on the boundary are not considered inside
+    /// - Returns: `true` if the coordinate lies within the polygon
     func contains(
         _ coordinate: Coordinate3D,
         ignoringBoundary: Bool
     ) -> Bool
 
     /// Check if this `(Multi)Polygon` contains *Point*.
+    ///
+    /// - Parameters:
+    ///    - point: The point to test
+    ///    - ignoringBoundary: If `true`, points on the boundary are not considered inside
+    /// - Returns: `true` if the point lies within the polygon
     func contains(
         _ point: Point,
         ignoringBoundary: Bool

--- a/Sources/GISTools/GeoJson/GeoJsonCodable.swift
+++ b/Sources/GISTools/GeoJson/GeoJsonCodable.swift
@@ -9,6 +9,8 @@ extension GeoJson {
     /// Try to initialize a GeoJSON object from a Decoder.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - decoder: The decoder to read data from
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: GeoJsonCodingKey.self)
         let json = container.decodeGeoJsonDictionary()
@@ -23,6 +25,8 @@ extension GeoJson {
     /// Write the GeoJSON object to an Encoder.
     ///
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
+    /// - Parameters:
+    ///    - encoder: The encoder to write data to
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: GeoJsonCodingKey.self)
 
@@ -36,6 +40,8 @@ extension BoundingBox: Codable {
     /// Try to initialize a BoundingBox from a Decoder.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - decoder: The decoder to read data from
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
         let json = container.decodeGeoJsonArray()
@@ -50,6 +56,8 @@ extension BoundingBox: Codable {
     /// Write the BoundingBox to an Encoder.
     ///
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
+    /// - Parameters:
+    ///    - encoder: The encoder to write data to
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
 
@@ -65,6 +73,8 @@ extension Coordinate3D: Codable {
     /// Try to initialize a Coordinate3D from a Decoder.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - decoder: The decoder to read data from
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
         let json = container.decodeGeoJsonArray()
@@ -79,6 +89,8 @@ extension Coordinate3D: Codable {
     /// Write the Coordinate3D to an Encoder.
     ///
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
+    /// - Parameters:
+    ///    - encoder: The encoder to write data to
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
 

--- a/Sources/GISTools/GeoJson/GeoJsonCodable.swift
+++ b/Sources/GISTools/GeoJson/GeoJsonCodable.swift
@@ -13,7 +13,7 @@ extension GeoJson {
     ///    - decoder: The decoder to read data from
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: GeoJsonCodingKey.self)
-        let json = container.decodeGeoJsonDictionary()
+        let json = try container.decodeGeoJsonDictionary()
 
         guard let newObject = Self(json: json) else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Invalid JSON object"))
@@ -21,6 +21,12 @@ extension GeoJson {
 
         self = newObject
     }
+
+}
+
+// MARK: -
+
+extension GeoJson {
 
     /// Write the GeoJSON object to an Encoder.
     ///
@@ -44,7 +50,7 @@ extension BoundingBox: Codable {
     ///    - decoder: The decoder to read data from
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        let json = container.decodeGeoJsonArray()
+        let json = try container.decodeGeoJsonArray()
 
         guard let newObject = Self(json: json) else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Invalid JSON object"))
@@ -77,7 +83,7 @@ extension Coordinate3D: Codable {
     ///    - decoder: The decoder to read data from
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        let json = container.decodeGeoJsonArray()
+        let json = try container.decodeGeoJsonArray()
 
         guard let newObject = Self(json: json) else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Invalid JSON object"))
@@ -212,7 +218,10 @@ extension KeyedEncodingContainer where Key == GeoJsonCodingKey {
                 }
 
             default:
-                print("Missing conversion for (\(key), \(type(of: value)))")
+                throw EncodingError.invalidValue(value, EncodingError.Context(
+                    codingPath: codingPath + [codingKey],
+                    debugDescription: "Unsupported value type '\(type(of: value))' for key '\(key)'",
+                    underlyingError: nil))
             }
         }
     }
@@ -222,7 +231,7 @@ extension KeyedEncodingContainer where Key == GeoJsonCodingKey {
 extension KeyedDecodingContainer where Key == GeoJsonCodingKey {
 
     /// Decode a GeoJSON dictionary from the decoder's container.
-    fileprivate func decodeGeoJsonDictionary() -> [String: Any] {
+    fileprivate func decodeGeoJsonDictionary() throws -> [String: Any] {
         var result: [String: Any] = [:]
 
         for key in allKeys {
@@ -243,13 +252,16 @@ extension KeyedDecodingContainer where Key == GeoJsonCodingKey {
                 result[key.stringValue] = decoded
             }
             else if var decoded = try? nestedUnkeyedContainer(forKey: key) {
-                result[key.stringValue] = decoded.decodeGeoJsonArray()
+                result[key.stringValue] = try decoded.decodeGeoJsonArray()
             }
             else if let decoded = try? nestedContainer(keyedBy: GeoJsonCodingKey.self, forKey: key) {
-                result[key.stringValue] = decoded.decodeGeoJsonDictionary()
+                result[key.stringValue] = try decoded.decodeGeoJsonDictionary()
             }
             else {
-                print("Missing conversion for \(key.stringValue)")
+                throw DecodingError.dataCorrupted(DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Missing conversion for key '\(key.stringValue)'",
+                    underlyingError: nil))
             }
         }
 
@@ -261,7 +273,7 @@ extension KeyedDecodingContainer where Key == GeoJsonCodingKey {
 extension UnkeyedDecodingContainer {
 
     /// Decode a GeoJSON array from the decoder's unkeyed container.
-    fileprivate mutating func decodeGeoJsonArray() -> [Any?] {
+    fileprivate mutating func decodeGeoJsonArray() throws -> [Any?] {
         var result: [Any?] = []
 
         while !isAtEnd {
@@ -285,13 +297,16 @@ extension UnkeyedDecodingContainer {
                 result.append(nil)
             }
             else if var decoded = try? nestedUnkeyedContainer() {
-                result.append(decoded.decodeGeoJsonArray())
+                result.append(try decoded.decodeGeoJsonArray())
             }
             else if let decoded = try? nestedContainer(keyedBy: GeoJsonCodingKey.self) {
-                result.append(decoded.decodeGeoJsonDictionary())
+                result.append(try decoded.decodeGeoJsonDictionary())
             }
             else {
-                print("Missing conversion while decoding an array")
+                throw DecodingError.dataCorrupted(DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Missing conversion while decoding an array element",
+                    underlyingError: nil))
             }
         }
 

--- a/Sources/GISTools/GeoJson/GeoJsonConvertible.swift
+++ b/Sources/GISTools/GeoJson/GeoJsonConvertible.swift
@@ -20,6 +20,8 @@ extension GeoJsonReadable {
 
     /// Try to initialize a GeoJSON object from a file/URL.
     ///
+    /// - Parameters:
+    ///    - url: The URL of the file to read
     /// - important: The source is expected to be in EPSG:4326.
     public init?(contentsOf url: URL) {
         guard let data = try? Data(contentsOf: url) else { return nil }
@@ -28,6 +30,8 @@ extension GeoJsonReadable {
 
     /// Try to initialize a GeoJSON object from a data object.
     ///
+    /// - Parameters:
+    ///    - jsonData: The JSON data
     /// - important: The source is expected to be in EPSG:4326.
     public init?(jsonData: Data) {
         guard let json = try? JSONSerialization.jsonObject(with: jsonData) else { return nil }
@@ -36,6 +40,8 @@ extension GeoJsonReadable {
 
     /// Try to initialize a GeoJSON object from a string.
     ///
+    /// - Parameters:
+    ///    - jsonString: The JSON string
     /// - important: The source is expected to be in EPSG:4326.
     public init?(jsonString: String) {
         guard let data = jsonString.data(using: .utf8),
@@ -62,6 +68,9 @@ extension GeoJsonWritable {
 
     /// Dump the object as JSON data.
     ///
+    /// - Parameters:
+    ///    - prettyPrinted: When `true`, format the output with indentation and sorted keys
+    /// - Returns: The JSON data, or `nil` if serialization failed
     /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
     public func asJsonData(prettyPrinted: Bool = false) -> Data? {
         var options: JSONSerialization.WritingOptions = []
@@ -75,16 +84,21 @@ extension GeoJsonWritable {
 
     /// Dump the object as a JSON string.
     ///
+    /// - Parameters:
+    ///    - prettyPrinted: When `true`, format the output with indentation and sorted keys
+    /// - Returns: The JSON string, or `nil` if serialization failed
     /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
     public func asJsonString(prettyPrinted: Bool = false) -> String? {
         guard let data = asJsonData(prettyPrinted: prettyPrinted) else { return nil }
 
-        return String(data: data, encoding: .utf8)!
+        return String(data: data, encoding: .utf8)
     }
 
     /// Write the object in it's JSON representation to a file.
     ///
-    /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
+    /// - Parameters:
+    ///    - url: The file URL to write to
+    ///    - prettyPrinted: When `true`, format the output with indentation and sorted keys
     /// - Returns: `true` if the write succeeded, `false` if serialization failed.
     @discardableResult
     public func write(to url: URL, prettyPrinted: Bool = false) -> Bool {
@@ -108,6 +122,7 @@ extension Sequence where Self.Iterator.Element: GeoJsonWritable {
 
     /// Returns all elements as an array of JSON objects
     ///
+    /// - Returns: An array of JSON dictionaries
     /// - important: Always projected to EPSG:4326, unless the coordinate has no SRID.
     public var asJson: [[String: Sendable]] {
         self.map({ $0.asJson })

--- a/Sources/GISTools/GeoJson/GeoJsonReader.swift
+++ b/Sources/GISTools/GeoJson/GeoJsonReader.swift
@@ -5,6 +5,9 @@ public enum GeoJsonReader {
 
     /// Try to initialize a GeoJSON object from any Swift object.
     ///
+    /// - Parameters:
+    ///    - json: A GeoJSON-compatible Swift object
+    /// - Returns: A GeoJson object, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public static func geoJsonFrom(json: Any?) -> GeoJson? {
         // Need a concrete type...
@@ -13,6 +16,9 @@ public enum GeoJsonReader {
 
     /// Try to initialize a GeoJSON object from a file.
     ///
+    /// - Parameters:
+    ///    - url: The URL of the file to read
+    /// - Returns: A GeoJson object, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public static func geoJsonFrom(contentsOf url: URL) -> GeoJson? {
         geoJsonFrom(json: try? Data(contentsOf: url))
@@ -20,6 +26,9 @@ public enum GeoJsonReader {
 
     /// Try to initialize a GeoJSON object from a data object.
     ///
+    /// - Parameters:
+    ///    - jsonData: The JSON data
+    /// - Returns: A GeoJson object, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public static func geoJsonFrom(jsonData: Data) -> GeoJson? {
         geoJsonFrom(json: try? JSONSerialization.jsonObject(with: jsonData))
@@ -27,6 +36,9 @@ public enum GeoJsonReader {
 
     /// Try to initialize a GeoJSON object from a string.
     ///
+    /// - Parameters:
+    ///    - jsonString: The JSON string
+    /// - Returns: A GeoJson object, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public static func geoJsonFrom(jsonString: String) -> GeoJson? {
         guard let data = jsonString.data(using: .utf8),

--- a/Sources/GISTools/GeoJson/GeometryCollection.swift
+++ b/Sources/GISTools/GeoJson/GeometryCollection.swift
@@ -28,11 +28,19 @@ public struct GeometryCollection: GeoJsonGeometry {
     public var foreignMembers: [String: Sendable] = [:]
 
     /// Initialize a GeometryCollection with a geometry object.
+    ///
+    /// - Parameters:
+    ///    - geometry: The geometry object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the geometry
     public init(_ geometry: GeoJsonGeometry, calculateBoundingBox: Bool = false) {
         self.init([geometry], calculateBoundingBox: calculateBoundingBox)
     }
 
     /// Initialize a GeometryCollection with some geometry objects.
+    ///
+    /// - Parameters:
+    ///    - geometries: The geometry objects
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the geometries
     public init(_ geometries: [GeoJsonGeometry], calculateBoundingBox: Bool = false) {
         self.geometries = geometries
 
@@ -44,15 +52,20 @@ public struct GeometryCollection: GeoJsonGeometry {
     /// Try to initialize a GeometryCollection from any GeoJSON object.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    /// - Returns: A geometry collection, or `nil` if the input is invalid
     public init?(json: Any?) {
         self.init(json: json, calculateBoundingBox: false)
     }
 
     /// Try to initialize a GeometryCollection from any GeoJSON object.
     ///
-    /// - parameter json: A GeoJSON object.
-    /// - parameter calculateBoundingBox: When true, calculate the bounding box from the coordinates.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Returns: A geometry collection, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
         guard let geoJson = json as? [String: Sendable],
               GeometryCollection.isValid(geoJson: geoJson),
@@ -78,6 +91,7 @@ public struct GeometryCollection: GeoJsonGeometry {
     /// The receiver represented as a JSON dictionary.
     ///
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
+    /// - Returns: A GeoJSON dictionary
     public var asJson: [String: Sendable] {
         var result: [String: Sendable] = [
             "type": GeoJsonType.geometryCollection.rawValue,
@@ -98,7 +112,8 @@ extension GeometryCollection {
 
     /// Update the receiver's bounding box.
     ///
-    /// - parameter ifNecessary: Only update if the receiver doesn't already have one.
+    /// - Parameter onlyIfNecessary: Only update if the receiver doesn't already have one
+    /// - Returns: The updated bounding box
     @discardableResult
     public mutating func updateBoundingBox(
         onlyIfNecessary ifNecessary: Bool = true
@@ -116,6 +131,8 @@ extension GeometryCollection {
     }
 
     /// Calculate and return the receiver's bounding box by combining all geometry bounding boxes.
+    ///
+    /// - Returns: The calculated bounding box, or `nil` if there are no geometries
     public func calculateBoundingBox() -> BoundingBox? {
         let geometryBoundingBoxes: [BoundingBox] = geometries.compactMap({ $0.boundingBox ?? $0.calculateBoundingBox() })
         guard !geometryBoundingBoxes.isEmpty else { return nil }
@@ -127,7 +144,8 @@ extension GeometryCollection {
 
     /// Check if the receiver intersects the other bounding box.
     ///
-    /// - parameter otherBoundingBox: The bounding box to check.
+    /// - Parameter otherBoundingBox: The bounding box to check
+    /// - Returns: `true` if the bounding boxes intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if let boundingBox = boundingBox,
            !boundingBox.intersects(otherBoundingBox)
@@ -160,7 +178,8 @@ extension GeometryCollection {
 
     /// Returns the receiver projected to a different projection.
     ///
-    /// - parameter newProjection: The target projection.
+    /// - Parameter newProjection: The target projection
+    /// - Returns: A new geometry collection in the requested projection
     public func projected(to newProjection: Projection) -> GeometryCollection {
         guard newProjection != projection else { return self }
 
@@ -180,6 +199,9 @@ extension GeometryCollection {
     /// Insert a GeoJsonGeometry into the receiver.
     ///
     /// - note: `geometry` must be in the same projection as the receiver.
+    /// - Parameters:
+    ///    - geometry: The geometry to insert
+    ///    - index: The index at which to insert
     public mutating func insertGeometry(
         _ geometry: GeoJsonGeometry,
         atIndex index: Int
@@ -201,6 +223,8 @@ extension GeometryCollection {
     /// Append a GeoJsonGeometry to the receiver.
     ///
     /// - note: `geometry` must be in the same projection as the receiver.
+    /// - Parameters:
+    ///    - geometry: The geometry to append
     public mutating func appendGeometry(_ geometry: GeoJsonGeometry) {
         guard geometries.count == 0 || projection == geometry.projection else { return }
 
@@ -212,6 +236,10 @@ extension GeometryCollection {
     }
 
     /// Remove a GeoJsonGeometry from the receiver.
+    ///
+    /// - Parameters:
+    ///    - index: The index of the geometry to remove
+    /// - Returns: The removed geometry, or `nil` if the index is out of bounds
     @discardableResult
     public mutating func removeGeometry(at index: Int) -> GeoJsonGeometry? {
         guard index >= 0, index < geometries.count else { return nil }
@@ -226,16 +254,25 @@ extension GeometryCollection {
     }
 
     /// Map Geometries in-place.
+    ///
+    /// - Parameters:
+    ///    - transform: The closure to apply to each geometry
     public mutating func mapGeometries(_ transform: (GeoJsonGeometry) -> GeoJsonGeometry) {
         geometries = geometries.map(transform)
     }
 
     /// Map Geometries in-place, removing *nil* values.
+    ///
+    /// - Parameters:
+    ///    - transform: The closure to apply to each geometry
     public mutating func compactMapGeometries(_ transform: (GeoJsonGeometry) -> GeoJsonGeometry?) {
         geometries = geometries.compactMap(transform)
     }
 
     /// Filter Geometries in-place.
+    ///
+    /// - Parameters:
+    ///    - isIncluded: The closure to test each geometry
     public mutating func filterGeometries(_ isIncluded: (GeoJsonGeometry) -> Bool) {
         geometries = geometries.filter(isIncluded)
     }

--- a/Sources/GISTools/GeoJson/LineSegment.swift
+++ b/Sources/GISTools/GeoJson/LineSegment.swift
@@ -57,7 +57,9 @@ extension LineSegment: Projectable {
 
     /// Returns the receiver projected to a different projection.
     ///
-    /// - parameter newProjection: The target projection.
+    /// - Parameters:
+    ///    - newProjection: The target projection
+    /// - Returns: A new `LineSegment` in the target projection
     public func projected(to newProjection: Projection) -> LineSegment {
         guard newProjection != projection else { return self }
 
@@ -76,6 +78,12 @@ extension LineSegment: Projectable {
 extension LineSegment {
 
     /// Initialize a LineSegment with two coordinates.
+    ///
+    /// - Parameters:
+    ///    - first: The segment's first coordinate
+    ///    - second: The segment's second coordinate
+    ///    - index: The index within a `LineString`, if applicable
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(
         first: CLLocationCoordinate2D,
         second: CLLocationCoordinate2D,
@@ -88,7 +96,13 @@ extension LineSegment {
                   calculateBoundingBox: calculateBoundingBox)
     }
 
-    /// Initialize a LineSegment with two locations.
+    /// Initialize a LineSegment with two coordinates.
+    ///
+    /// - Parameters:
+    ///    - first: The segment's first coordinate
+    ///    - second: The segment's second coordinate
+    ///    - index: The index within a `LineString`, if applicable
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(
         first: CLLocation,
         second: CLLocation,
@@ -109,13 +123,17 @@ extension LineSegment {
 extension LineSegment: BoundingBoxRepresentable {
 
     /// Calculate and return the segment's bounding box.
+    ///
+    /// - Returns: The bounding box, or `nil` if it could not be calculated
     public func calculateBoundingBox() -> BoundingBox? {
         BoundingBox(coordinates: coordinates)
     }
 
     /// Check if the receiver intersects the other bounding box.
     ///
-    /// - parameter otherBoundingBox: The bounding box to check.
+    /// - Parameters:
+    ///    - otherBoundingBox: The bounding box to check
+    /// - Returns: `true` if the geometries intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if let boundingBox = boundingBox ?? calculateBoundingBox(),
            !boundingBox.intersects(otherBoundingBox)

--- a/Sources/GISTools/GeoJson/LineString.swift
+++ b/Sources/GISTools/GeoJson/LineString.swift
@@ -44,6 +44,11 @@ public struct LineString:
     }
 
     /// Try to initialize a LineString with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates of the line string
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A line string, or `nil` if there are fewer than 2 coordinates
     public init?(_ coordinates: [Coordinate3D], calculateBoundingBox: Bool = false) {
         guard coordinates.count >= 2 else { return nil }
 
@@ -51,6 +56,10 @@ public struct LineString:
     }
 
     /// Initialize a LineString with some coordinates, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates of the line string
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked coordinates: [Coordinate3D], calculateBoundingBox: Bool = false) {
         self.coordinates = coordinates
 
@@ -60,6 +69,10 @@ public struct LineString:
     }
 
     /// Initialize a LineString with a LineSegment.
+    ///
+    /// - Parameters:
+    ///    - lineSegment: The line segment to convert
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(_ lineSegment: LineSegment, calculateBoundingBox: Bool = false) {
         self.coordinates = lineSegment.coordinates
 
@@ -69,6 +82,11 @@ public struct LineString:
     }
 
     /// Try to initialize a LineString with some LineSegments.
+    ///
+    /// - Parameters:
+    ///    - lineSegments: The line segments to join
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A line string, or `nil` if the segments don't form a valid line
     public init?(_ lineSegments: [LineSegment], calculateBoundingBox: Bool = false) {
         guard !lineSegments.isEmpty else { return nil }
 
@@ -99,15 +117,20 @@ public struct LineString:
     /// Try to initialize a LineString from any GeoJSON object.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    /// - Returns: A line string, or `nil` if the input is invalid
     public init?(json: Any?) {
         self.init(json: json, calculateBoundingBox: false)
     }
 
     /// Try to initialize a LineString from any GeoJSON object.
     ///
-    /// - parameter json: A GeoJSON object.
-    /// - parameter calculateBoundingBox: When true, calculate the bounding box from the coordinates.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Returns: A line string, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
         guard let geoJson = json as? [String: Sendable],
               LineString.isValid(geoJson: geoJson),
@@ -133,6 +156,7 @@ public struct LineString:
     /// The receiver represented as a JSON dictionary.
     ///
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
+    /// - Returns: A GeoJSON dictionary
     public var asJson: [String: Sendable] {
         var result: [String: Sendable] = [
             "type": GeoJsonType.lineString.rawValue,
@@ -152,11 +176,15 @@ public struct LineString:
 extension LineString {
 
     /// The receiver's first coordinate.
+    ///
+    /// - Returns: The first coordinate, or `nil` if the line string is empty
     public var firstCoordinate: Coordinate3D? {
         coordinates.first
     }
 
     /// The receiver's last coordinate.
+    ///
+    /// - Returns: The last coordinate, or `nil` if the line string is empty
     public var lastCoordinate: Coordinate3D? {
         coordinates.last
     }
@@ -169,7 +197,8 @@ extension LineString {
 
     /// Returns the receiver projected to a different projection.
     ///
-    /// - parameter newProjection: The target projection.
+    /// - Parameter newProjection: The target projection.
+    /// - Returns: A new line string in the requested projection
     public func projected(to newProjection: Projection) -> LineString {
         guard newProjection != projection else { return self }
 
@@ -188,11 +217,21 @@ extension LineString {
 extension LineString {
 
     /// Try to initialize a LineString with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates of the line string
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A line string, or `nil` if there are fewer than 2 coordinates
     public init?(_ coordinates: [CLLocationCoordinate2D], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ Coordinate3D($0) }), calculateBoundingBox: calculateBoundingBox)
     }
 
     /// Try to initialize a LineString with some locations.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The locations of the line string
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A line string, or `nil` if there are fewer than 2 locations
     public init?(_ coordinates: [CLLocation], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ Coordinate3D($0) }), calculateBoundingBox: calculateBoundingBox)
     }
@@ -205,13 +244,16 @@ extension LineString {
 extension LineString {
 
     /// Calculate and return the receiver's bounding box.
+    ///
+    /// - Returns: The calculated bounding box, or `nil` if there are no coordinates
     public func calculateBoundingBox() -> BoundingBox? {
         BoundingBox(coordinates: coordinates)
     }
 
     /// Check if the receiver intersects the other bounding box.
     ///
-    /// - parameter otherBoundingBox: The bounding box to check.
+    /// - Parameter otherBoundingBox: The bounding box to check.
+    /// - Returns: `true` if the bounding boxes intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if let boundingBox = boundingBox ?? calculateBoundingBox(),
            !boundingBox.intersects(otherBoundingBox)

--- a/Sources/GISTools/GeoJson/MultiLineString.swift
+++ b/Sources/GISTools/GeoJson/MultiLineString.swift
@@ -49,6 +49,11 @@ public struct MultiLineString:
     }
 
     /// Try to initialize a MultiLineString with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The array of line string coordinates
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A multi line string, or `nil` if the coordinates are invalid
     public init?(_ coordinates: [[Coordinate3D]], calculateBoundingBox: Bool = false) {
         guard !coordinates.isEmpty,
               coordinates[0].count >= 2
@@ -58,6 +63,10 @@ public struct MultiLineString:
     }
 
     /// Try to initialize a MultiLineString with some coordinates, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The array of line string coordinates
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked coordinates: [[Coordinate3D]], calculateBoundingBox: Bool = false) {
         self.coordinates = coordinates
 
@@ -67,6 +76,11 @@ public struct MultiLineString:
     }
 
     /// Try to initialize a MultiLineString with some LineStrings.
+    ///
+    /// - Parameters:
+    ///    - lineStrings: The line strings
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A multi line string, or `nil` if the array is empty
     public init?(_ lineStrings: [LineString], calculateBoundingBox: Bool = false) {
         guard !lineStrings.isEmpty else { return nil }
 
@@ -74,6 +88,10 @@ public struct MultiLineString:
     }
 
     /// Try to initialize a MultiLineString with some LineStrings, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - lineStrings: The line strings
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked lineStrings: [LineString], calculateBoundingBox: Bool = false) {
         self.lineStrings = lineStrings
 
@@ -83,6 +101,11 @@ public struct MultiLineString:
     }
 
     /// Try to initialize a MultiLineString with some LineSegments. Each LineSegment will result in one LineString.
+    ///
+    /// - Parameters:
+    ///    - lineSegments: The line segments (each becomes one line string)
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A multi line string, or `nil` if the array is empty
     public init?(_ lineSegments: [LineSegment], calculateBoundingBox: Bool = false) {
         guard !lineSegments.isEmpty else { return nil }
 
@@ -90,6 +113,10 @@ public struct MultiLineString:
     }
 
     /// Try to initialize a MultiLineString with some LineSegments, don't check the coordinates for validity. Each LineSegment will result in one LineString.
+    ///
+    /// - Parameters:
+    ///    - lineSegments: The line segments (each becomes one line string)
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked lineSegments: [LineSegment], calculateBoundingBox: Bool = false) {
         self.coordinates = lineSegments.map({ $0.coordinates })
 
@@ -101,15 +128,20 @@ public struct MultiLineString:
     /// Try to initialize a MultiLineString from any GeoJSON object.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    /// - Returns: A multi line string, or `nil` if the input is invalid
     public init?(json: Any?) {
         self.init(json: json, calculateBoundingBox: false)
     }
 
     /// Try to initialize a MultiLineString from any GeoJSON object.
     ///
-    /// - parameter json: A GeoJSON object.
-    /// - parameter calculateBoundingBox: When true, calculate the bounding box from the coordinates.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Returns: A multi line string, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
         guard let geoJson = json as? [String: Sendable],
               MultiLineString.isValid(geoJson: geoJson),
@@ -135,6 +167,7 @@ public struct MultiLineString:
     /// The receiver represented as a JSON dictionary.
     ///
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
+    /// - Returns: A GeoJSON dictionary
     public var asJson: [String: Sendable] {
         var result: [String: Sendable] = [
             "type": GeoJsonType.multiLineString.rawValue,
@@ -154,11 +187,15 @@ public struct MultiLineString:
 extension MultiLineString {
 
     /// The receiver's first coordinate.
+    ///
+    /// - Returns: The first coordinate of the first line string, or `nil` if empty
     public var firstCoordinate: Coordinate3D? {
         coordinates.first?.first
     }
 
     /// The receiver's last coordinate.
+    ///
+    /// - Returns: The last coordinate of the last line string, or `nil` if empty
     public var lastCoordinate: Coordinate3D? {
         coordinates.last?.last
     }
@@ -171,7 +208,8 @@ extension MultiLineString {
 
     /// Returns the receiver projected to a different projection.
     ///
-    /// - parameter newProjection: The target projection.
+    /// - Parameter newProjection: The target projection.
+    /// - Returns: A new multi line string in the requested projection
     public func projected(to newProjection: Projection) -> MultiLineString {
         guard newProjection != projection else { return self }
 
@@ -190,11 +228,21 @@ extension MultiLineString {
 extension MultiLineString {
 
     /// Try to initialize a MultiLineString with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The array of line string coordinates
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A multi line string, or `nil` if the coordinates are invalid
     public init?(_ coordinates: [[CLLocationCoordinate2D]], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ $0.map({ Coordinate3D($0) }) }), calculateBoundingBox: calculateBoundingBox)
     }
 
     /// Try to initialize a MultiLineString with some locations.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The array of line string locations
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A multi line string, or `nil` if the coordinates are invalid
     public init?(_ coordinates: [[CLLocation]], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ $0.map({ Coordinate3D($0) }) }), calculateBoundingBox: calculateBoundingBox)
     }
@@ -226,6 +274,8 @@ extension MultiLineString {
     }
 
     /// Calculate and return the receiver's bounding box.
+    ///
+    /// - Returns: The calculated bounding box, or `nil` if there are no coordinates
     public func calculateBoundingBox() -> BoundingBox? {
         let flattened: [Coordinate3D] = Array(coordinates.joined())
         return BoundingBox(coordinates: flattened)
@@ -233,7 +283,8 @@ extension MultiLineString {
 
     /// Check if the receiver intersects the other bounding box.
     ///
-    /// - parameter otherBoundingBox: The bounding box to check.
+    /// - Parameter otherBoundingBox: The bounding box to check.
+    /// - Returns: `true` if the bounding boxes intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if let boundingBox = boundingBox ?? calculateBoundingBox(),
            !boundingBox.intersects(otherBoundingBox)
@@ -266,6 +317,9 @@ extension MultiLineString {
     /// Insert a LineString into the receiver.
     ///
     /// - note: `linestring` must be in the same projection as the receiver.
+    /// - Parameters:
+    ///    - lineString: The line string to insert
+    ///    - index: The index at which to insert
     public mutating func insertLineString(
         _ lineString: LineString,
         atIndex index: Int
@@ -287,6 +341,8 @@ extension MultiLineString {
     /// Append a LineString to the receiver.
     ///
     /// - note: `linestring` must be in the same projection as the receiver.
+    /// - Parameters:
+    ///    - lineString: The line string to append
     public mutating func appendLineString(_ lineString: LineString) {
         guard lineStrings.count == 0 || projection == lineString.projection else { return }
 
@@ -298,6 +354,10 @@ extension MultiLineString {
     }
 
     /// Remove a LineString from the receiver.
+    ///
+    /// - Parameters:
+    ///    - index: The index of the line string to remove
+    /// - Returns: The removed line string, or `nil` if the index is out of bounds
     @discardableResult
     public mutating func removeLineString(at index: Int) -> LineString? {
         guard index >= 0, index < lineStrings.count else { return nil }
@@ -312,16 +372,25 @@ extension MultiLineString {
     }
 
     /// Map Linestrings in-place.
+    ///
+    /// - Parameters:
+    ///    - transform: The closure to apply to each line string
     public mutating func mapLinestrings(_ transform: (LineString) -> LineString) {
         lineStrings = lineStrings.map(transform)
     }
 
     /// Map Linestrings in-place, removing *nil* values.
+    ///
+    /// - Parameters:
+    ///    - transform: The closure to apply to each line string
     public mutating func compactMapLinestrings(_ transform: (LineString) -> LineString?) {
         lineStrings = lineStrings.compactMap(transform)
     }
 
     /// Filter Linestrings in-place.
+    ///
+    /// - Parameters:
+    ///    - isIncluded: The closure to test each line string
     public mutating func filterLinestrings(_ isIncluded: (LineString) -> Bool) {
         lineStrings = lineStrings.filter(isIncluded)
     }

--- a/Sources/GISTools/GeoJson/MultiPoint.swift
+++ b/Sources/GISTools/GeoJson/MultiPoint.swift
@@ -49,6 +49,10 @@ public struct MultiPoint:
     }
 
     /// Try to initialize a MultiPoint with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init?(_ coordinates: [Coordinate3D], calculateBoundingBox: Bool = false) {
         guard !coordinates.isEmpty else { return nil }
 
@@ -56,6 +60,10 @@ public struct MultiPoint:
     }
 
     /// Try to initialize a MultiPoint with some coordinates, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked coordinates: [Coordinate3D], calculateBoundingBox: Bool = false) {
         self.coordinates = coordinates
 
@@ -65,6 +73,10 @@ public struct MultiPoint:
     }
 
     /// Try to initialize a MultiPoint with some Points.
+    ///
+    /// - Parameters:
+    ///    - points: The points
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init?(_ points: [Point], calculateBoundingBox: Bool = false) {
         guard !points.isEmpty else { return nil }
 
@@ -72,6 +84,10 @@ public struct MultiPoint:
     }
 
     /// Try to initialize a MultiPoint with some Points, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - points: The points
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked points: [Point], calculateBoundingBox: Bool = false) {
         self.points = points
 
@@ -82,6 +98,9 @@ public struct MultiPoint:
 
     /// Try to initialize a MultiPoint from any GeoJSON object.
     ///
+    /// - Parameters:
+    ///    - json: A GeoJSON-compatible Swift object
+    /// - Returns: A `MultiPoint`, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public init?(json: Any?) {
         self.init(json: json, calculateBoundingBox: false)
@@ -89,8 +108,10 @@ public struct MultiPoint:
 
     /// Try to initialize a MultiPoint from any GeoJSON object.
     ///
-    /// - parameter json: A GeoJSON object.
-    /// - parameter calculateBoundingBox: When true, calculate the bounding box from the coordinates.
+    /// - Parameters:
+    ///    - json: A GeoJSON-compatible Swift object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A `MultiPoint`, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
         guard let geoJson = json as? [String: Sendable],
@@ -116,6 +137,7 @@ public struct MultiPoint:
 
     /// The receiver represented as a JSON dictionary.
     ///
+    /// - Returns: A JSON-compatible dictionary
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
     public var asJson: [String: Sendable] {
         var result: [String: Sendable] = [
@@ -139,7 +161,9 @@ extension MultiPoint {
 
     /// Returns the receiver projected to a different projection.
     ///
-    /// - parameter newProjection: The target projection.
+    /// - Parameters:
+    ///    - newProjection: The target projection
+    /// - Returns: A new `MultiPoint` in the target projection
     public func projected(to newProjection: Projection) -> MultiPoint {
         guard newProjection != projection else { return self }
 
@@ -158,11 +182,19 @@ extension MultiPoint {
 extension MultiPoint {
 
     /// Try to initialize a MultiPoint with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init?(_ coordinates: [CLLocationCoordinate2D], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ Coordinate3D($0) }), calculateBoundingBox: calculateBoundingBox)
     }
 
     /// Try to initialize a MultiPoint with some locations.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The locations
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init?(_ coordinates: [CLLocation], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ Coordinate3D($0) }), calculateBoundingBox: calculateBoundingBox)
     }
@@ -176,7 +208,9 @@ extension MultiPoint {
 
     /// Update the receiver's bounding box.
     ///
-    /// - parameter ifNecessary: Only update if the receiver doesn't already have one.
+    /// - Parameters:
+    ///    - ifNecessary: Only update if the receiver doesn't already have one
+    /// - Returns: The updated bounding box, or `nil` if it could not be calculated
     @discardableResult
     public mutating func updateBoundingBox(
         onlyIfNecessary ifNecessary: Bool = true
@@ -194,13 +228,17 @@ extension MultiPoint {
     }
 
     /// Calculate and return the receiver's bounding box.
+    ///
+    /// - Returns: The bounding box, or `nil` if it could not be calculated
     public func calculateBoundingBox() -> BoundingBox? {
         BoundingBox(coordinates: coordinates)
     }
 
     /// Check if the receiver intersects the other bounding box.
     ///
-    /// - parameter otherBoundingBox: The bounding box to check.
+    /// - Parameters:
+    ///    - otherBoundingBox: The bounding box to check
+    /// - Returns: `true` if the geometries intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if let boundingBox = boundingBox ?? calculateBoundingBox(),
            !boundingBox.intersects(otherBoundingBox)
@@ -232,6 +270,9 @@ extension MultiPoint {
 
     /// Insert a Point into the receiver.
     ///
+    /// - Parameters:
+    ///    - point: The point to insert
+    ///    - index: The index at which to insert
     /// - note: `point` must be in the same projection as the receiver.
     public mutating func insertPoint(
         _ point: Point,
@@ -253,6 +294,8 @@ extension MultiPoint {
 
     /// Append a Point to the receiver.
     ///
+    /// - Parameters:
+    ///    - point: The point to append
     /// - note: `point` must be in the same projection as the receiver.
     public mutating func appendPoint(_ point: Point) {
         guard points.count == 0 || projection == point.projection else { return }
@@ -265,6 +308,10 @@ extension MultiPoint {
     }
 
     /// Remove a Point from the receiver.
+    ///
+    /// - Parameters:
+    ///    - index: The index of the point to remove
+    /// - Returns: The removed point, or `nil` if the index is out of range
     @discardableResult
     public mutating func removePoint(at index: Int) -> Point? {
         guard index >= 0, index < points.count else { return nil }
@@ -279,16 +326,25 @@ extension MultiPoint {
     }
 
     /// Map Points in-place.
+    ///
+    /// - Parameters:
+    ///    - transform: The transform to apply to each point
     public mutating func mapPoints(_ transform: (Point) -> Point) {
         points = points.map(transform)
     }
 
     /// Map Points in-place, removing *nil* values.
+    ///
+    /// - Parameters:
+    ///    - transform: The transform to apply to each point
     public mutating func compactMapPoints(_ transform: (Point) -> Point?) {
         points = points.compactMap(transform)
     }
 
     /// Filter Points in-place.
+    ///
+    /// - Parameters:
+    ///    - isIncluded: A closure that determines whether a point should be kept
     public mutating func filterPoints(_ isIncluded: (Point) -> Bool) {
         points = points.filter(isIncluded)
     }

--- a/Sources/GISTools/GeoJson/MultiPolygon.swift
+++ b/Sources/GISTools/GeoJson/MultiPolygon.swift
@@ -49,6 +49,11 @@ public struct MultiPolygon:
     }
 
     /// Try to initialize a MultiPolygon with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The polygon coordinates
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A multi polygon, or `nil` if the coordinates are invalid
     public init?(_ coordinates: [[[Coordinate3D]]], calculateBoundingBox: Bool = false) {
         guard !coordinates.isEmpty,
               !coordinates[0].isEmpty,
@@ -59,6 +64,10 @@ public struct MultiPolygon:
     }
 
     /// Try to initialize a MultiPolygon with some coordinates, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The polygon coordinates
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked coordinates: [[[Coordinate3D]]], calculateBoundingBox: Bool = false) {
         self.coordinates = coordinates
 
@@ -68,6 +77,11 @@ public struct MultiPolygon:
     }
 
     /// Try to initialize a MultiPolygon with some Polygons.
+    ///
+    /// - Parameters:
+    ///    - polygons: The polygons
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A multi polygon, or `nil` if the array is empty
     public init?(_ polygons: [Polygon], calculateBoundingBox: Bool = false) {
         guard polygons.isNotEmpty else { return nil }
 
@@ -75,6 +89,10 @@ public struct MultiPolygon:
     }
 
     /// Try to initialize a MultiPolygon with some Polygons, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - polygons: The polygons
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked polygons: [Polygon], calculateBoundingBox: Bool = false) {
         self.polygons = polygons
 
@@ -86,15 +104,20 @@ public struct MultiPolygon:
     /// Try to initialize a MultiPolygon from any GeoJSON object.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    /// - Returns: A multi polygon, or `nil` if the input is invalid
     public init?(json: Any?) {
         self.init(json: json, calculateBoundingBox: false)
     }
 
     /// Try to initialize a MultiPolygon from any GeoJSON object.
     ///
-    /// - parameter json: A GeoJSON object.
-    /// - parameter calculateBoundingBox: When true, calculate the bounding box from the coordinates.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Returns: A multi polygon, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
         guard let geoJson = json as? [String: Sendable],
               MultiPolygon.isValid(geoJson: geoJson),
@@ -120,6 +143,7 @@ public struct MultiPolygon:
     /// The receiver represented as a JSON dictionary.
     ///
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
+    /// - Returns: A GeoJSON dictionary
     public var asJson: [String: Sendable] {
         var result: [String: Sendable] = [
             "type": GeoJsonType.multiPolygon.rawValue,
@@ -142,7 +166,8 @@ extension MultiPolygon {
 
     /// Returns the receiver projected to a different projection.
     ///
-    /// - parameter newProjection: The target projection.
+    /// - Parameter newProjection: The target projection.
+    /// - Returns: A new multi polygon in the requested projection
     public func projected(to newProjection: Projection) -> MultiPolygon {
         guard newProjection != projection else { return self }
 
@@ -161,11 +186,21 @@ extension MultiPolygon {
 extension MultiPolygon {
 
     /// Try to initialize a MultiPolygon with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The polygon coordinates
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A multi polygon, or `nil` if the coordinates are invalid
     public init?(_ coordinates: [[[CLLocationCoordinate2D]]], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ $0.map({ $0.map({ Coordinate3D($0) }) }) }), calculateBoundingBox: calculateBoundingBox)
     }
 
     /// Try to initialize a MultiPolygon with some locations.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The polygon locations
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A multi polygon, or `nil` if the coordinates are invalid
     public init?(_ coordinates: [[[CLLocation]]], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ $0.map({ $0.map({ Coordinate3D($0) }) }) }), calculateBoundingBox: calculateBoundingBox)
     }
@@ -197,13 +232,16 @@ extension MultiPolygon {
     }
 
     /// Calculate and return the receiver's bounding box.
+    ///
+    /// - Returns: The calculated bounding box, or `nil` if there are no coordinates
     public func calculateBoundingBox() -> BoundingBox? {
         BoundingBox(coordinates: Array(coordinates.map({ $0.first ?? [] }).joined()))
     }
 
     /// Check if the receiver intersects the other bounding box.
     ///
-    /// - parameter otherBoundingBox: The bounding box to check.
+    /// - Parameter otherBoundingBox: The bounding box to check.
+    /// - Returns: `true` if the bounding boxes intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if let boundingBox = boundingBox ?? calculateBoundingBox(),
            !boundingBox.intersects(otherBoundingBox)
@@ -223,7 +261,7 @@ extension MultiPolygon: Equatable {
         lhs: MultiPolygon,
         rhs: MultiPolygon
     ) -> Bool {
-        // TODO: The coordinats might be shifted (like [1, 2, 3] => [3, 1, 2])
+        // Fix: The coordinates might be shifted (like [1, 2, 3] => [3, 1, 2])
         return lhs.projection == rhs.projection
             && lhs.coordinates == rhs.coordinates
     }
@@ -237,6 +275,9 @@ extension MultiPolygon {
     /// Insert a Polygon into the receiver.
     ///
     /// - note: `polygon` must be in the same projection as the receiver.
+    /// - Parameters:
+    ///    - polygon: The polygon to insert
+    ///    - index: The index at which to insert
     public mutating func insertPolygon(
         _ polygon: Polygon,
         atIndex index: Int
@@ -258,6 +299,8 @@ extension MultiPolygon {
     /// Append a Polygon to the receiver.
     ///
     /// - note: `polygon` must be in the same projection as the receiver.
+    /// - Parameters:
+    ///    - polygon: The polygon to append
     public mutating func appendPolygon(_ polygon: Polygon) {
         guard polygons.count == 0 || projection == polygon.projection else { return }
 
@@ -269,6 +312,10 @@ extension MultiPolygon {
     }
 
     /// Remove a Polygon from the receiver.
+    ///
+    /// - Parameters:
+    ///    - index: The index of the polygon to remove
+    /// - Returns: The removed polygon, or `nil` if the index is out of bounds
     @discardableResult
     public mutating func removePolygon(at index: Int) -> Polygon? {
         guard index >= 0, index < polygons.count else { return nil }
@@ -283,16 +330,25 @@ extension MultiPolygon {
     }
 
     /// Map Polygons in-place.
+    ///
+    /// - Parameters:
+    ///    - transform: The closure to apply to each polygon
     public mutating func mapPolygons(_ transform: (Polygon) -> Polygon) {
         polygons = polygons.map(transform)
     }
 
     /// Map Polygons in-place, removing *nil* values.
+    ///
+    /// - Parameters:
+    ///    - transform: The closure to apply to each polygon
     public mutating func compactMapPolygons(_ transform: (Polygon) -> Polygon?) {
         polygons = polygons.compactMap(transform)
     }
 
     /// Filter Polygons in-place.
+    ///
+    /// - Parameters:
+    ///    - isIncluded: The closure to test each polygon
     public mutating func filterPolygons(_ isIncluded: (Polygon) -> Bool) {
         polygons = polygons.filter(isIncluded)
     }

--- a/Sources/GISTools/GeoJson/MultiPolygon.swift
+++ b/Sources/GISTools/GeoJson/MultiPolygon.swift
@@ -256,14 +256,13 @@ extension MultiPolygon {
 
 extension MultiPolygon: Equatable {
 
-    /// Check if two MultiPolygons are equal.
+    /// Check if two MultiPolygons are equal, accounting for shifted ring start vertices.
     public static func ==(
         lhs: MultiPolygon,
         rhs: MultiPolygon
     ) -> Bool {
-        // Fix: The coordinates might be shifted (like [1, 2, 3] => [3, 1, 2])
-        return lhs.projection == rhs.projection
-            && lhs.coordinates == rhs.coordinates
+        lhs.projection == rhs.projection
+        && lhs.polygons == rhs.polygons
     }
 
 }

--- a/Sources/GISTools/GeoJson/Point.swift
+++ b/Sources/GISTools/GeoJson/Point.swift
@@ -36,6 +36,10 @@ public struct Point: PointGeometry {
     }
 
     /// Initialize a Point with a coordinate.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The coordinate
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(_ coordinate: Coordinate3D, calculateBoundingBox: Bool = false) {
         self.coordinate = coordinate
 
@@ -46,6 +50,9 @@ public struct Point: PointGeometry {
 
     /// Try to initialize a Point from any GeoJSON object.
     ///
+    /// - Parameters:
+    ///    - json: A GeoJSON-compatible Swift object
+    /// - Returns: A `Point`, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public init?(json: Any?) {
         self.init(json: json, calculateBoundingBox: false)
@@ -53,8 +60,10 @@ public struct Point: PointGeometry {
 
     /// Try to initialize a Point from any GeoJSON object.
     ///
-    /// - parameter json: A GeoJSON object.
-    /// - parameter calculateBoundingBox: When true, calculate the bounding box from the coordinates.
+    /// - Parameters:
+    ///    - json: A GeoJSON-compatible Swift object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A `Point`, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
         guard let geoJson = json as? [String: Sendable],
@@ -80,6 +89,7 @@ public struct Point: PointGeometry {
 
     /// The receiver represented as a JSON dictionary.
     ///
+    /// - Returns: A JSON-compatible dictionary
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
     public var asJson: [String: Sendable] {
         var result: [String: Sendable] = [
@@ -103,7 +113,9 @@ extension Point {
 
     /// Returns the receiver projected to a different projection.
     ///
-    /// - parameter newProjection: The target projection.
+    /// - Parameters:
+    ///    - newProjection: The target projection
+    /// - Returns: A new `Point` in the target projection
     public func projected(to newProjection: Projection) -> Point {
         guard newProjection != projection else { return self }
 
@@ -122,11 +134,19 @@ extension Point {
 extension Point {
 
     /// Initialize a Point with a coordinate.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The coordinate
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(_ coordinate: CLLocationCoordinate2D, calculateBoundingBox: Bool = false) {
         self.init(Coordinate3D(coordinate), calculateBoundingBox: calculateBoundingBox)
     }
 
     /// Initialize a Point with a location.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The location
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(_ coordinate: CLLocation, calculateBoundingBox: Bool = false) {
         self.init(Coordinate3D(coordinate), calculateBoundingBox: calculateBoundingBox)
     }
@@ -139,13 +159,17 @@ extension Point {
 extension Point {
 
     /// Calculate and return the receiver's bounding box.
+    ///
+    /// - Returns: The bounding box, or `nil` if it could not be calculated
     public func calculateBoundingBox() -> BoundingBox? {
         BoundingBox(coordinates: [coordinate])
     }
 
     /// Check if the receiver intersects the other bounding box.
     ///
-    /// - parameter otherBoundingBox: The bounding box to check.
+    /// - Parameters:
+    ///    - otherBoundingBox: The bounding box to check
+    /// - Returns: `true` if the geometries intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         otherBoundingBox.contains(coordinate)
     }

--- a/Sources/GISTools/GeoJson/Polygon.swift
+++ b/Sources/GISTools/GeoJson/Polygon.swift
@@ -61,6 +61,11 @@ public struct Polygon:
     }
 
     /// Try to initialize a Polygon with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The ring coordinates (first array is the outer ring, subsequent are holes)
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A polygon, or `nil` if the coordinates are invalid
     public init?(_ coordinates: [[Coordinate3D]], calculateBoundingBox: Bool = false) {
         guard coordinates.isNotEmpty,
               coordinates[0].count >= 3
@@ -70,6 +75,10 @@ public struct Polygon:
     }
 
     /// Try to initialize a Polygon with some coordinates, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The ring coordinates (first array is the outer ring, subsequent are holes)
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked coordinates: [[Coordinate3D]], calculateBoundingBox: Bool = false) {
         self.coordinates = coordinates
 
@@ -79,13 +88,22 @@ public struct Polygon:
     }
 
     /// Try to initialize a Polygon with some Rings.
+    ///
+    /// - Parameters:
+    ///    - rings: The rings (first is the outer ring, subsequent are holes)
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A polygon, or `nil` if the rings array is empty
     public init?(_ rings: [Ring], calculateBoundingBox: Bool = false) {
-        guard !rings.isEmpty else { return nil }
+        guard rings.isNotEmpty else { return nil }
 
         self.init(unchecked: rings, calculateBoundingBox: calculateBoundingBox)
     }
 
     /// Try to initialize a Polygon with some Rings, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - rings: The rings (first is the outer ring, subsequent are holes)
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     public init(unchecked rings: [Ring], calculateBoundingBox: Bool = false) {
         self.coordinates = rings.map { $0.coordinates }
 
@@ -97,14 +115,18 @@ public struct Polygon:
     /// Try to initialize a Polygon from any GeoJSON object.
     ///
     /// - important: The source is expected to be in EPSG:4326.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    /// - Returns: A polygon, or `nil` if the input is invalid
     public init?(json: Any?) {
         self.init(json: json, calculateBoundingBox: false)
     }
 
     /// Try to initialize a Polygon from any GeoJSON object.
     ///
-    /// - parameter json: A GeoJSON object.
-    /// - parameter calculateBoundingBox: When true, calculate the bounding box from the coordinates.
+    /// - Parameters:
+    ///    - json: A GeoJSON object
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     /// - important: The source is expected to be in EPSG:4326.
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
         guard let geoJson = json as? [String: Sendable],
@@ -131,6 +153,7 @@ public struct Polygon:
     /// The receiver represented as a JSON dictionary.
     ///
     /// - important: Always projected to EPSG:4326, unless the receiver has no SRID.
+    /// - Returns: A GeoJSON dictionary
     public var asJson: [String: Sendable] {
         var result: [String: Sendable] = [
             "type": GeoJsonType.polygon.rawValue,
@@ -153,7 +176,8 @@ extension Polygon {
 
     /// Returns the receiver projected to a different projection.
     ///
-    /// - parameter newProjection: The target projection.
+    /// - Parameter newProjection: The target projection.
+    /// - Returns: A new polygon in the requested projection
     public func projected(to newProjection: Projection) -> Polygon {
         guard newProjection != projection else { return self }
 
@@ -172,11 +196,21 @@ extension Polygon {
 extension Polygon {
 
     /// Try to initialize a Polygon with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The ring coordinates (first array is the outer ring, subsequent are holes)
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A polygon, or `nil` if the coordinates are invalid
     public init?(_ coordinates: [[CLLocationCoordinate2D]], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ $0.map({ Coordinate3D($0) }) }), calculateBoundingBox: calculateBoundingBox)
     }
 
     /// Try to initialize a Polygon with some locations.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The ring locations (first array is the outer ring, subsequent are holes)
+    ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
+    /// - Returns: A polygon, or `nil` if the coordinates are invalid
     public init?(_ coordinates: [[CLLocation]], calculateBoundingBox: Bool = false) {
         self.init(coordinates.map({ $0.map({ Coordinate3D($0) }) }), calculateBoundingBox: calculateBoundingBox)
     }
@@ -189,6 +223,8 @@ extension Polygon {
 extension Polygon {
 
     /// Calculate and return the receiver's bounding box.
+    ///
+    /// - Returns: The calculated bounding box, or `nil` if there are no coordinates
     public func calculateBoundingBox() -> BoundingBox? {
         guard let coordinates = outerRing?.coordinates else { return nil }
         return BoundingBox(coordinates: coordinates)
@@ -196,7 +232,8 @@ extension Polygon {
 
     /// Check if the receiver intersects the other bounding box.
     ///
-    /// - parameter otherBoundingBox: The bounding box to check.
+    /// - Parameter otherBoundingBox: The bounding box to check.
+    /// - Returns: `true` if the bounding boxes intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if let boundingBox = boundingBox ?? calculateBoundingBox(),
            !boundingBox.intersects(otherBoundingBox)
@@ -216,7 +253,7 @@ extension Polygon: Equatable {
         lhs: Polygon,
         rhs: Polygon
     ) -> Bool {
-        // TODO: The coordinats might be shifted (like [1, 2, 3] => [3, 1, 2])
+        // Fix: The coordinates might be shifted (like [1, 2, 3] => [3, 1, 2])
         return lhs.projection == rhs.projection
             && lhs.coordinates == rhs.coordinates
     }

--- a/Sources/GISTools/GeoJson/Polygon.swift
+++ b/Sources/GISTools/GeoJson/Polygon.swift
@@ -248,14 +248,22 @@ extension Polygon {
 
 extension Polygon: Equatable {
 
-    /// Check if two Polygons are equal.
+    /// Check if two Polygons are equal, accounting for shifted ring start vertices.
     public static func ==(
         lhs: Polygon,
         rhs: Polygon
     ) -> Bool {
-        // Fix: The coordinates might be shifted (like [1, 2, 3] => [3, 1, 2])
-        return lhs.projection == rhs.projection
-            && lhs.coordinates == rhs.coordinates
+        guard lhs.projection == rhs.projection,
+              lhs.coordinates.count == rhs.coordinates.count
+        else { return false }
+
+        for i in lhs.coordinates.indices {
+            guard lhs.coordinates[i] == rhs.coordinates[i]
+                || lhs.coordinates[i].compareShifted(rhs.coordinates[i])
+            else { return false }
+        }
+
+        return true
     }
 
 }

--- a/Sources/GISTools/GeoJson/Polyline.swift
+++ b/Sources/GISTools/GeoJson/Polyline.swift
@@ -6,6 +6,10 @@ import Foundation
 extension [Coordinate3D] {
 
     /// Encodes the coordinates to a Polyline with the given precision.
+    ///
+    /// - Parameters:
+    ///    - precision: The encoding precision (default `GISTool.defaultPolylinePrecision`)
+    /// - Returns: A Polyline-encoded string
     public func encodePolyline(
         precision: Double = GISTool.defaultPolylinePrecision
     ) -> String {
@@ -17,6 +21,10 @@ extension [Coordinate3D] {
 extension String {
 
     /// Decodes a Polyline to coordinates with the given precision (must match the encoding precision).
+    ///
+    /// - Parameters:
+    ///    - precision: The decoding precision (default `GISTool.defaultPolylinePrecision`)
+    /// - Returns: An array of coordinates, or `nil` if decoding fails
     public func decodePolyline(
         precision: Double = GISTool.defaultPolylinePrecision
     ) -> [Coordinate3D]? {
@@ -29,6 +37,11 @@ extension String {
 enum Polyline {
 
     /// Encodes the coordinates to a Polyline with the given precision.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates to encode
+    ///    - precision: The encoding precision (default `GISTool.defaultPolylinePrecision`)
+    /// - Returns: A Polyline-encoded string
     public static func encode(
         coordinates: [Coordinate3D],
         precision: Double = GISTool.defaultPolylinePrecision
@@ -53,6 +66,11 @@ enum Polyline {
     }
 
     /// Decodes a Polyline to coordinates with the given precision (must match the encoding precision).
+    ///
+    /// - Parameters:
+    ///    - polyline: The Polyline-encoded string to decode
+    ///    - precision: The decoding precision (default `GISTool.defaultPolylinePrecision`)
+    /// - Returns: An array of coordinates, or `nil` if decoding fails
     public static func decode(
         polyline: String,
         precision: Double = GISTool.defaultPolylinePrecision

--- a/Sources/GISTools/GeoJson/Projectable.swift
+++ b/Sources/GISTools/GeoJson/Projectable.swift
@@ -1,5 +1,5 @@
 
-/// Objects supporting ``Projection``s..
+/// Objects supporting ``Projection``.
 public protocol Projectable {
 
     /// The receiver's projection, which should typically be EPSG:4326.
@@ -12,7 +12,10 @@ public protocol Projectable {
 
 extension Projectable {
 
-    /// Reproject this coordinate.
+    /// Reproject this coordinate in-place.
+    ///
+    /// - Parameters:
+    ///    - newProjection: The target projection
     public mutating func project(to newProjection: Projection) {
         guard newProjection != projection else { return }
 

--- a/Sources/GISTools/GeoJson/Projection.swift
+++ b/Sources/GISTools/GeoJson/Projection.swift
@@ -15,6 +15,10 @@ public enum Projection:
     case epsg4326 = 4326
 
     /// Initialize a Projection with a SRID number.
+    ///
+    /// - Parameters:
+    ///    - srid: The SRID number (e.g. 4326, 3857)
+    /// - Returns: A `Projection`, or `nil` if the SRID is not supported
     public init?(srid: Int) {
         switch srid {
         // A placeholder for 'No SRID'

--- a/Sources/GISTools/GeoJson/RTree.swift
+++ b/Sources/GISTools/GeoJson/RTree.swift
@@ -63,6 +63,11 @@ public struct RTree<T: BoundingBoxRepresentable & Sendable>: Sendable {
     }
 
     /// Create a new R-Tree from `objects`.
+    ///
+    /// - Parameters:
+    ///    - objects: The objects to index
+    ///    - nodeSize: The maximum number of items per node (default `16`, clamped to 4-65535)
+    ///    - sortOption: The sorting strategy for tree construction (default `.hilbert`)
     public init(
         _ objects: [T],
         nodeSize: Int = 16,
@@ -165,6 +170,10 @@ extension RTree {
         distance: CLLocationDistance)
 
     /// Search for objects inside a bounding box.
+    ///
+    /// - Parameters:
+    ///    - searchBoundingBox: The bounding box to search within
+    /// - Returns: An array of objects that intersect the search bounding box
     public func search(inBoundingBox searchBoundingBox: BoundingBox) -> [T] {
         guard count > nodeSize,
               position == boundingBoxes.count
@@ -213,6 +222,10 @@ extension RTree {
     }
 
     /// Search for objects inside a bounding box using serial search.
+    ///
+    /// - Parameters:
+    ///    - searchBoundingBox: The bounding box to search within
+    /// - Returns: An array of objects that intersect the search bounding box
     public func searchSerial(inBoundingBox searchBoundingBox: BoundingBox) -> [T] {
         let searchBoundingBox = searchBoundingBox.projected(to: projection)
 
@@ -232,6 +245,12 @@ extension RTree {
     }
 
     /// Search for objects around a coordinate.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The center point of the search
+    ///    - maximumDistance: The maximum distance from the center in meters
+    ///    - sorted: Whether to sort results by distance (default `true`)
+    /// - Returns: An array of search results with objects and their distances
     public func search(
         aroundCoordinate coordinate: Coordinate3D,
         maximumDistance: CLLocationDistance,
@@ -288,6 +307,12 @@ extension RTree {
     }
 
     /// Search for objects around a coordinate using serial search.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The center point of the search
+    ///    - maximumDistance: The maximum distance from the center in meters
+    ///    - sorted: Whether to sort results by distance (default `true`)
+    /// - Returns: An array of search results with objects and their distances
     public func searchSerial(
         aroundCoordinate coordinate: Coordinate3D,
         maximumDistance: CLLocationDistance,

--- a/Sources/GISTools/GeoJson/Ring.swift
+++ b/Sources/GISTools/GeoJson/Ring.swift
@@ -67,6 +67,55 @@ public struct Ring: Sendable {
 
 }
 
+// MARK: - Equatable
+
+extension Ring: Equatable {
+
+    /// Check if two Rings are equal, accounting for shifted start vertices.
+    ///
+    /// Two rings are equal if they contain the same vertices, regardless
+    /// of which vertex appears first.
+    public static func ==(lhs: Ring, rhs: Ring) -> Bool {
+        lhs.projection == rhs.projection
+        && (lhs.coordinates == rhs.coordinates
+            || lhs.coordinates.compareShifted(rhs.coordinates))
+    }
+
+}
+
+extension [Coordinate3D] {
+
+    /// Compare two coordinate arrays as closed rings, treating them as
+    /// equal when one is a rotation of the other.
+    func compareShifted(_ other: Self) -> Bool {
+        guard count == other.count,
+              count >= 2
+        else { return false }
+
+        let a = dropLast()
+        let b = other.dropLast()
+        guard a.count == b.count else { return false }
+
+        if a.first == b.first { return a == b }
+
+        let doubled = a + a
+        let len = b.count
+        guard len <= doubled.count else { return false }
+
+        outer: for start in 0...(doubled.count - len) {
+            for i in 0..<len {
+                if doubled[start + i] != b[i] {
+                    continue outer
+                }
+            }
+            return true
+        }
+
+        return false
+    }
+
+}
+
 // MARK: - Projection
 
 extension Ring: Projectable {

--- a/Sources/GISTools/GeoJson/Ring.swift
+++ b/Sources/GISTools/GeoJson/Ring.swift
@@ -30,6 +30,10 @@ public struct Ring: Sendable {
     }
 
     /// Try to initialize a Ring with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates forming the ring (will be closed automatically if needed)
+    /// - Returns: A ring, or `nil` if there are fewer than 4 positions
     public init?(_ coordinates: [Coordinate3D]) {
         // Close the ring, if necessary
         var coordinates = coordinates
@@ -45,11 +49,16 @@ public struct Ring: Sendable {
     }
 
     /// Try to initialize a Ring with some coordinates, don't check the coordinates for validity.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates forming the ring
     public init(unchecked coordinates: [Coordinate3D]) {
         self.coordinates = coordinates
     }
 
     /// The Ring's circumference.
+    ///
+    /// - Returns: The circumference in meters
     public var circumference: CLLocationDistance {
         guard coordinates.count >= 2 else { return 0.0 }
 
@@ -63,6 +72,9 @@ public struct Ring: Sendable {
 extension Ring: Projectable {
 
     /// Reproject the receiver.
+    ///
+    /// - Parameter newProjection: The target projection
+    /// - Returns: A new ring in the requested projection
     public func projected(to newProjection: Projection) -> Ring {
         guard newProjection != projection else { return self }
 
@@ -76,6 +88,9 @@ extension Ring: Projectable {
 extension Ring {
 
     /// Check if the receiver intersects the given bounding box.
+    ///
+    /// - Parameter otherBoundingBox: The bounding box to check
+    /// - Returns: `true` if the bounding boxes intersect
     public func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
         if otherBoundingBox.allCoordinates.contains(where: { contains($0) })
             || contains(otherBoundingBox.center)
@@ -94,11 +109,19 @@ extension Ring {
 extension Ring {
 
     /// Try to initialize a Ring with some coordinates.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The coordinates forming the ring
+    /// - Returns: A ring, or `nil` if there are fewer than 4 positions
     public init?(_ coordinates: [CLLocationCoordinate2D]) {
         self.init(coordinates.map({ Coordinate3D($0) }))
     }
 
     /// Try to initialize a Ring with some locations.
+    ///
+    /// - Parameters:
+    ///    - coordinates: The locations forming the ring
+    /// - Returns: A ring, or `nil` if there are fewer than 4 positions
     public init?(_ coordinates: [CLLocation]) {
         self.init(coordinates.map({ Coordinate3D($0) }))
     }

--- a/Sources/GISTools/GeoJson/TWKBCoder.swift
+++ b/Sources/GISTools/GeoJson/TWKBCoder.swift
@@ -9,6 +9,12 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceSrid: The SRID of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A GeoJSON geometry object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         twkb: Data,
@@ -26,6 +32,12 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceProjection: The projection of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A GeoJSON geometry object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         twkb: Data,
@@ -43,6 +55,11 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceSrid: The SRID of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    /// - Returns: A GeoJSON geometry object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func parse(
         twkb: Data,
@@ -57,6 +74,11 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceProjection: The projection of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    /// - Returns: A GeoJSON geometry object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func parse(
         twkb: Data,
@@ -77,6 +99,14 @@ extension Feature {
 
     /// Decode a GeoJSON Feature from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceSrid: The SRID of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    ///    - id: An optional feature identifier. Defaults to `nil`.
+    ///    - properties: A dictionary of feature properties. Defaults to `[:]`.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A GeoJSON Feature object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         twkb: Data,
@@ -96,6 +126,14 @@ extension Feature {
 
     /// Decode a GeoJSON Feature from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceProjection: The projection of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    ///    - id: An optional feature identifier. Defaults to `nil`.
+    ///    - properties: A dictionary of feature properties. Defaults to `[:]`.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A GeoJSON Feature object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         twkb: Data,
@@ -121,6 +159,12 @@ extension FeatureCollection {
 
     /// Decode a GeoJSON FeatureCollection from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceSrid: The SRID of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A GeoJSON FeatureCollection object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         twkb: Data,
@@ -138,6 +182,12 @@ extension FeatureCollection {
 
     /// Decode a GeoJSON FeatureCollection from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceProjection: The projection of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A GeoJSON FeatureCollection object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         twkb: Data,
@@ -161,6 +211,10 @@ extension Data {
 
     /// Decode a GeoJSON object from TWKB.
     ///
+    /// - Parameters:
+    ///    - sourceSrid: The SRID of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    /// - Returns: A GeoJSON geometry object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asGeoJsonGeometryFromTWKB(
         sourceSrid: Int?,
@@ -174,6 +228,10 @@ extension Data {
 
     /// Decode a GeoJSON object from TWKB.
     ///
+    /// - Parameters:
+    ///    - sourceProjection: The projection of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    /// - Returns: A GeoJSON geometry object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asGeoJsonGeometryFromTWKB(
         sourceProjection: Projection?,
@@ -185,8 +243,14 @@ extension Data {
             targetProjection: targetProjection)
     }
 
-    /// Decode a GeoJSON object from TWKB.
+    /// Decode a GeoJSON Feature from TWKB.
     ///
+    /// - Parameters:
+    ///    - sourceSrid: The SRID of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    ///    - id: An optional feature identifier. Defaults to `nil`.
+    ///    - properties: A dictionary of feature properties. Defaults to `[:]`.
+    /// - Returns: A GeoJSON Feature object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeatureFromTWKB(
         sourceSrid: Int?,
@@ -202,8 +266,14 @@ extension Data {
             properties: properties)
     }
 
-    /// Decode a GeoJSON object from TWKB.
+    /// Decode a GeoJSON Feature from TWKB.
     ///
+    /// - Parameters:
+    ///    - sourceProjection: The projection of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    ///    - id: An optional feature identifier. Defaults to `nil`.
+    ///    - properties: A dictionary of feature properties. Defaults to `[:]`.
+    /// - Returns: A GeoJSON Feature object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeatureFromTWKB(
         sourceProjection: Projection?,
@@ -219,8 +289,12 @@ extension Data {
             properties: properties)
     }
 
-    /// Decode a GeoJSON object from TWKB.
+    /// Decode a GeoJSON FeatureCollection from TWKB.
     ///
+    /// - Parameters:
+    ///    - sourceSrid: The SRID of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    /// - Returns: A GeoJSON FeatureCollection object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeatureCollectionFromTWKB(
         sourceSrid: Int?,
@@ -232,8 +306,12 @@ extension Data {
             targetProjection: targetProjection)
     }
 
-    /// Decode a GeoJSON object from TWKB.
+    /// Decode a GeoJSON FeatureCollection from TWKB.
     ///
+    /// - Parameters:
+    ///    - sourceProjection: The projection of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    /// - Returns: A GeoJSON FeatureCollection object, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeatureCollectionFromTWKB(
         sourceProjection: Projection?,
@@ -270,6 +348,12 @@ public enum TWKBCoder {
 
     /// Decode a GeoJSON object from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceSrid: The SRID of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    /// - Returns: A decoded GeoJSON geometry object.
+    /// - Throws: A `TWKBError` if the data is corrupted, empty, invalid, or of an unexpected type.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func decode(
         twkb: Data,
@@ -291,6 +375,12 @@ public enum TWKBCoder {
 
     /// Decode a GeoJSON object from TWKB.
     ///
+    /// - Parameters:
+    ///    - twkb: The TWKB data to decode.
+    ///    - sourceProjection: The projection of the source data.
+    ///    - targetProjection: The projection to transform the result into. Defaults to EPSG:4326.
+    /// - Returns: A decoded GeoJSON geometry object.
+    /// - Throws: A `TWKBError` if the data is corrupted, empty, invalid, or of an unexpected type.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func decode(
         twkb: Data,

--- a/Sources/GISTools/GeoJson/WKBCoder.swift
+++ b/Sources/GISTools/GeoJson/WKBCoder.swift
@@ -6,6 +6,12 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to read the SRID from the WKB data.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    ///    - calculateBoundingBox: Whether to calculate a bounding box (default `false`).
+    /// - Returns: A GeoJSON geometry, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkb: Data,
@@ -23,6 +29,12 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceProjection: The source projection.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    ///    - calculateBoundingBox: Whether to calculate a bounding box (default `false`).
+    /// - Returns: A GeoJSON geometry, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkb: Data,
@@ -40,6 +52,11 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to read the SRID from the WKB data.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    /// - Returns: A GeoJSON geometry, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func parse(
         wkb: Data,
@@ -54,6 +71,11 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceProjection: The source projection.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    /// - Returns: A GeoJSON geometry, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func parse(
         wkb: Data,
@@ -67,6 +89,8 @@ extension GeoJsonGeometry {
     }
 
     /// Returns the receiver as WKB encoded data.
+    ///
+    /// - Returns: The WKB encoded data, or `nil` if the geometry is empty.
     public var asWKB: Data? {
         WKBCoder.encode(geometry: self)
     }
@@ -79,6 +103,14 @@ extension Feature {
 
     /// Decode a GeoJSON Feature from WKB.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to read the SRID from the WKB data.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    ///    - id: A feature identifier (default `nil`).
+    ///    - properties: Feature properties (default `[:]`).
+    ///    - calculateBoundingBox: Whether to calculate a bounding box (default `false`).
+    /// - Returns: A Feature, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkb: Data,
@@ -98,6 +130,14 @@ extension Feature {
 
     /// Decode a GeoJSON Feature from WKB.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceProjection: The source projection.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    ///    - id: A feature identifier (default `nil`).
+    ///    - properties: Feature properties (default `[:]`).
+    ///    - calculateBoundingBox: Whether to calculate a bounding box (default `false`).
+    /// - Returns: A Feature, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkb: Data,
@@ -112,6 +152,8 @@ extension Feature {
     }
 
     /// Returns the receiver as WKB encoded data.
+    ///
+    /// - Returns: The WKB encoded data, or `nil` if the geometry is empty.
     public var asWKB: Data? {
         WKBCoder.encode(geometry: self.geometry)
     }
@@ -124,6 +166,12 @@ extension FeatureCollection {
 
     /// Decode a GeoJSON FeatureCollection from WKB.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to read the SRID from the WKB data.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    ///    - calculateBoundingBox: Whether to calculate a bounding box (default `false`).
+    /// - Returns: A FeatureCollection, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkb: Data,
@@ -137,6 +185,12 @@ extension FeatureCollection {
 
     /// Decode a GeoJSON FeatureCollection from WKB.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceProjection: The source projection.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    ///    - calculateBoundingBox: Whether to calculate a bounding box (default `false`).
+    /// - Returns: A FeatureCollection, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkb: Data,
@@ -149,6 +203,8 @@ extension FeatureCollection {
     }
 
     /// Returns the receiver as WKB encoded data.
+    ///
+    /// - Returns: The WKB encoded data, or `nil` if the geometry is empty.
     public var asWKB: Data? {
         WKBCoder.encode(geometry: GeometryCollection(self.features.map(\.geometry)))
     }
@@ -161,6 +217,10 @@ extension Data {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to read the SRID from the WKB data.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    /// - Returns: A GeoJSON geometry, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asGeoJsonGeometry(
         sourceSrid: Int?,
@@ -174,6 +234,10 @@ extension Data {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - sourceProjection: The source projection.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    /// - Returns: A GeoJSON geometry, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asGeoJsonGeometry(
         sourceProjection: Projection,
@@ -187,6 +251,12 @@ extension Data {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to read the SRID from the WKB data.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    ///    - id: A feature identifier (default `nil`).
+    ///    - properties: Feature properties (default `[:]`).
+    /// - Returns: A Feature, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeature(
         sourceSrid: Int?,
@@ -204,6 +274,12 @@ extension Data {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - sourceProjection: The source projection.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    ///    - id: A feature identifier (default `nil`).
+    ///    - properties: Feature properties (default `[:]`).
+    /// - Returns: A Feature, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeature(
         sourceProjection: Projection,
@@ -221,6 +297,10 @@ extension Data {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to read the SRID from the WKB data.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    /// - Returns: A FeatureCollection, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeatureCollection(
         sourceSrid: Int?,
@@ -234,6 +314,10 @@ extension Data {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - sourceProjection: The source projection.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    /// - Returns: A FeatureCollection, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeatureCollection(
         sourceProjection: Projection,
@@ -299,6 +383,12 @@ extension WKBCoder {
 
     /// Decode a GeoJSON object from WKB.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to read the SRID from the WKB data.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    /// - Returns: A decoded GeoJSON geometry.
+    /// - Throws: A `WKBCoderError` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func decode(
         wkb: Data,
@@ -320,6 +410,12 @@ extension WKBCoder {
 
     /// Decode a GeoJSON object from WKB using a specified source projection.
     ///
+    /// - Parameters:
+    ///    - wkb: The WKB encoded data.
+    ///    - sourceProjection: The source projection.
+    ///    - targetProjection: The target projection (default `.epsg4326`).
+    /// - Returns: A decoded GeoJSON geometry.
+    /// - Throws: A `WKBCoderError` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func decode(
         wkb: Data,
@@ -674,6 +770,12 @@ extension WKBCoder {
 extension WKBCoder {
 
     /// Returns the geometry as WKB encoded data.
+    ///
+    /// - Parameters:
+    ///    - geometry: The geometry to encode.
+    ///    - byteOrder: The byte order to use for encoding (default `.littleEndian`).
+    ///    - targetProjection: The target projection for encoding (default `.epsg4326`).
+    /// - Returns: The WKB encoded data, or `nil` if the geometry is empty.
     public static func encode(
         geometry: GeoJsonGeometry,
         byteOrder: ByteOrder = .littleEndian,

--- a/Sources/GISTools/GeoJson/WKTCoder.swift
+++ b/Sources/GISTools/GeoJson/WKTCoder.swift
@@ -6,6 +6,12 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to detect from the WKT.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A decoded GeoJSON geometry, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkt: String,
@@ -19,6 +25,12 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceProjection: The projection of the source coordinates.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A decoded GeoJSON geometry, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkt: String,
@@ -32,6 +44,11 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to detect from the WKT.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    /// - Returns: A decoded GeoJSON geometry, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func parse(
         wkt: String,
@@ -43,6 +60,11 @@ extension GeoJsonGeometry {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceProjection: The projection of the source coordinates.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    /// - Returns: A decoded GeoJSON geometry, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func parse(
         wkt: String,
@@ -53,6 +75,8 @@ extension GeoJsonGeometry {
     }
 
     /// Returns the receiver as a WKT encoded string.
+    ///
+    /// - Returns: A WKT string, or `nil` if encoding fails.
     public var asWKT: String? {
         WKTCoder.encode(geometry: self)
     }
@@ -65,6 +89,14 @@ extension Feature {
 
     /// Decode a GeoJSON Feature from WKT.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to detect from the WKT.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    ///    - id: An optional feature identifier. Defaults to `nil`.
+    ///    - properties: A dictionary of feature properties. Defaults to `[:]`.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A decoded Feature, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkt: String,
@@ -80,6 +112,14 @@ extension Feature {
 
     /// Decode a GeoJSON Feature from WKT.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceProjection: The projection of the source coordinates.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    ///    - id: An optional feature identifier. Defaults to `nil`.
+    ///    - properties: A dictionary of feature properties. Defaults to `[:]`.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A decoded Feature, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkt: String,
@@ -94,6 +134,8 @@ extension Feature {
     }
 
     /// Returns the receiver as a WKT encoded string.
+    ///
+    /// - Returns: A WKT string, or `nil` if encoding fails.
     public var asWKT: String? {
         WKTCoder.encode(geometry: self.geometry)
     }
@@ -106,6 +148,12 @@ extension FeatureCollection {
 
     /// Decode a GeoJSON FeatureCollection from WKT.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to detect from the WKT.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A decoded FeatureCollection, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkt: String,
@@ -124,6 +172,12 @@ extension FeatureCollection {
 
     /// Decode a GeoJSON FeatureCollection from WKT.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceProjection: The projection of the source coordinates.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    ///    - calculateBoundingBox: Whether to calculate the bounding box. Defaults to `false`.
+    /// - Returns: A decoded FeatureCollection, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkt: String,
@@ -141,6 +195,8 @@ extension FeatureCollection {
     }
 
     /// Returns the receiver as a WKT encoded string.
+    ///
+    /// - Returns: A WKT string, or `nil` if encoding fails.
     public var asWKT: String? {
         WKTCoder.encode(geometry: GeometryCollection(self.features.map(\.geometry)))
     }
@@ -153,6 +209,10 @@ extension String {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to detect from the WKT.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    /// - Returns: A decoded GeoJSON geometry, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asGeoJsonGeometry(
         sourceSrid: Int?,
@@ -163,6 +223,10 @@ extension String {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - sourceProjection: The projection of the source coordinates.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    /// - Returns: A decoded GeoJSON geometry, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asGeoJsonGeometry(
         sourceProjection: Projection,
@@ -173,6 +237,12 @@ extension String {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to detect from the WKT.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    ///    - id: An optional feature identifier. Defaults to `nil`.
+    ///    - properties: A dictionary of feature properties. Defaults to `[:]`.
+    /// - Returns: A decoded Feature, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeature(
         sourceSrid: Int?,
@@ -185,6 +255,12 @@ extension String {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - sourceProjection: The projection of the source coordinates.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    ///    - id: An optional feature identifier. Defaults to `nil`.
+    ///    - properties: A dictionary of feature properties. Defaults to `[:]`.
+    /// - Returns: A decoded Feature, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeature(
         sourceProjection: Projection,
@@ -197,6 +273,10 @@ extension String {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to detect from the WKT.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    /// - Returns: A decoded FeatureCollection, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeatureCollection(
         sourceSrid: Int?,
@@ -207,6 +287,10 @@ extension String {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - sourceProjection: The projection of the source coordinates.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    /// - Returns: A decoded FeatureCollection, or `nil` if the WKT is invalid.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeatureCollection(
         sourceProjection: Projection,
@@ -260,6 +344,12 @@ extension WKTCoder {
 
     /// Decode a GeoJSON object from WKT.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceSrid: The SRID of the source coordinate system, or `nil` to detect from the WKT.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    /// - Returns: A decoded GeoJSON geometry.
+    /// - Throws: A `WKTCoderError` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func decode(
         wkt: String,
@@ -278,6 +368,12 @@ extension WKTCoder {
 
     /// Decode a GeoJSON object from WKT using a specified source projection.
     ///
+    /// - Parameters:
+    ///    - wkt: The WKT string to decode.
+    ///    - sourceProjection: The projection of the source coordinates, or `nil` to detect from the WKT.
+    ///    - targetProjection: The projection to decode into. Defaults to `.epsg4326`.
+    /// - Returns: A decoded GeoJSON geometry.
+    /// - Throws: A `WKTCoderError` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func decode(
         wkt: String,
@@ -579,6 +675,11 @@ extension WKTCoder {
 extension WKTCoder {
 
     /// Returns a geometry as a WKT encoded string.
+    ///
+    /// - Parameters:
+    ///    - geometry: The GeoJSON geometry to encode.
+    ///    - targetProjection: The projection to encode into. If `nil`, the geometry's native projection is used. Defaults to `.epsg4326`.
+    /// - Returns: A WKT string, or `nil` if the geometry is empty.
     public static func encode(
         geometry: GeoJsonGeometry,
         targetProjection: Projection? = .epsg4326
@@ -613,6 +714,7 @@ extension WKTCoder {
         case .geometryCollection:
             encode(geometry as! GeometryCollection, targetProjection: targetProjection, to: &result)
         case .feature, .featureCollection, .invalid:
+            // Feature and FeatureCollection can't happen
             break
         }
     }

--- a/Sources/GISTools/Other/MapTile.swift
+++ b/Sources/GISTools/Other/MapTile.swift
@@ -3,6 +3,9 @@ import CoreLocation
 #endif
 import Foundation
 
+/// A map tile identified by its x/y coordinates and zoom level in the Web Mercator
+/// (EPSG:3857) tile coordinate system, commonly used by map renderers such as
+/// MapKit, Google Maps, and OpenStreetMap.
 public struct MapTile: CustomStringConvertible, Sendable {
 
     /// The x-coordinate of the tile.
@@ -50,6 +53,11 @@ public struct MapTile: CustomStringConvertible, Sendable {
     }
 
     /// Creates a map tile from its coordinates and zoom level.
+    ///
+    /// - Parameters:
+    ///    - x: The x-coordinate of the tile
+    ///    - y: The y-coordinate of the tile
+    ///    - z: The zoom level
     public init(x: Int, y: Int, z: Int) {
         self.x = x
         self.y = y
@@ -57,6 +65,10 @@ public struct MapTile: CustomStringConvertible, Sendable {
     }
 
     /// Creates a map tile from a geographic coordinate at the given zoom level.
+    ///
+    /// - Parameters:
+    ///    - coordinate: The geographic coordinate
+    ///    - zoom: The zoom level
     public init(coordinate: Coordinate3D, atZoom zoom: Int) {
         let scale = Double(1 << zoom)
         let normalizedCoordinate = MapTile.normalizeCoordinate(coordinate.projected(to: .epsg4326))
@@ -70,8 +82,9 @@ public struct MapTile: CustomStringConvertible, Sendable {
     /// Initialize a tile from a bounding box.
     /// The resulting tile will have a zoom level in `0...maxZoom`.
     ///
-    /// - parameter boundingBox: The bounding box that the tile should completely contain
-    /// - parameter maxZoom: The maximum zoom level of the resulting tile, 0...32
+    /// - Parameters:
+    ///    - boundingBox: The bounding box that the tile should completely contain
+    ///    - maxZoom: The maximum zoom level of the resulting tile, 0...32
     public init(
         boundingBox: BoundingBox,
         maxZoom: Int = 32
@@ -111,6 +124,10 @@ public struct MapTile: CustomStringConvertible, Sendable {
     }
 
     /// Creates a map tile from a ``String`` in the format `"z/x/y"`.
+    ///
+    /// - Parameters:
+    ///    - string: A tile string in the format `"z/x/y"`
+    /// - Returns: A `MapTile`, or `nil` if the string format is invalid
     public init?(string: String) {
         guard let components = string.components(separatedBy: "/").nilIfEmpty,
               components.count == 3,
@@ -175,6 +192,8 @@ public struct MapTile: CustomStringConvertible, Sendable {
     // MARK: - Quadkey
 
     /// The quadkey representation of the tile.
+    ///
+    /// - Returns: A quadkey string
     public var quadkey: String {
         var quadkey = ""
 
@@ -196,6 +215,10 @@ public struct MapTile: CustomStringConvertible, Sendable {
     }
 
     /// Creates a map tile from a quadkey string.
+    ///
+    /// - Parameters:
+    ///    - quadkey: A quadkey string
+    /// - Returns: A `MapTile`, or `nil` if the quadkey is invalid
     public init?(quadkey: String) {
         guard !quadkey.isEmpty else {
             self.x = 0
@@ -260,6 +283,8 @@ public struct MapTile: CustomStringConvertible, Sendable {
     }
 
     /// Resolution (meters/pixel) for a given zoom level measured at the tile center.
+    ///
+    /// - Returns: The meters per pixel at the tile's center
     public var metersPerPixel: Double {
         GISTool.metersPerPixel(atZoom: z, latitude: centerCoordinate().latitude)
     }
@@ -294,6 +319,10 @@ extension MapTile: Equatable, Hashable {}
 extension Coordinate3D {
 
     /// The receiver as a ``MapTile``.
+    ///
+    /// - Parameters:
+    ///    - zoom: The zoom level
+    /// - Returns: A `MapTile` for the receiver at the given zoom
     public func mapTile(atZoom zoom: Int) -> MapTile {
         MapTile(coordinate: self, atZoom: zoom)
     }
@@ -304,6 +333,10 @@ extension Coordinate3D {
 extension CLLocation {
 
     /// The receiver as a ``MapTile``.
+    ///
+    /// - Parameters:
+    ///    - zoom: The zoom level
+    /// - Returns: A `MapTile` for the receiver at the given zoom
     public func mapTile(atZoom zoom: Int) -> MapTile {
         MapTile(coordinate: Coordinate3D(self), atZoom: zoom)
     }
@@ -313,6 +346,10 @@ extension CLLocation {
 extension CLLocationCoordinate2D {
 
     /// The receiver as a ``MapTile``.
+    ///
+    /// - Parameters:
+    ///    - zoom: The zoom level
+    /// - Returns: A `MapTile` for the receiver at the given zoom
     public func mapTile(atZoom zoom: Int) -> MapTile {
         MapTile(coordinate: Coordinate3D(self), atZoom: zoom)
     }

--- a/Tests/GISToolsTests/Algorithms/BearingTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BearingTests.swift
@@ -29,4 +29,17 @@ struct BearingTests {
         #expect((-395.0).bearingToAzimuth == 325.0)
     }
 
+    // Tests bearing calculation with .noSRID (Cartesian coordinates).
+    @Test
+    func bearingNoSRID() async throws {
+        let origin = Coordinate3D(x: 0.0, y: 0.0, projection: .noSRID)
+        let east = Coordinate3D(x: 1.0, y: 0.0, projection: .noSRID)
+        let north = Coordinate3D(x: 0.0, y: 1.0, projection: .noSRID)
+        let northEast = Coordinate3D(x: 1.0, y: 1.0, projection: .noSRID)
+
+        #expect(abs(origin.bearing(to: east) - 90.0) < 1e-10)
+        #expect(abs(origin.bearing(to: north)) < 1e-10)
+        #expect(abs(origin.bearing(to: northEast) - 45.0) < 1e-10)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/BooleanIntersectsTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanIntersectsTests.swift
@@ -1,0 +1,43 @@
+@testable import GISTools
+import Testing
+
+struct BooleanIntersectsTests {
+
+    @Test func intersectingGeometries() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let insidePoint = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        let overlappingLine = try #require(LineString([
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 12.0, longitude: 12.0),
+        ]))
+
+        #expect(polygon.intersects(insidePoint))
+        #expect(insidePoint.intersects(polygon))
+        #expect(polygon.intersects(overlappingLine))
+    }
+
+    @Test func nonIntersectingGeometries() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let outsidePoint = Point(Coordinate3D(latitude: 20.0, longitude: 20.0))
+
+        #expect(!polygon.intersects(outsidePoint))
+        #expect(!outsidePoint.intersects(polygon))
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/BooleanParallelTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanParallelTests.swift
@@ -3,9 +3,166 @@ import Testing
 
 struct BooleanParallelTests {
 
-    // Validates that `isParallel` returns true for parallel line strings.
-    @Test
-    func isTrue() async throws {
+    // MARK: - LineSegment tests
+
+    @Test func segment_exactParallel_directed() {
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let c = Coordinate3D(latitude: 5.0, longitude: 0.0)
+        let d = Coordinate3D(latitude: 15.0, longitude: 0.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(s1.isParallel(to: s2))
+        #expect(s2.isParallel(to: s1))
+    }
+
+    @Test func segment_notParallel() {
+        // Northward vs. Eastward — clearly not parallel
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let c = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let d = Coordinate3D(latitude: 0.0, longitude: 10.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(!s1.isParallel(to: s2))
+    }
+
+    @Test func segment_antiParallel_directed() {
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: b, second: a)
+        #expect(!s1.isParallel(to: s2))
+    }
+
+    @Test func segment_antiParallel_undirected() {
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: b, second: a)
+        #expect(s1.isParallel(to: s2, undirectedEdge: true))
+    }
+
+    @Test func segment_circularWrap_355vs5() {
+        // Two near-north segments straddling the 0°/360° boundary.
+        // Segment 1: bearing ≈ 0.57° (just east of true north)
+        // Segment 2: bearing ≈ -1.14° → azimuth 358.86°
+        // Naive abs(a - b) = 358.29° (WRONG), correct diff = 1.71°
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.1)
+        let c = Coordinate3D(latitude: 0.0, longitude: 0.2)
+        let d = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(s1.isParallel(to: s2, tolerance: 2.0))
+    }
+
+    @Test func segment_circularWrap_notParallel() {
+        // Bearings on opposite sides of 0° but far enough apart
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.5)
+        let c = Coordinate3D(latitude: 0.0, longitude: 1.0)
+        let d = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(!s1.isParallel(to: s2, tolerance: 1.0))
+    }
+
+    @Test func segment_withinTolerance() {
+        // Bearing difference ≈ 0.057°, within 0.1° tolerance
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let c = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let d = Coordinate3D(latitude: 10.0, longitude: 0.01)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(s1.isParallel(to: s2, tolerance: 0.1))
+    }
+
+    @Test func segment_justOutsideTolerance() {
+        // Bearing difference ≈ 0.57°, outside 0.5° tolerance
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let c = Coordinate3D(latitude: 0.0, longitude: 0.1)
+        let d = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(!s1.isParallel(to: s2, tolerance: 0.5))
+    }
+
+    @Test func segment_selfIsParallel() {
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let s = LineSegment(first: a, second: b)
+        #expect(s.isParallel(to: s))
+        #expect(s.isParallel(to: s, undirectedEdge: true))
+    }
+
+    @Test func segment_noSRID() {
+        // With noSRID, rhumbBearing uses atan2(deltaLon, deltaLat)
+        let a = Coordinate3D(x: 0.0, y: 0.0, projection: .noSRID)
+        let b = Coordinate3D(x: 0.0, y: 10.0, projection: .noSRID)
+        let c = Coordinate3D(x: 5.0, y: 0.0, projection: .noSRID)
+        let d = Coordinate3D(x: 5.0, y: 10.0, projection: .noSRID)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(s1.isParallel(to: s2))
+    }
+
+    @Test func segment_undirected_wrap() {
+        // Anti-parallel where undirectedEdge corrects the 180° flip
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let c = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let d = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(!s1.isParallel(to: s2))
+        #expect(s1.isParallel(to: s2, undirectedEdge: true))
+    }
+
+    // MARK: - Anti-meridian tests
+
+    @Test func segment_antiMeridian_parallel() {
+        // Two segments crossing the anti-meridian (180° longitude) with the
+        // same ~2° eastward longitude step at different latitudes.
+        // After deltaLambda normalisation both have bearing ≈ 11.25° and
+        // ≈ 11.12°, well within a 0.2° tolerance.
+        let a = Coordinate3D(latitude: 0.0, longitude: 179.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: -179.0)
+        let c = Coordinate3D(latitude: 5.0, longitude: 179.0)
+        let d = Coordinate3D(latitude: 15.0, longitude: -179.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(s1.isParallel(to: s2, tolerance: 0.2))
+    }
+
+    @Test func segment_antiMeridian_notParallel() {
+        // Segment crossing the anti-meridian by 2° East (bearing ≈ 11.25°)
+        // vs. one crossing by 15° East (bearing ≈ 56.2°) — clearly different.
+        let a = Coordinate3D(latitude: 0.0, longitude: 179.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: -179.0)
+        let c = Coordinate3D(latitude: 0.0, longitude: 170.0)
+        let d = Coordinate3D(latitude: 10.0, longitude: -175.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: c, second: d)
+        #expect(!s1.isParallel(to: s2, tolerance: 1.0))
+    }
+
+    @Test func segment_antiMeridian_undirected() {
+        // A segment crossing the anti-meridian and its reverse should be
+        // parallel when treated as an undirected edge.
+        let a = Coordinate3D(latitude: 0.0, longitude: 179.0)
+        let b = Coordinate3D(latitude: 10.0, longitude: -179.0)
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: b, second: a)
+        #expect(!s1.isParallel(to: s2))
+        #expect(s1.isParallel(to: s2, tolerance: 1e-10, undirectedEdge: true))
+    }
+
+    // MARK: - LineString tests
+
+    @Test func lineString_isTrue() async throws {
         let lineString1 = try TestData.lineString(package: "BooleanParallel", name: "LineStringTrue1_1")
         let lineString2 = try TestData.lineString(package: "BooleanParallel", name: "LineStringTrue1_2")
 
@@ -24,17 +181,15 @@ struct BooleanParallelTests {
         #expect(lineString7.isParallel(to: lineString8))
     }
 
-    // Validates that `isParallel` returns false for non-parallel line strings.
-    @Test
-    func isFalse() async throws {
+    @Test func lineString_isFalse() async throws {
         let lineString1 = try TestData.lineString(package: "BooleanParallel", name: "LineStringFalse1_1")
         let lineString2 = try TestData.lineString(package: "BooleanParallel", name: "LineStringFalse1_2")
 
         let lineString3 = try TestData.lineString(package: "BooleanParallel", name: "LineStringFalse2_1")
         let lineString4 = try TestData.lineString(package: "BooleanParallel", name: "LineStringFalse2_2")
 
-        #expect(lineString1.isParallel(to: lineString2) == false)
-        #expect(lineString3.isParallel(to: lineString4) == false)
+        #expect(!lineString1.isParallel(to: lineString2))
+        #expect(!lineString3.isParallel(to: lineString4))
     }
 
 }

--- a/Tests/GISToolsTests/Algorithms/BoundingBoxPositionTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BoundingBoxPositionTests.swift
@@ -1,0 +1,69 @@
+@testable import GISTools
+import Testing
+
+struct BoundingBoxPositionTests {
+
+    @Test func center() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let center = Coordinate3D(latitude: 5.0, longitude: 5.0)
+
+        let position = bbox.position(of: center)
+        #expect(position.contains(.center))
+        #expect(!position.contains(.outside))
+        #expect(!position.contains(.top))
+        #expect(!position.contains(.bottom))
+        #expect(!position.contains(.left))
+        #expect(!position.contains(.right))
+    }
+
+    @Test func topRight() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let topRight = Coordinate3D(latitude: 9.0, longitude: 9.0)
+
+        let position = bbox.position(of: topRight)
+        #expect(position.contains(.top))
+        #expect(position.contains(.right))
+        #expect(!position.contains(.outside))
+        #expect(!position.contains(.center))
+    }
+
+    @Test func bottomLeft() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let bottomLeft = Coordinate3D(latitude: 1.0, longitude: 1.0)
+
+        let position = bbox.position(of: bottomLeft)
+        #expect(position.contains(.bottom))
+        #expect(position.contains(.left))
+        #expect(!position.contains(.outside))
+        #expect(!position.contains(.center))
+    }
+
+    @Test func outside() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let outside = Coordinate3D(latitude: 20.0, longitude: 20.0)
+
+        let position = bbox.position(of: outside)
+        #expect(position.contains(.outside))
+        #expect(position.contains(.top))
+        #expect(position.contains(.right))
+    }
+
+    @Test func pointOverload() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let center = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+
+        let position = bbox.position(of: center)
+        #expect(position.contains(.center))
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/ConversionTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ConversionTests.swift
@@ -110,7 +110,7 @@ struct ConversionTests {
         #expect(GISTool.convertToMeters(1.0, .miles) == 1609.344)
         #expect(GISTool.convertToMeters(100.0, .centimeters) == 1.0)
         #expect(GISTool.convertToMeters(1000.0, .millimeters) == 1.0)
-        #expect(GISTool.convertToMeters(1.0, .nauticalmiles) == 1852.0)
+        #expect(GISTool.convertToMeters(1.0, .nauticalMiles) == 1852.0)
         #expect(GISTool.convertToMeters(1.0, .meters) == 1.0)
         #expect(GISTool.convertToMeters(1.0, .inches) > 0.0)
     }

--- a/Tests/GISToolsTests/Algorithms/DissolveTests.swift
+++ b/Tests/GISToolsTests/Algorithms/DissolveTests.swift
@@ -1,0 +1,116 @@
+@testable import GISTools
+import Testing
+
+struct DissolveTests {
+
+    // MARK: - Helpers
+
+    private func square(
+        latitude: Double,
+        longitude: Double,
+        size: Double = 1.0
+    ) -> Polygon {
+        let half = size * 0.5
+        let coords = [
+            Coordinate3D(latitude: latitude - half, longitude: longitude - half),
+            Coordinate3D(latitude: latitude + half, longitude: longitude - half),
+            Coordinate3D(latitude: latitude + half, longitude: longitude + half),
+            Coordinate3D(latitude: latitude - half, longitude: longitude + half),
+            Coordinate3D(latitude: latitude - half, longitude: longitude - half),
+        ]
+        return try! #require(Polygon([coords]))
+    }
+
+    // MARK: - String property values
+
+    @Test
+    func stringProperty() async throws {
+        let a1 = Feature(square(latitude: 0.0, longitude: 0.0), properties: ["group": "a"])
+        let a2 = Feature(square(latitude: 0.0, longitude: 10.0), properties: ["group": "a"])
+        let b1 = Feature(square(latitude: 10.0, longitude: 0.0), properties: ["group": "b"])
+        let line = Feature(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ])!, properties: ["group": "a"])
+
+        let dissolved = FeatureCollection([a1, a2, b1, line]).dissolved(by: "group")
+
+        #expect(dissolved.features.count == 2)
+        let groups = dissolved.features.compactMap({ $0.properties["group"] as? String }).sorted()
+        #expect(groups == ["a", "b"])
+    }
+
+    // MARK: - Int property values
+
+    @Test
+    func intProperty() async throws {
+        let f1 = Feature(square(latitude: 0.0, longitude: 0.0), properties: ["zone": 1])
+        let f2 = Feature(square(latitude: 0.0, longitude: 10.0), properties: ["zone": 1])
+        let f3 = Feature(square(latitude: 10.0, longitude: 0.0), properties: ["zone": 2])
+
+        let dissolved = FeatureCollection([f1, f2, f3]).dissolved(by: "zone")
+
+        #expect(dissolved.features.count == 2)
+        let groups = dissolved.features.compactMap({ $0.properties["zone"] as? Int }).sorted()
+        #expect(groups == [1, 2])
+    }
+
+    // MARK: - Bool property values
+
+    @Test
+    func boolProperty() async throws {
+        let f1 = Feature(square(latitude: 0.0, longitude: 0.0), properties: ["active": true])
+        let f2 = Feature(square(latitude: 0.0, longitude: 10.0), properties: ["active": true])
+        let f3 = Feature(square(latitude: 10.0, longitude: 0.0), properties: ["active": false])
+
+        let dissolved = FeatureCollection([f1, f2, f3]).dissolved(by: "active")
+
+        #expect(dissolved.features.count == 2)
+        let groups = dissolved.features.compactMap({ $0.properties["active"] as? Bool })
+        #expect(groups.count == 2)
+        #expect(groups.contains(true))
+        #expect(groups.contains(false))
+    }
+
+    // MARK: - removeUnknown
+
+    @Test
+    func removeUnknownDropsFeaturesWithoutProperty() async throws {
+        let withProp = Feature(square(latitude: 0.0, longitude: 0.0), properties: ["cat": "x"])
+        let withoutProp = Feature(square(latitude: 10.0, longitude: 0.0))
+
+        let dissolved = FeatureCollection([withProp, withoutProp]).dissolved(by: "cat", removeUnknown: true)
+
+        #expect(dissolved.features.count == 1)
+        #expect(dissolved.features.first?.properties["cat"] as? String == "x")
+    }
+
+    @Test
+    func keepUnknownGroupsFeaturesWithoutProperty() async throws {
+        let withProp = Feature(square(latitude: 0.0, longitude: 0.0), properties: ["cat": "x"])
+        let withoutProp = Feature(square(latitude: 10.0, longitude: 0.0))
+
+        let dissolved = FeatureCollection([withProp, withoutProp]).dissolved(by: "cat", removeUnknown: false)
+
+        #expect(dissolved.features.count == 2)
+        let withCat = dissolved.features.first(where: { $0.properties["cat"] != nil })
+        #expect(withCat?.properties["cat"] as? String == "x")
+        let withoutCat = dissolved.features.first(where: { $0.properties["cat"] == nil })
+        #expect(withoutCat != nil)
+    }
+
+    // MARK: - Non-polygon features are filtered out
+
+    @Test
+    func nonPolygonFeaturesRemoved() async throws {
+        let polygon = Feature(square(latitude: 0.0, longitude: 0.0), properties: ["g": "a"])
+        let point = Feature(Point(Coordinate3D(latitude: 5.0, longitude: 5.0)), properties: ["g": "a"])
+
+        let dissolved = FeatureCollection([polygon, point]).dissolved(by: "g")
+
+        #expect(dissolved.features.count == 1)
+        let g = try #require(dissolved.features.first?.properties["g"] as? String)
+        #expect(g == "a")
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/DistanceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/DistanceTests.swift
@@ -26,4 +26,13 @@ struct DistanceTests {
         #expect(abs(origin.distance(from: point) - expected) < 1e-6)
     }
 
+    // Validates Euclidean distance in noSRID (Cartesian plane).
+    @Test
+    func distanceNoSRID() async throws {
+        let origin = Coordinate3D(x: 0.0, y: 0.0, projection: .noSRID)
+        let point = Coordinate3D(x: 3.0, y: 4.0, projection: .noSRID)
+
+        #expect(abs(origin.distance(from: point) - 5.0) < 1e-12)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/DistanceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/DistanceTests.swift
@@ -16,4 +16,14 @@ struct DistanceTests {
         #expect(abs(coordinate1.distance(from: coordinate2) - expectedDistance) < 0.000001)
     }
 
+    // Validates Euclidean distance in EPSG:3857 (projected meters).
+    @Test
+    func distanceEPSG3857() async throws {
+        let origin = Coordinate3D(x: 0.0, y: 0.0, projection: .epsg3857)
+        let point = Coordinate3D(x: 300_000.0, y: 400_000.0, projection: .epsg3857)
+        let expected = 500_000.0 // 3-4-5 triangle
+
+        #expect(abs(origin.distance(from: point) - expected) < 1e-6)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/EnumerateCoordinatesTests.swift
+++ b/Tests/GISToolsTests/Algorithms/EnumerateCoordinatesTests.swift
@@ -1,0 +1,76 @@
+@testable import GISTools
+import Testing
+
+struct EnumerateCoordinatesTests {
+
+    @Test func featureCollection() {
+        let a = Coordinate3D(latitude: 1.0, longitude: 2.0)
+        let b = Coordinate3D(latitude: 3.0, longitude: 4.0)
+        let c = Coordinate3D(latitude: 5.0, longitude: 6.0)
+        let collection = FeatureCollection([
+            Feature(Point(a)),
+            Feature(LineString([b, c])!),
+        ])
+
+        var visited: [(Int, Int, Coordinate3D)] = []
+        collection.enumerateCoordinates { featureIndex, coordIndex, coord in
+            visited.append((featureIndex, coordIndex, coord))
+        }
+
+        #expect(visited.count == 3)
+        #expect(visited[0] == (0, 0, a))
+        #expect(visited[1] == (1, 0, b))
+        #expect(visited[2] == (1, 1, c))
+    }
+
+    @Test func feature() {
+        let a = Coordinate3D(latitude: 1.0, longitude: 2.0)
+        let b = Coordinate3D(latitude: 3.0, longitude: 4.0)
+        let feature = Feature(LineString([a, b])!)
+
+        var visited: [(Int, Coordinate3D)] = []
+        feature.enumerateCoordinates { index, coord in
+            visited.append((index, coord))
+        }
+
+        #expect(visited.count == 2)
+        #expect(visited[0] == (0, a))
+        #expect(visited[1] == (1, b))
+    }
+
+    @Test func geometryCollection() {
+        let a = Coordinate3D(latitude: 1.0, longitude: 2.0)
+        let b = Coordinate3D(latitude: 3.0, longitude: 4.0)
+        let c = Coordinate3D(latitude: 5.0, longitude: 6.0)
+        let collection = GeometryCollection([
+            Point(a),
+            LineString([b, c])!,
+        ])
+
+        var visited: [(Int, Int, Coordinate3D)] = []
+        collection.enumerateCoordinates { geometryIndex, coordIndex, coord in
+            visited.append((geometryIndex, coordIndex, coord))
+        }
+
+        #expect(visited.count == 3)
+        #expect(visited[0] == (0, 0, a))
+        #expect(visited[1] == (1, 0, b))
+        #expect(visited[2] == (1, 1, c))
+    }
+
+    @Test func geoJsonGeometry() {
+        let a = Coordinate3D(latitude: 1.0, longitude: 2.0)
+        let b = Coordinate3D(latitude: 3.0, longitude: 4.0)
+        let lineString = LineString([a, b])!
+
+        var visited: [(Int, Coordinate3D)] = []
+        (lineString as GeoJsonGeometry).enumerateCoordinates { index, coord in
+            visited.append((index, coord))
+        }
+
+        #expect(visited.count == 2)
+        #expect(visited[0] == (0, a))
+        #expect(visited[1] == (1, b))
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/EnumeratePropertiesTests.swift
+++ b/Tests/GISToolsTests/Algorithms/EnumeratePropertiesTests.swift
@@ -1,0 +1,45 @@
+@testable import GISTools
+import Testing
+
+struct EnumeratePropertiesTests {
+
+    @Test func enumerateProperties() async throws {
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let feature1 = Feature(point, properties: ["name": "Alpha", "value": 1])
+        let feature2 = Feature(point, properties: ["name": "Beta", "value": 2])
+        let feature3 = Feature(point, properties: [:])
+        let collection = FeatureCollection([feature1, feature2, feature3])
+
+        var visited: [(Int, [String: Sendable])] = []
+        collection.enumerateProperties { index, properties in
+            visited.append((index, properties))
+        }
+
+        #expect(visited.count == 3)
+        #expect(visited[0].0 == 0)
+        #expect(visited[0].1["name"] as? String == "Alpha")
+        #expect(visited[1].0 == 1)
+        #expect(visited[1].1["value"] as? Int == 2)
+        #expect(visited[2].0 == 2)
+        #expect(visited[2].1.isEmpty)
+    }
+
+    @Test func propertiesSummary() async throws {
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let feature1 = Feature(point, properties: ["name": "Alpha", "category": "A"])
+        let feature2 = Feature(point, properties: ["name": "Beta", "category": "B"])
+        let feature3 = Feature(point, properties: ["category": "A", "extra": true])
+        let collection = FeatureCollection([feature1, feature2, feature3])
+
+        let summary = collection.propertiesSummary()
+        #expect(summary["name"]?.count == 2)
+        #expect(summary["name"]?.contains("Alpha") == true)
+        #expect(summary["name"]?.contains("Beta") == true)
+        #expect(summary["category"]?.count == 2)
+        #expect(summary["category"]?.contains("A") == true)
+        #expect(summary["category"]?.contains("B") == true)
+        #expect(summary["extra"]?.count == 1)
+        #expect(summary["extra"]?.contains(true) == true)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/FrechetDistanceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/FrechetDistanceTests.swift
@@ -2,6 +2,7 @@
 import CoreLocation
 #endif
 @testable import GISTools
+import Foundation
 import Testing
 
 struct FrechetDistanceTests {
@@ -29,6 +30,90 @@ struct FrechetDistanceTests {
 
         let distanceEucliden = lineArc1.frechetDistance(from: lineArc2, distanceFunction: .euclidean)
         #expect(abs(distanceEucliden - 1000.0) < 2.0)
+    }
+
+    // Validates Frechet distance with unequal-length coordinate arrays (regression for bug #1).
+    @Test
+    func frechetDistanceUnequalLengths() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.0, longitude: 0.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.5),
+            Coordinate3D(latitude: 2.0, longitude: 0.5),
+        ]))
+
+        let distance = line1.frechetDistance(from: line2, distanceFunction: .haversine)
+        #expect(distance > 0.0)
+        #expect(distance < 200_000.0)
+    }
+
+    // Validates Frechet distance with a custom distance function.
+    @Test
+    func frechetDistanceCustomFunction() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+
+        let distance = line1.frechetDistance(
+            from: line2,
+            distanceFunction: .other({ a, b in
+                hypot(a.longitude - b.longitude, a.latitude - b.latitude)
+            })
+        )
+        #expect(distance == 0.0)
+    }
+
+    // Validates Frechet distance with segmentLength producing different intermediate point counts.
+    @Test
+    func frechetDistanceWithSegmentLength() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.5),
+        ]))
+
+        let distance = line1.frechetDistance(from: line2, distanceFunction: .haversine, segmentLength: 10_000.0)
+        #expect(distance > 0.0)
+    }
+
+    // Fréchet distance of a line with itself is zero.
+    @Test
+    func frechetDistanceSelf() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+
+        let distance = line.frechetDistance(from: line, distanceFunction: .haversine)
+        #expect(distance == 0.0)
+    }
+
+    // Fréchet distance between two parallel lines equals their separation.
+    @Test
+    func frechetDistanceParallelLines() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+
+        let distance = line1.frechetDistance(from: line2, distanceFunction: .euclidean)
+        #expect(abs(distance - 1.0) < 0.0001)
     }
 
 }

--- a/Tests/GISToolsTests/Algorithms/FrechetDistanceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/FrechetDistanceTests.swift
@@ -32,7 +32,7 @@ struct FrechetDistanceTests {
         #expect(abs(distanceEucliden - 1000.0) < 2.0)
     }
 
-    // Validates Frechet distance with unequal-length coordinate arrays (regression for bug #1).
+    // Validates Frechet distance with unequal-length coordinate arrays.
     @Test
     func frechetDistanceUnequalLengths() async throws {
         let line1 = try #require(LineString([

--- a/Tests/GISToolsTests/Algorithms/LineIntersectionTests.swift
+++ b/Tests/GISToolsTests/Algorithms/LineIntersectionTests.swift
@@ -17,7 +17,7 @@ struct LineIntersectionTests {
                 Coordinate3D(latitude: -14.008696, longitude: 127.22168),
             ])!)
 
-        let intersections: [Point] = feature1.intersections(other: feature2)
+        let intersections: [Point] = feature1.intersections(with: feature2)
         let results: [Point] = [Point(Coordinate3D(latitude: -14.835723, longitude: 125.583754))]
 
         #expect(intersections.count == 1)
@@ -31,7 +31,7 @@ struct LineIntersectionTests {
         let lineString1 = try TestData.lineString(package: "LineIntersection", name: "LineIntersectionDouble1")
         let lineString2 = try TestData.lineString(package: "LineIntersection", name: "LineIntersectionDouble2")
 
-        let intersections: [Point] = lineString1.intersections(other: lineString2)
+        let intersections: [Point] = lineString1.intersections(with: lineString2)
         let results: [Point] = [
             Point(Coordinate3D(latitude: -11.630938, longitude: 132.808697)),
             Point(Coordinate3D(latitude: -19.58857, longitude: 119.832884)),
@@ -57,7 +57,7 @@ struct LineIntersectionTests {
         let polygon1 = try TestData.polygon(package: "LineIntersection", name: "LineIntersectionPolygonsWithHoles1")
         let polygon2 = try TestData.polygon(package: "LineIntersection", name: "LineIntersectionPolygonsWithHoles2")
 
-        let intersections: [Point] = polygon1.intersections(other: polygon2)
+        let intersections: [Point] = polygon1.intersections(with: polygon2)
         let results: [Point] = [
             Point(Coordinate3D(latitude: -33.654475, longitude: 120.170188)),
             Point(Coordinate3D(latitude: -19.242649, longitude: 118.465639)),
@@ -99,7 +99,7 @@ struct LineIntersectionTests {
         let multiLineString1 = try TestData.multiLineString(package: "LineIntersection", name: "LineIntersectionMultiLineStrings1")
         let multiLineString2 = try TestData.multiLineString(package: "LineIntersection", name: "LineIntersectionMultiLineStrings2")
 
-        let intersections: [Point] = multiLineString1.intersections(other: multiLineString2)
+        let intersections: [Point] = multiLineString1.intersections(with: multiLineString2)
         let results: [Point] = [
             Point(Coordinate3D(latitude: -14.675333, longitude: 136.479474)),
             Point(Coordinate3D(latitude: -14.506578, longitude: 136.389417)),
@@ -133,7 +133,7 @@ struct LineIntersectionTests {
         let lineString1 = try TestData.lineString(package: "LineIntersection", name: "LineIntersectionSameCoordinates1")
         let lineString2 = try TestData.lineString(package: "LineIntersection", name: "LineIntersectionSameCoordinates2")
 
-        let intersections: [Point] = lineString1.intersections(other: lineString2)
+        let intersections: [Point] = lineString1.intersections(with: lineString2)
         let results: [Point] = [
             Point(Coordinate3D(latitude: -20, longitude: 120)),
             Point(Coordinate3D(latitude: -20, longitude: 130)),

--- a/Tests/GISToolsTests/Algorithms/LineSliceAlongTests.swift
+++ b/Tests/GISToolsTests/Algorithms/LineSliceAlongTests.swift
@@ -35,4 +35,45 @@ struct LineSliceAlongTests {
         #expect(sliced.coordinates[sliced.coordinates.count - 1] == endCoordinate)
     }
 
+    // Verifies that slicing at the very start of the line produces a valid zero-length segment.
+    @Test
+    func sliceStartAtZero() async throws {
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 22.466878364528448, longitude: -97.88131713867188),
+            Coordinate3D(latitude: 22.17596, longitude: -97.820892),
+        ]))
+
+        let sliced = try #require(lineString.sliceAlong(startDistance: 0.0, stopDistance: 0.0))
+        #expect(sliced.coordinates.count >= 2)
+        #expect(sliced.coordinates[0] == sliced.coordinates[1])
+    }
+
+    // Verifies that slicing exactly at a vertex (start boundary) returns a valid LineString.
+    @Test
+    func sliceStartAtFirstVertex() async throws {
+        let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let b = Coordinate3D(latitude: 1.0, longitude: 0.0)
+        let c = Coordinate3D(latitude: 2.0, longitude: 0.0)
+        let lineString = try #require(LineString([a, b, c]))
+
+        // Distance from (0,0) to (1,0) ≈ 111,319.5 m.
+        // Slicing from exactly that distance should hit the start-at-vertex branch.
+        let vertexDistance = a.distance(from: b)
+        let sliced = try #require(lineString.sliceAlong(startDistance: vertexDistance, stopDistance: 200_000.0))
+        #expect(sliced.coordinates.count >= 2)
+        #expect(sliced.coordinates[0] == b)
+    }
+
+    // Verifies that slicing to the end of the line returns the last segment.
+    @Test
+    func sliceStopAtEnd() async throws {
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+        ]))
+
+        let sliced = try #require(lineString.sliceAlong(startDistance: 50_000.0, stopDistance: .greatestFiniteMagnitude))
+        #expect(sliced.coordinates.count >= 2)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/NearestCoordinateOnLineTests.swift
+++ b/Tests/GISToolsTests/Algorithms/NearestCoordinateOnLineTests.swift
@@ -150,4 +150,46 @@ struct NearestCoordinateOnLineTests {
         #expect(nearestCoordinate == result)
     }
 
+    // MARK: - Early-exit regression tests
+
+    // Verifies that every segment is evaluated, not stopping at the first
+    // within 1 m. A later segment may be even closer.
+    @Test
+    func closestOnLaterSegmentAtRightAngle() async throws {
+        // Line: 0.0009° (≈100 m) east, then 0.0018° (≈200 m) north.
+        // Query point is 0.5 m north and 0.5 m east of the corner.
+        //   - Seg 0 clamped foot (corner) distance ≈ 0.71 m (would trigger old early exit)
+        //   - Seg 1 interpolated foot distance ≈ 0.50 m (correctly closer)
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0009),
+            Coordinate3D(latitude: 0.0018, longitude: 0.0009),
+        ]))
+        let query = Coordinate3D(latitude: 0.0000045, longitude: 0.0009045)
+        let expected = Coordinate3D(latitude: 0.0000045, longitude: 0.0009)
+
+        let result = try #require(lineString.nearestCoordinateOnLine(from: query))
+        #expect(result.index == 1)
+        #expect(result.coordinate == expected)
+    }
+
+    // Verifies that the closest point on a multi-segment line is always
+    // found, even when the early segments are far away.
+    @Test
+    func closestOnLastSegment() async throws {
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.01),
+            Coordinate3D(latitude: 0.01, longitude: 0.01),
+            Coordinate3D(latitude: 0.02, longitude: 0.01),
+        ]))
+        // Query near the midpoint of the last segment
+        let query = Coordinate3D(latitude: 0.015, longitude: 0.0100001)
+        let expected = Coordinate3D(latitude: 0.015, longitude: 0.01)
+
+        let result = try #require(lineString.nearestCoordinateOnLine(from: query))
+        #expect(result.index == 2)
+        #expect(result.coordinate == expected)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/NearestPointToLineTests.swift
+++ b/Tests/GISToolsTests/Algorithms/NearestPointToLineTests.swift
@@ -6,7 +6,7 @@ struct NearestPointToLineTests {
 
     // Verifies that the nearest coordinate to a line is selected from a list of candidates.
     @Test
-    func nearestCoordinateOutOf() async throws {
+    func nearestCoordinateFrom() async throws {
         let ls = try #require(LineString([
             Coordinate3D(latitude: 0.0, longitude: 0.0),
             Coordinate3D(latitude: 0.0, longitude: 10.0),
@@ -16,7 +16,7 @@ struct NearestPointToLineTests {
             Coordinate3D(latitude: 10.0, longitude: 1.0),
             Coordinate3D(latitude: 0.0, longitude: 1.0),
         ]
-        let result = try #require(ls.nearestCoordinate(outOf: candidates))
+        let result = try #require(ls.nearestCoordinate(from: candidates))
         // (0, 1) is closest to the line (which runs along lon=0)
         #expect(result.coordinate == Coordinate3D(latitude: 0.0, longitude: 1.0))
     }
@@ -32,18 +32,18 @@ struct NearestPointToLineTests {
             Point(Coordinate3D(latitude: 5.0, longitude: 5.0)),
             Point(Coordinate3D(latitude: 0.0, longitude: 2.0)),
         ]
-        let result = try #require(ls.nearestPointAndDistance(outOf: candidates))
+        let result = try #require(ls.nearestPointAndDistance(from: candidates))
         #expect(result.point.coordinate == Coordinate3D(latitude: 0.0, longitude: 2.0))
     }
 
     // Verifies that an empty candidate list returns nil when querying the nearest coordinate.
     @Test
-    func nearestCoordinateOutOfEmpty() async throws {
+    func nearestCoordinateFromEmpty() async throws {
         let ls = try #require(LineString([
             Coordinate3D(latitude: 0.0, longitude: 0.0),
             Coordinate3D(latitude: 0.0, longitude: 10.0),
         ]))
-        #expect(ls.nearestCoordinate(outOf: []) == nil)
+        #expect(ls.nearestCoordinate(from: []) == nil)
     }
 
 }

--- a/Tests/GISToolsTests/Algorithms/PolygonToLineTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PolygonToLineTests.swift
@@ -1,0 +1,70 @@
+@testable import GISTools
+import Testing
+
+struct PolygonToLineTests {
+
+    @Test func singlePolygon() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let result = polygon.lineStrings
+        #expect(result.count == 1)
+        #expect(result[0].lineStrings.count == 1)
+        #expect(result[0].lineStrings[0].coordinates.count == polygon.rings[0].coordinates.count)
+    }
+
+    @Test func multiPolygon() async throws {
+        let polygon1 = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let polygon2 = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 20.0, longitude: 10.0),
+                Coordinate3D(latitude: 20.0, longitude: 20.0),
+                Coordinate3D(latitude: 10.0, longitude: 20.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+            ],
+        ]))
+        let multiPolygon = try #require(MultiPolygon([polygon1, polygon2]))
+        let result = multiPolygon.lineStrings
+        #expect(result.count == 2)
+        #expect(result[0].lineStrings[0].coordinates.count == polygon1.rings[0].coordinates.count)
+        #expect(result[1].lineStrings[0].coordinates.count == polygon2.rings[0].coordinates.count)
+    }
+
+    @Test func polygonWithHole() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 20.0, longitude: 0.0),
+                Coordinate3D(latitude: 20.0, longitude: 20.0),
+                Coordinate3D(latitude: 0.0, longitude: 20.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+            [
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 5.0, longitude: 15.0),
+                Coordinate3D(latitude: 15.0, longitude: 15.0),
+                Coordinate3D(latitude: 15.0, longitude: 5.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+            ],
+        ]))
+        let result = polygon.lineStrings
+        #expect(result.count == 1)
+        #expect(result[0].lineStrings.count == 2)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/ReverseTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ReverseTests.swift
@@ -84,4 +84,32 @@ struct ReverseTests {
         #expect(reversed.features[0].allCoordinates == [Coordinate3D(latitude: 40.0, longitude: 40.0)])
     }
 
+    // Tests that GeometryCollection reverses coordinates within each geometry
+    // but preserves the order of geometries.
+    @Test
+    func geometryCollection() async throws {
+        let geometryCollection = GeometryCollection([
+            try #require(LineString([
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 1.0),
+            ])),
+            Point(Coordinate3D(latitude: 20.0, longitude: 20.0)),
+            try #require(MultiLineString([[
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 1.0),
+            ]])),
+        ])
+        let reversed = geometryCollection.reversed
+
+        // Geometry order is preserved
+        #expect(reversed.geometries[0].type == .lineString)
+        #expect(reversed.geometries[1].type == .point)
+        #expect(reversed.geometries[2].type == .multiLineString)
+
+        // Coordinates within each geometry are reversed
+        #expect(reversed.geometries[0].allCoordinates.map(\.latitude) == [1.0, 0.0])
+        #expect(reversed.geometries[1].allCoordinates.map(\.latitude) == [20.0])
+        #expect(reversed.geometries[2].allCoordinates.map(\.latitude) == [1.0, 0.0])
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/RhumbBearingTests.swift
+++ b/Tests/GISToolsTests/Algorithms/RhumbBearingTests.swift
@@ -19,4 +19,17 @@ struct RhumbBearingTests {
         #expect(abs(finalBearing - -104.719) < 0.01)
     }
 
+    // Tests rhumb bearing calculation with .noSRID (Cartesian coordinates).
+    @Test
+    func rhumbBearingNoSRID() async throws {
+        let origin = Coordinate3D(x: 0.0, y: 0.0, projection: .noSRID)
+        let east = Coordinate3D(x: 1.0, y: 0.0, projection: .noSRID)
+        let north = Coordinate3D(x: 0.0, y: 1.0, projection: .noSRID)
+        let northEast = Coordinate3D(x: 1.0, y: 1.0, projection: .noSRID)
+
+        #expect(abs(origin.rhumbBearing(to: east) - 90.0) < 1e-10)
+        #expect(abs(origin.rhumbBearing(to: north)) < 1e-10)
+        #expect(abs(origin.rhumbBearing(to: northEast) - 45.0) < 1e-10)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/RhumbDestinationTests.swift
+++ b/Tests/GISToolsTests/Algorithms/RhumbDestinationTests.swift
@@ -67,4 +67,28 @@ struct RhumbDestinationTests {
         #expect(other == result)
     }
 
+    // Tests rhumb destination with .noSRID (Cartesian coordinates).
+    @Test
+    func rhumbDestinationNoSRID() async throws {
+        let origin = Coordinate3D(x: 0.0, y: 0.0, projection: .noSRID)
+
+        let north = origin.rhumbDestination(distance: 10.0, bearing: 0.0)
+        #expect(abs(north.latitude - 10.0) < 1e-10)
+        #expect(abs(north.longitude) < 1e-10)
+        #expect(north.projection == .noSRID)
+
+        let east = origin.rhumbDestination(distance: 10.0, bearing: 90.0)
+        #expect(abs(east.longitude - 10.0) < 1e-10)
+        #expect(abs(east.latitude) < 1e-10)
+
+        let south = origin.rhumbDestination(distance: 10.0, bearing: 180.0)
+        #expect(abs(south.latitude + 10.0) < 1e-10)
+        #expect(abs(south.longitude) < 1e-10)
+
+        let angle = origin.rhumbDestination(distance: 10.0, bearing: 45.0)
+        let expected = 10.0 * 0.7071067811865476
+        #expect(abs(angle.longitude - expected) < 1e-10)
+        #expect(abs(angle.latitude - expected) < 1e-10)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/RhumbDistanceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/RhumbDistanceTests.swift
@@ -96,4 +96,22 @@ struct RhumbDistanceTests {
         #expect(abs(distance - 111_319.5) < 200.0)
     }
 
+    // Validates rhumb distance in noSRID (Euclidean on Cartesian plane).
+    @Test
+    func distanceNoSRID() async throws {
+        let origin = Coordinate3D(x: 0.0, y: 0.0, projection: .noSRID)
+        let point = Coordinate3D(x: 3.0, y: 4.0, projection: .noSRID)
+
+        #expect(abs(origin.rhumbDistance(from: point) - 5.0) < 1e-12)
+    }
+
+    // Validates rhumb distance symmetry in noSRID.
+    @Test
+    func distanceNoSRIDSymmetry() async throws {
+        let a = Coordinate3D(x: 10.0, y: 20.0, projection: .noSRID)
+        let b = Coordinate3D(x: 30.0, y: 50.0, projection: .noSRID)
+
+        #expect(abs(a.rhumbDistance(from: b) - b.rhumbDistance(from: a)) < 1e-12)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/RhumbDistanceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/RhumbDistanceTests.swift
@@ -31,4 +31,69 @@ struct RhumbDistanceTests {
         #expect(abs(coordinate7.rhumbDistance(from: coordinate8) - expectedDistance4) < 0.001)
     }
 
+    // Validates rhumb distance symmetry (A→B equals B→A).
+    @Test
+    func distanceSymmetry() async throws {
+        let a = Coordinate3D(latitude: 40.0, longitude: -75.0)
+        let b = Coordinate3D(latitude: 35.0, longitude: -80.0)
+
+        let d1 = a.rhumbDistance(from: b)
+        let d2 = b.rhumbDistance(from: a)
+
+        #expect(abs(d1 - d2) < 0.001)
+    }
+
+    // Validates rhumb distance with antimeridian crossing where compensation is active.
+    @Test
+    func distanceAntimeridian() async throws {
+        // Points straddling the antimeridian that trigger the longitude compensation
+        let east = Coordinate3D(latitude: 0.0, longitude: 179.0)
+        let west = Coordinate3D(latitude: 0.0, longitude: -179.0)
+
+        let distance = east.rhumbDistance(from: west)
+        #expect(distance > 0.0)
+        #expect(distance < 300_000.0)  // ~2 degrees at equator = ~222km
+    }
+
+    // Validates rhumb distance between two identical coordinates is zero.
+    @Test
+    func distanceZero() async throws {
+        let coordinate = Coordinate3D(latitude: 40.0, longitude: -75.0)
+        #expect(coordinate.rhumbDistance(from: coordinate) == 0.0)
+    }
+
+    // Validates rhumb distance via the Point wrapper.
+    @Test
+    func distancePoint() async throws {
+        let point1 = Point(Coordinate3D(latitude: 39.984, longitude: -75.343))
+        let point2 = Point(Coordinate3D(latitude: 39.123, longitude: -75.534))
+
+        let pointDistance = point1.rhumbDistance(from: point2)
+        let coordDistance = point1.coordinate.rhumbDistance(from: point2.coordinate)
+
+        #expect(abs(pointDistance - coordDistance) < 0.001)
+    }
+
+    // Validates rhumb distance in EPSG:3857 projection.
+    @Test
+    func distance3857() async throws {
+        let coord1 = Coordinate3D(latitude: 40.0, longitude: -75.0).projected(to: .epsg3857)
+        let coord2 = Coordinate3D(latitude: 39.0, longitude: -74.0).projected(to: .epsg3857)
+
+        let distance3857 = coord1.rhumbDistance(from: coord2)
+        #expect(distance3857 > 0.0)
+        #expect(distance3857 < 500_000.0)
+    }
+
+    // Validates north-south rhumb distance.
+    @Test
+    func distanceNorthSouth() async throws {
+        // 1 degree of latitude ≈ 111km
+        let north = Coordinate3D(latitude: 10.0, longitude: 0.0)
+        let south = Coordinate3D(latitude: 9.0, longitude: 0.0)
+
+        let distance = north.rhumbDistance(from: south)
+        #expect(abs(distance - 111_319.5) < 200.0)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/TileCoverTests.swift
+++ b/Tests/GISToolsTests/Algorithms/TileCoverTests.swift
@@ -3,30 +3,290 @@ import Testing
 
 struct TileCoverTests {
 
-    // Validates tile cover calculation for a single point at zoom level 1.
+    // MARK: - Point
+
     @Test
-    func tileCover1() async throws {
+    func pointTileCover() {
         let point = Point(Coordinate3D(latitude: 45.0, longitude: 90.0))
-        let tileCover = point.tileCover(atZoom: 1)
-        #expect(tileCover == [MapTile(x: 1, y: 0, z: 1)])
+        let tiles = point.tileCover(atZoom: 1)
+        #expect(tiles == [MapTile(x: 1, y: 0, z: 1)])
     }
 
-    // Validates tile cover calculation for a line string at zoom level 2.
     @Test
-    func tileCover2() async throws {
+    func multiPointTileCover() throws {
+        let multiPoint = try #require(MultiPoint([
+            Coordinate3D(latitude: 45.0, longitude: 90.0),
+            Coordinate3D(latitude: -45.0, longitude: -90.0),
+        ]))
+        let tiles = multiPoint.tileCover(atZoom: 1)
+        #expect(Set(tiles) == Set([
+            MapTile(x: 1, y: 0, z: 1),
+            MapTile(x: 0, y: 1, z: 1),
+        ]))
+    }
+
+    // MARK: - Line string (edge walking)
+
+    @Test
+    func lineStringQuadTileCover() throws {
         let lineString = try #require(LineString([
             Coordinate3D(latitude: 10.0, longitude: -10.0),
             Coordinate3D(latitude: 10.0, longitude: 10.0),
             Coordinate3D(latitude: -10.0, longitude: 10.0),
             Coordinate3D(latitude: -10.0, longitude: -10.0),
         ]))
-        let tileCover = lineString.tileCover(atZoom: 2)
-        #expect(Set(tileCover) == Set([
+        let tiles = lineString.tileCover(atZoom: 2)
+        #expect(Set(tiles) == Set([
             MapTile(x: 1, y: 1, z: 2),
             MapTile(x: 1, y: 2, z: 2),
             MapTile(x: 2, y: 1, z: 2),
             MapTile(x: 2, y: 2, z: 2),
         ]))
+    }
+
+    @Test
+    func lineStringDiagonalCoversIntermediateTiles() throws {
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 80.0, longitude: -170.0),
+            Coordinate3D(latitude: -80.0, longitude: 170.0),
+        ]))
+        let tiles = lineString.tileCover(atZoom: 2)
+        // At zoom 2 (4×4 world), a diagonal across the whole
+        // world crosses every column and row
+        #expect(tiles.count >= 4)
+        #expect(tiles.count > 2)
+        let distinctX = Set(tiles.map(\.x))
+        let distinctY = Set(tiles.map(\.y))
+        #expect(distinctX.count >= 2)
+        #expect(distinctY.count >= 2)
+    }
+
+    @Test
+    func lineStringHorizontalEdgeCrossesMultipleTiles() throws {
+        // A horizontal line crossing the equator spanning many tiles
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: -45.0),
+            Coordinate3D(latitude: 0.0, longitude: 45.0),
+        ]))
+        let tiles = lineString.tileCover(atZoom: 3)
+        // At zoom 3 (8×8), longitude -45°→45° covers tiles x=3,4,5.
+        let sortedTiles = tiles.sorted { $0.x < $1.x }
+        #expect(sortedTiles.count >= 3)
+        #expect(sortedTiles.first?.x ?? 0 <= 3)
+        #expect(sortedTiles.last?.x ?? 0 >= 5)
+        // All tiles should be at the same y
+        let uniqueY = Set(tiles.map(\.y))
+        #expect(uniqueY.count == 1)
+    }
+
+    @Test
+    func lineStringVerticalEdgeCrossesMultipleTiles() throws {
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 60.0, longitude: 0.0),
+            Coordinate3D(latitude: -60.0, longitude: 0.0),
+        ]))
+        let tiles = lineString.tileCover(atZoom: 3)
+        let sortedTiles = tiles.sorted { $0.y < $1.y }
+        #expect(sortedTiles.count >= 4)
+        #expect(sortedTiles.first?.y ?? 0 >= 1)
+        #expect(sortedTiles.last?.y ?? 0 <= 6)
+        let uniqueX = Set(tiles.map(\.x))
+        #expect(uniqueX.count == 1)
+    }
+
+    // MARK: - Polygon
+
+    @Test
+    func polygonTileCover() throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 10.0, longitude: -10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: -10.0, longitude: 10.0),
+            Coordinate3D(latitude: -10.0, longitude: -10.0),
+        ]]))
+        let tiles = polygon.tileCover(atZoom: 2)
+        #expect(Set(tiles) == Set([
+            MapTile(x: 1, y: 1, z: 2),
+            MapTile(x: 1, y: 2, z: 2),
+            MapTile(x: 2, y: 1, z: 2),
+            MapTile(x: 2, y: 2, z: 2),
+        ]))
+    }
+
+    @Test
+    func polygonTileCoverWithInterior() throws {
+        // A polygon covering a 3×3 block of tiles at zoom 2.
+        // Roughly spans across tiles x: 0-2 and y: 0-2.
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 30.0, longitude: -50.0),
+            Coordinate3D(latitude: 30.0, longitude: 50.0),
+            Coordinate3D(latitude: -30.0, longitude: 50.0),
+            Coordinate3D(latitude: -30.0, longitude: -50.0),
+        ]]))
+        let tiles = polygon.tileCover(atZoom: 2)
+        // At zoom 2 (4×4 world), a polygon spanning ~60° lat × 100° lon
+        // should cover at least 4 tiles
+        #expect(tiles.count >= 4)
+    }
+
+    @Test
+    func multiPolygonTileCover() throws {
+        let polygon1 = try #require(Polygon([[
+            Coordinate3D(latitude: 10.0, longitude: -10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: -10.0, longitude: 10.0),
+            Coordinate3D(latitude: -10.0, longitude: -10.0),
+        ]]))
+        let polygon2 = try #require(Polygon([[
+            Coordinate3D(latitude: 60.0, longitude: -10.0),
+            Coordinate3D(latitude: 60.0, longitude: 10.0),
+            Coordinate3D(latitude: 40.0, longitude: 10.0),
+            Coordinate3D(latitude: 40.0, longitude: -10.0),
+        ]]))
+        let multiPolygon = try #require(MultiPolygon([polygon1, polygon2]))
+        let tiles = multiPolygon.tileCover(atZoom: 2)
+        #expect(!tiles.isEmpty)
+        #expect(tiles.contains(MapTile(x: 1, y: 1, z: 2)))
+        #expect(tiles.contains(MapTile(x: 2, y: 1, z: 2)))
+    }
+
+    @Test
+    func multiLineStringTileCover() throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 10.0, longitude: -10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: -10.0, longitude: -10.0),
+            Coordinate3D(latitude: -10.0, longitude: 10.0),
+        ]))
+        let multiLineString = try #require(MultiLineString([line1, line2]))
+        let tiles = multiLineString.tileCover(atZoom: 2)
+        #expect(tiles.contains(MapTile(x: 1, y: 1, z: 2)))
+        #expect(tiles.contains(MapTile(x: 2, y: 1, z: 2)))
+        #expect(tiles.contains(MapTile(x: 1, y: 2, z: 2)))
+        #expect(tiles.contains(MapTile(x: 2, y: 2, z: 2)))
+    }
+
+    // MARK: - Feature / FeatureCollection
+
+    @Test
+    func featureTileCover() {
+        let point = Point(Coordinate3D(latitude: 45.0, longitude: 90.0))
+        let feature = Feature(point)
+        let tiles = feature.tileCover(atZoom: 1)
+        #expect(tiles == [MapTile(x: 1, y: 0, z: 1)])
+    }
+
+    @Test
+    func featureCollectionTileCover() {
+        let point1 = Point(Coordinate3D(latitude: 45.0, longitude: 90.0))
+        let point2 = Point(Coordinate3D(latitude: -45.0, longitude: -90.0))
+        let collection = FeatureCollection([Feature(point1), Feature(point2)])
+        let tiles = collection.tileCover(atZoom: 1)
+        #expect(Set(tiles) == Set([
+            MapTile(x: 1, y: 0, z: 1),
+            MapTile(x: 0, y: 1, z: 1),
+        ]))
+    }
+
+    // MARK: - BoundingBox
+
+    @Test
+    func boundingBoxTileCover() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: -10.0, longitude: -10.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let tiles = bbox.tileCover(atZoom: 2)
+        #expect(Set(tiles) == Set([
+            MapTile(x: 1, y: 1, z: 2),
+            MapTile(x: 1, y: 2, z: 2),
+            MapTile(x: 2, y: 1, z: 2),
+            MapTile(x: 2, y: 2, z: 2),
+        ]))
+    }
+
+    // MARK: - Edge cases
+
+    @Test
+    func zoomLevelZero() {
+        let point = Point(Coordinate3D(latitude: 45.0, longitude: 90.0))
+        let tiles = point.tileCover(atZoom: 0)
+        #expect(tiles == [MapTile(x: 0, y: 0, z: 0)])
+    }
+
+    @Test
+    func highZoomLevel() {
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let tiles = point.tileCover(atZoom: 18)
+        #expect(tiles.count == 1)
+        #expect(tiles.first?.z == 18)
+    }
+
+    @Test
+    func coordinateOnTileBoundary() {
+        // These coordinates fall exactly on tile boundaries at zoom 1
+        // (lat=0, lon=0 maps to the intersection of all 4 tiles at zoom 1,
+        // but the tile algorithm should include it in one of them).
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let tiles = point.tileCover(atZoom: 1)
+        #expect(tiles.count == 1)
+    }
+
+    @Test
+    func emptyMultiPointReturnsNil() {
+        let multiPoint: MultiPoint? = MultiPoint([] as [Coordinate3D])
+        #expect(multiPoint == nil)
+    }
+
+    // MARK: - Anti-meridian
+
+    @Test
+    func lineStringAcrossAntiMeridian() throws {
+        // A line crossing the anti-meridian (180° longitude).
+        // Per RFC 7946 the shortest path is taken, which crosses
+        // the date line and only covers tiles at both edges.
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+        ]))
+        let tiles = lineString.tileCover(atZoom: 2)
+        #expect(Set(tiles) == Set([
+            MapTile(x: 0, y: 2, z: 2),
+            MapTile(x: 3, y: 2, z: 2),
+        ]))
+    }
+
+    @Test
+    func boundingBoxAcrossAntiMeridian() {
+        // A bounding box crossing the anti-meridian is internally
+        // represented as a MultiPolygon split at ±180°, so the
+        // tile cover correctly covers tiles on both hemispheres.
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: -10.0, longitude: 170.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: -170.0))
+        let tiles = bbox.tileCover(atZoom: 2)
+        #expect(!tiles.isEmpty)
+        let xs = Set(tiles.map(\.x))
+        #expect(xs.contains(0))
+        #expect(xs.contains(3))
+    }
+
+    @Test
+    func polygonAcrossAntiMeridian() throws {
+        // A polygon that crosses the anti-meridian, represented
+        // as a single Polygon with coordinates that span the
+        // date line (not split into a MultiPolygon).
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: -10.0, longitude: 170.0),
+            Coordinate3D(latitude: 10.0, longitude: 170.0),
+            Coordinate3D(latitude: 10.0, longitude: -170.0),
+            Coordinate3D(latitude: -10.0, longitude: -170.0),
+        ]]))
+        let tiles = polygon.tileCover(atZoom: 2)
+        #expect(!tiles.isEmpty)
+        let xs = Set(tiles.map(\.x))
+        #expect(xs.contains(0) || xs.contains(3))
     }
 
 }

--- a/Tests/GISToolsTests/Algorithms/TransformTranslateTests.swift
+++ b/Tests/GISToolsTests/Algorithms/TransformTranslateTests.swift
@@ -5,7 +5,7 @@ struct TransformTranslateTests {
 
     // Validates translating a point east and west using rhumb distance.
     @Test
-    func translate() async throws {
+    func translatePointEastWest() async throws {
         let point = Point(Coordinate3D(latitude: 10.0, longitude: 0.0))
         let result1 = Point(Coordinate3D(latitude: 10.0, longitude: 10.0))
         let result2 = Point(Coordinate3D(latitude: 10.0, longitude: -10.0))
@@ -18,6 +18,91 @@ struct TransformTranslateTests {
         #expect(translated2 == result2)
     }
 
+    // Validates translating a point west using a negative direction.
+    @Test
+    func translatePointNegativeDirection() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 0.0))
+        let result = Point(Coordinate3D(latitude: 10.0, longitude: -10.0))
+
+        let distance = point.coordinate.rhumbDistance(from: result.coordinate)
+        let translated = point.translated(distance: distance, direction: -90.0)
+
+        #expect(translated == result)
+    }
+
+    // Validates that translating with direction 0 (north) changes latitude.
+    @Test
+    func translatePointNorth() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 0.0))
+        let distance = 111_319.5  // ~1 degree at equator
+        let translated = point.translated(distance: distance, direction: 0.0)
+
+        #expect(translated.coordinate.latitude > 10.0)
+        #expect(abs(translated.coordinate.longitude) < 0.001)
+    }
+
+    // Validates translating a LineString.
+    @Test
+    func translateLineString() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+        ]))
+        let distance = 111_319.5  // ~1 degree at equator
+        let translated = line.translated(distance: distance, direction: 90.0)
+
+        let coords = translated.allCoordinates
+        #expect(coords.count == 2)
+        #expect(abs(coords[0].longitude - 1.0) < 0.01)
+        #expect(abs(coords[1].longitude - 1.0) < 0.01)
+    }
+
+    // Validates translating a Polygon.
+    @Test
+    func translatePolygon() async throws {
+        let polygon = try #require(Polygon([
+            [Coordinate3D(latitude: 0.0, longitude: 0.0),
+             Coordinate3D(latitude: 0.0, longitude: 1.0),
+             Coordinate3D(latitude: 1.0, longitude: 1.0),
+             Coordinate3D(latitude: 0.0, longitude: 0.0)],
+        ]))
+        let distance = 111_319.5  // ~1 degree at equator
+        let translated = polygon.translated(distance: distance, direction: 90.0)
+
+        let coords = translated.allCoordinates
+        for coord in coords {
+            #expect(abs(coord.longitude - 1.0) < 0.01 || abs(coord.longitude - 2.0) < 0.01)
+        }
+    }
+
+    // Validates translating a MultiPoint.
+    @Test
+    func translateMultiPoint() async throws {
+        let multiPoint = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+        let distance = 111_319.5  // ~1 degree at equator
+        let translated = multiPoint.translated(distance: distance, direction: 90.0)
+
+        let coords = translated.allCoordinates
+        #expect(coords.count == 2)
+        #expect(abs(coords[0].longitude - 1.0) < 0.01)
+        #expect(abs(coords[1].longitude - 2.0) < 0.01)
+    }
+
+    // Validates the mutating translate method.
+    @Test
+    func translateMutating() async throws {
+        var point = Point(Coordinate3D(latitude: 10.0, longitude: 0.0))
+        let result = Point(Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let distance = point.coordinate.rhumbDistance(from: result.coordinate)
+
+        point.translate(distance: distance, direction: 90.0)
+
+        #expect(point == result)
+    }
+
     // Validates translating a point east with an altitude adjustment.
     @Test
     func translateAltitude() async throws {
@@ -28,6 +113,40 @@ struct TransformTranslateTests {
         let translated = point.translated(distance: distance, direction: 90.0, zTranslation: 250.0)
 
         #expect(translated == result)
+    }
+
+    // Validates that zero distance returns the original geometry unchanged.
+    @Test
+    func translateZeroDistance() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
+        let translated = point.translated(distance: 0.0, direction: 90.0)
+        #expect(translated == point)
+    }
+
+    // Validates that zero translation with only zTranslation still moves vertically.
+    @Test
+    func translateOnlyZ() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0, altitude: 500.0))
+        let translated = point.translated(distance: 0.0, direction: 0.0, zTranslation: 100.0)
+        #expect(translated.coordinate.altitude == 600.0)
+    }
+
+    // Validates translating a Feature with properties.
+    @Test
+    func translateFeature() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+        ]))
+        let feature = Feature(line)
+        let distance = 111_319.5
+        let translated = feature.translated(distance: distance, direction: 90.0)
+
+        #expect(translated.geometry is LineString)
+        if let translatedLine = translated.geometry as? LineString {
+            let coords = translatedLine.allCoordinates
+            #expect(abs(coords[0].longitude - 1.0) < 0.01)
+        }
     }
 
 }

--- a/Tests/GISToolsTests/Algorithms/ValidatableTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ValidatableTests.swift
@@ -210,4 +210,27 @@ struct ValidatableTests {
         #expect(Feature.isValid(geoJson: ["type": "Feature"]) == false)
     }
 
+    // MARK: - validated property
+
+    @Test
+    func validatedReturnsSelfWhenValid() async throws {
+        let point = Point(Coordinate3D(latitude: 1.0, longitude: 1.0))
+        #expect(point.validated != nil)
+        #expect(point.validated?.isValid == true)
+    }
+
+    @Test
+    func validatedReturnsNilWhenInvalid() async throws {
+        let empty = MultiPoint()
+        #expect(empty.validated == nil)
+    }
+
+    @Test
+    func validatedFeatureCollection() async throws {
+        let valid = FeatureCollection([Feature(Point(Coordinate3D(latitude: 1.0, longitude: 1.0)))])
+        #expect(valid.validated != nil)
+        let invalid = FeatureCollection([Feature(LineString())])
+        #expect(invalid.validated == nil)
+    }
+
 }

--- a/Tests/GISToolsTests/Extensions/DoubleExtensionsTests.swift
+++ b/Tests/GISToolsTests/Extensions/DoubleExtensionsTests.swift
@@ -44,7 +44,7 @@ struct DoubleExtensionsTests {
         #expect(abs(GISTool.convertToMeters(1.0, .feet) - GISTool.convert(length: 1.0, from: .feet, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(1.0, .yards) - GISTool.convert(length: 1.0, from: .yards, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(1.0, .miles) - GISTool.convert(length: 1.0, from: .miles, to: .meters)!) < 0.001)
-        #expect(abs(GISTool.convertToMeters(1.0, .nauticalmiles) - GISTool.convert(length: 1.0, from: .nauticalmiles, to: .meters)!) < 0.001)
+        #expect(abs(GISTool.convertToMeters(1.0, .nauticalMiles) - GISTool.convert(length: 1.0, from: .nauticalMiles, to: .meters)!) < 0.001)
 
         // pi units
         #expect(abs(GISTool.convertToMeters(Double.pi, .meters) - GISTool.convert(length: Double.pi, from: .meters, to: .meters)!) < 0.001)
@@ -55,7 +55,7 @@ struct DoubleExtensionsTests {
         #expect(abs(GISTool.convertToMeters(Double.pi, .feet) - GISTool.convert(length: Double.pi, from: .feet, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(Double.pi, .yards) - GISTool.convert(length: Double.pi, from: .yards, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(Double.pi, .miles) - GISTool.convert(length: Double.pi, from: .miles, to: .meters)!) < 0.001)
-        #expect(abs(GISTool.convertToMeters(Double.pi, .nauticalmiles) - GISTool.convert(length: Double.pi, from: .nauticalmiles, to: .meters)!) < 0.001)
+        #expect(abs(GISTool.convertToMeters(Double.pi, .nauticalMiles) - GISTool.convert(length: Double.pi, from: .nauticalMiles, to: .meters)!) < 0.001)
 
         // -1 unit
         #expect(abs(GISTool.convertToMeters(-1.0, .meters) - -GISTool.convert(length: 1.0, from: .meters, to: .meters)!) < 0.001)
@@ -66,7 +66,7 @@ struct DoubleExtensionsTests {
         #expect(abs(GISTool.convertToMeters(-1.0, .feet) - -GISTool.convert(length: 1.0, from: .feet, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(-1.0, .yards) - -GISTool.convert(length: 1.0, from: .yards, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(-1.0, .miles) - -GISTool.convert(length: 1.0, from: .miles, to: .meters)!) < 0.001)
-        #expect(abs(GISTool.convertToMeters(-1.0, .nauticalmiles) - -GISTool.convert(length: 1.0, from: .nauticalmiles, to: .meters)!) < 0.001)
+        #expect(abs(GISTool.convertToMeters(-1.0, .nauticalMiles) - -GISTool.convert(length: 1.0, from: .nauticalMiles, to: .meters)!) < 0.001)
     }
 
 }

--- a/Tests/GISToolsTests/Extensions/IntExtensionsTests.swift
+++ b/Tests/GISToolsTests/Extensions/IntExtensionsTests.swift
@@ -15,7 +15,7 @@ struct IntExtensionsTests {
         #expect(abs(GISTool.convertToMeters(1, .feet) - GISTool.convert(length: 1.0, from: .feet, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(1, .yards) - GISTool.convert(length: 1.0, from: .yards, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(1, .miles) - GISTool.convert(length: 1.0, from: .miles, to: .meters)!) < 0.001)
-        #expect(abs(GISTool.convertToMeters(1, .nauticalmiles) - GISTool.convert(length: 1.0, from: .nauticalmiles, to: .meters)!) < 0.001)
+        #expect(abs(GISTool.convertToMeters(1, .nauticalMiles) - GISTool.convert(length: 1.0, from: .nauticalMiles, to: .meters)!) < 0.001)
 
         // 314 units
         #expect(abs(GISTool.convertToMeters(314, .meters) - GISTool.convert(length: 314.0, from: .meters, to: .meters)!) < 0.001)
@@ -26,7 +26,7 @@ struct IntExtensionsTests {
         #expect(abs(GISTool.convertToMeters(314, .feet) - GISTool.convert(length: 314.0, from: .feet, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(314, .yards) - GISTool.convert(length: 314.0, from: .yards, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(314, .miles) - GISTool.convert(length: 314.0, from: .miles, to: .meters)!) < 0.001)
-        #expect(abs(GISTool.convertToMeters(314, .nauticalmiles) - GISTool.convert(length: 314.0, from: .nauticalmiles, to: .meters)!) < 0.001)
+        #expect(abs(GISTool.convertToMeters(314, .nauticalMiles) - GISTool.convert(length: 314.0, from: .nauticalMiles, to: .meters)!) < 0.001)
 
         // -1 unit
         #expect(abs(GISTool.convertToMeters(-1, .meters) - -GISTool.convert(length: 1.0, from: .meters, to: .meters)!) < 0.001)
@@ -37,7 +37,7 @@ struct IntExtensionsTests {
         #expect(abs(GISTool.convertToMeters(-1, .feet) - -GISTool.convert(length: 1.0, from: .feet, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(-1, .yards) - -GISTool.convert(length: 1.0, from: .yards, to: .meters)!) < 0.001)
         #expect(abs(GISTool.convertToMeters(-1, .miles) - -GISTool.convert(length: 1.0, from: .miles, to: .meters)!) < 0.001)
-        #expect(abs(GISTool.convertToMeters(-1, .nauticalmiles) - -GISTool.convert(length: 1.0, from: .nauticalmiles, to: .meters)!) < 0.001)
+        #expect(abs(GISTool.convertToMeters(-1, .nauticalMiles) - -GISTool.convert(length: 1.0, from: .nauticalMiles, to: .meters)!) < 0.001)
     }
 
 }

--- a/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
+++ b/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
@@ -666,4 +666,32 @@ struct BoundingBoxTests {
         #expect(geometry is Polygon)
     }
 
+    // MARK: - position(of:)
+
+    // Validates position(of:) correctly identifies center, corner, and outside coordinates.
+    @Test
+    func positionOfCoordinate() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+
+        #expect(bbox.position(of: Coordinate3D(latitude: 5.0, longitude: 5.0)).contains(.center))
+        #expect(bbox.position(of: Coordinate3D(latitude: 9.0, longitude: 9.0)).contains(.top))
+        #expect(bbox.position(of: Coordinate3D(latitude: 9.0, longitude: 9.0)).contains(.right))
+        #expect(bbox.position(of: Coordinate3D(latitude: 1.0, longitude: 1.0)).contains(.bottom))
+        #expect(bbox.position(of: Coordinate3D(latitude: 1.0, longitude: 1.0)).contains(.left))
+        #expect(bbox.position(of: Coordinate3D(latitude: 20.0, longitude: 5.0)).contains(.outside))
+    }
+
+    // Validates position(of:) for Point and CLLocation overloads.
+    @Test
+    func positionOfPoint() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+
+        let point = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        #expect(bbox.position(of: point).contains(.center))
+    }
+
 }

--- a/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
+++ b/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
@@ -557,6 +557,77 @@ struct BoundingBoxTests {
         #expect(clamped == BoundingBox.world)
     }
 
+    // MARK: - Normalize
+
+    // Validates that `normalized()` preserves an already in-range bounding box.
+    @Test
+    func normalizedInRange() async throws {
+        let box = BoundingBox(
+            southWest: Coordinate3D(latitude: -45.0, longitude: 10.0),
+            northEast: Coordinate3D(latitude: 45.0, longitude: 20.0))
+        let n = box.normalized()
+        #expect(n.southWest.longitude == 10.0)
+        #expect(n.northEast.longitude == 20.0)
+    }
+
+    // Validates that `normalized()` handles a bounding box crossing the anti-meridian
+    // with longitudes that are already in the [-180, 180] range.
+    @Test
+    func normalizedCrossesAntiMeridian() async throws {
+        let box = BoundingBox(
+            southWest: Coordinate3D(latitude: -45.0, longitude: 170.0),
+            northEast: Coordinate3D(latitude: 45.0, longitude: -170.0))
+        let n = box.normalized()
+        #expect(n.southWest.longitude == 170.0)
+        #expect(n.northEast.longitude == -170.0)
+    }
+
+    // Validates that `normalized()` returns the full world when the original
+    // bounding box spans 360° or more of longitude.
+    @Test
+    func normalizedWidthSpansWorld() async throws {
+        let box = BoundingBox(
+            southWest: Coordinate3D(latitude: -45.0, longitude: -200.0),
+            northEast: Coordinate3D(latitude: 45.0, longitude: 200.0))
+        let n = box.normalized()
+        #expect(n.southWest.longitude == -180.0)
+        #expect(n.northEast.longitude == 180.0)
+    }
+
+    // Validates that `normalized()` correctly converts out-of-range longitudes
+    // to a wrapping (anti-meridian-crossing) representation.
+    @Test
+    func normalizedOutOfRangeBecomesWrapping() async throws {
+        let box = BoundingBox(
+            southWest: Coordinate3D(latitude: -45.0, longitude: 200.0),
+            northEast: Coordinate3D(latitude: 45.0, longitude: 160.0))
+        let n = box.normalized()
+        #expect(n.southWest.longitude == -160.0)
+        #expect(n.northEast.longitude == 160.0)
+    }
+
+    // Validates the mutating normalize method.
+    @Test
+    func normalizedMutating() async throws {
+        var box = BoundingBox(
+            southWest: Coordinate3D(latitude: -45.0, longitude: 200.0),
+            northEast: Coordinate3D(latitude: 45.0, longitude: 400.0))
+        box.normalize()
+        #expect(box.southWest.longitude == -160.0)
+        #expect(box.northEast.longitude == 40.0)
+    }
+
+    // Validates that `normalized()` is a no-op for .noSRID bounding boxes.
+    @Test
+    func normalizedNoSRID() async throws {
+        let sw = Coordinate3D(x: 170.0, y: -45.0, projection: .noSRID)
+        let ne = Coordinate3D(x: 200.0, y: 45.0, projection: .noSRID)
+        let box = BoundingBox(southWest: sw, northEast: ne)
+        let n = box.normalized()
+        #expect(n.southWest.longitude == 170.0)
+        #expect(n.northEast.longitude == 200.0)
+    }
+
     // MARK: - Expanding
 
     // Validates that a bounding box can be expanded by distance and by degrees in both coordinate systems.

--- a/Tests/GISToolsTests/GeoJson/Cartesian3DTests.swift
+++ b/Tests/GISToolsTests/GeoJson/Cartesian3DTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct Cartesian3DTests {
+
+    private let accuracy: Double = 1e-12
+
+    @Test
+    func description() async throws {
+        let point = Cartesian3D(x: 1.0, y: 2.0, z: 3.0)
+
+        #expect(point.description == "Cartesian3D(x: 1.0, y: 2.0, z: 3.0)")
+    }
+
+    @Test
+    func initialization() async throws {
+        let point = Cartesian3D(x: 1.0, y: 2.0, z: 3.0)
+
+        #expect(point.x == 1.0)
+        #expect(point.y == 2.0)
+        #expect(point.z == 3.0)
+    }
+
+    @Test
+    func conversionFromCoordinate3D() async throws {
+        // Equator, prime meridian → (1, 0, 0)
+        let equator = Cartesian3D(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        #expect(abs(equator.x - 1.0) < accuracy)
+        #expect(abs(equator.y - 0.0) < accuracy)
+        #expect(abs(equator.z - 0.0) < accuracy)
+
+        // North pole → (0, 0, 1)
+        let northPole = Cartesian3D(Coordinate3D(latitude: 90.0, longitude: 0.0))
+        #expect(abs(northPole.x - 0.0) < accuracy)
+        #expect(abs(northPole.y - 0.0) < accuracy)
+        #expect(abs(northPole.z - 1.0) < accuracy)
+
+        // South pole → (0, 0, -1)
+        let southPole = Cartesian3D(Coordinate3D(latitude: -90.0, longitude: 0.0))
+        #expect(abs(southPole.x - 0.0) < accuracy)
+        #expect(abs(southPole.z - (-1.0)) < accuracy)
+
+        // Equator, 90°E → (0, 1, 0)
+        let east = Cartesian3D(Coordinate3D(latitude: 0.0, longitude: 90.0))
+        #expect(abs(east.x - 0.0) < accuracy)
+        #expect(abs(east.y - 1.0) < accuracy)
+        #expect(abs(east.z - 0.0) < accuracy)
+    }
+
+    @Test
+    func conversionFromCartesian3D() async throws {
+        let cartesian = Cartesian3D(x: 1.0, y: 0.0, z: 0.0)
+        let coordinate = Coordinate3D(cartesian)
+
+        #expect(abs(coordinate.latitude - 0.0) < accuracy)
+        #expect(abs(coordinate.longitude - 0.0) < accuracy)
+    }
+
+    @Test
+    func roundTrip() async throws {
+        let original = Coordinate3D(latitude: 42.5, longitude: -73.8)
+        let cartesian = Cartesian3D(original)
+        let roundTripped = Coordinate3D(cartesian)
+
+        #expect(abs(roundTripped.latitude - original.latitude) < accuracy)
+        #expect(abs(roundTripped.longitude - original.longitude) < accuracy)
+    }
+
+    @Test
+    func equatable() async throws {
+        let a = Cartesian3D(x: 1.0, y: 2.0, z: 3.0)
+        let b = Cartesian3D(x: 1.0, y: 2.0, z: 3.0)
+        let c = Cartesian3D(x: 4.0, y: 5.0, z: 6.0)
+
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test
+    func hashable() async throws {
+        let a = Cartesian3D(x: 1.0, y: 2.0, z: 3.0)
+        let b = Cartesian3D(x: 1.0, y: 2.0, z: 3.0)
+
+        let set: Set<Cartesian3D> = [a, b]
+        #expect(set.count == 1)
+    }
+
+}

--- a/Tests/GISToolsTests/GeoJson/CoordinateTests.swift
+++ b/Tests/GISToolsTests/GeoJson/CoordinateTests.swift
@@ -373,6 +373,24 @@ struct CoordinateTests {
         #expect(a.latitude == 90.0)
     }
 
+    // Validates that normalization is a no-op for .noSRID coordinates.
+    @Test
+    func normalizedNoSRID() async throws {
+        let a = Coordinate3D(x: 200.0, y: 10.0, projection: .noSRID)
+        let n = a.normalized()
+        #expect(n.longitude == 200.0)
+        #expect(n.latitude == 10.0)
+    }
+
+    // Validates that clamping is a no-op for .noSRID coordinates.
+    @Test
+    func clampedNoSRID() async throws {
+        let a = Coordinate3D(x: 300.0, y: 200.0, projection: .noSRID)
+        let c = a.clamped()
+        #expect(c.longitude == 300.0)
+        #expect(c.latitude == 200.0)
+    }
+
     // MARK: - Hashable
 
     // Validates that equal coordinates have the same hash value.

--- a/Tests/GISToolsTests/GeoJson/FeatureCollectionTests.swift
+++ b/Tests/GISToolsTests/GeoJson/FeatureCollectionTests.swift
@@ -72,10 +72,40 @@ struct FeatureCollectionTests {
         #expect(featureCollection[foreignMember: "other"] == "something else")
     }
 
-    // Placeholder test for creating a FeatureCollection JSON.
+    // Validates creating a FeatureCollection from features and generating its JSON representation.
     @Test
     func createJson() async throws {
-        // TODO:
+        let point = Point(Coordinate3D(latitude: 0.5, longitude: 102.0))
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 102.0),
+            Coordinate3D(latitude: 1.0, longitude: 103.0),
+            Coordinate3D(latitude: 0.0, longitude: 104.0),
+            Coordinate3D(latitude: 1.0, longitude: 105.0),
+        ]))
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 101.0),
+            Coordinate3D(latitude: 1.0, longitude: 101.0),
+            Coordinate3D(latitude: 1.0, longitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 100.0),
+        ]]))
+
+        let feature0 = Feature(point, properties: ["prop0": "value0", "prop2": "a"])
+        let feature1 = Feature(lineString, properties: ["prop0": "value0", "prop1": 0.0, "prop2": "a"])
+        let feature2 = Feature(polygon, properties: ["prop0": "value0", "prop1": ["this": "that"], "prop2": "b"])
+
+        let featureCollection = FeatureCollection([feature0, feature1, feature2])
+        let string = featureCollection.asJsonString()!
+
+        #expect(featureCollection.projection == .epsg4326)
+        #expect(string.contains("\"type\":\"FeatureCollection\""))
+        #expect(string.contains("\"type\":\"Feature\""))
+        #expect(string.contains("\"type\":\"Point\""))
+        #expect(string.contains("\"type\":\"LineString\""))
+        #expect(string.contains("\"type\":\"Polygon\""))
+        #expect(string.contains("\"prop0\":\"value0\""))
+        #expect(string.contains("\"prop2\":\"a\""))
+        #expect(string.contains("\"prop2\":\"b\""))
     }
 
     // Validates adding features with mismatched projections filters them by projection.

--- a/Tests/GISToolsTests/GeoJson/FeatureCollectionTests.swift
+++ b/Tests/GISToolsTests/GeoJson/FeatureCollectionTests.swift
@@ -184,7 +184,7 @@ struct FeatureCollectionTests {
     @Test
     func divideFeaturesByKey() async throws {
         let featureCollection = try #require(FeatureCollection(jsonString: FeatureCollectionTests.featureCollectionJson))
-        let divided = featureCollection.divideFeatures { feature in
+        let divided: [String: [Feature]] = featureCollection.divideFeatures { feature in
             feature.property(for: "prop2")
         }
 

--- a/Tests/GISToolsTests/GeoJson/GeoJsonConvertibleCodableTests.swift
+++ b/Tests/GISToolsTests/GeoJson/GeoJsonConvertibleCodableTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct GeoJsonConvertibleCodableTests {
+
+    private let pointJson = """
+    {"type":"Point","coordinates":[100.0,0.0]}
+    """
+    private let invalidJson = """
+    {not valid json}
+    """
+    private let notGeoJson = """
+    {"type":"NotAGeoJsonType","coordinates":[]}
+    """
+
+    // MARK: - GeoJsonReadable
+
+    @Test
+    func initFromJsonWithNil() async throws {
+        let point: Point? = Point(json: nil)
+
+        #expect(point == nil)
+    }
+
+    @Test
+    func initFromJsonWithInvalidType() async throws {
+        let pointFromString: Point? = Point(json: "not a dictionary")
+        let pointFromNumber: Point? = Point(json: 42)
+
+        #expect(pointFromString == nil)
+        #expect(pointFromNumber == nil)
+    }
+
+    @Test
+    func initFromValidJsonString() async throws {
+        let point = try #require(Point(jsonString: pointJson))
+
+        #expect(point.type == .point)
+        #expect(point.projection == .epsg4326)
+        #expect(point.coordinate == Coordinate3D(latitude: 0.0, longitude: 100.0))
+    }
+
+    @Test
+    func initFromInvalidJsonString() async throws {
+        let point: Point? = Point(jsonString: invalidJson)
+
+        #expect(point == nil)
+    }
+
+    @Test
+    func initFromJsonStringWithWrongType() async throws {
+        let point: Point? = Point(jsonString: notGeoJson)
+
+        #expect(point == nil)
+    }
+
+    @Test
+    func initFromValidJsonData() async throws {
+        let data = try #require(pointJson.data(using: .utf8))
+        let point = try #require(Point(jsonData: data))
+
+        #expect(point.type == .point)
+    }
+
+    @Test
+    func initFromInvalidJsonData() async throws {
+        let data = Data([0x00, 0x01, 0x02])
+        let point: Point? = Point(jsonData: data)
+
+        #expect(point == nil)
+    }
+
+    @Test
+    func initFromContentsOfUrl() async throws {
+        let data = try #require(pointJson.data(using: .utf8))
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_point_\(UUID().uuidString).geojson")
+        try data.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let point = try #require(Point(contentsOf: url))
+
+        #expect(point.type == .point)
+    }
+
+    @Test
+    func initFromContentsOfUrlWithMissingFile() async throws {
+        let url = URL(fileURLWithPath: "/nonexistent/file.geojson")
+        let point: Point? = Point(contentsOf: url)
+
+        #expect(point == nil)
+    }
+
+    // MARK: - GeoJsonWritable
+
+    @Test
+    func asJsonDictionary() async throws {
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 100.0))
+        let json = point.asJson
+
+        #expect(json["type"] as? String == "Point")
+        #expect(json["coordinates"] as? [Double] == [100.0, 0.0])
+    }
+
+    @Test
+    func asJsonData() async throws {
+        let point = try #require(Point(jsonString: pointJson))
+        let data = try #require(point.asJsonData())
+
+        let parsed = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(parsed["type"] as? String == "Point")
+    }
+
+    @Test
+    func asJsonString() async throws {
+        let point = try #require(Point(jsonString: pointJson))
+        let string = try #require(point.asJsonString())
+
+        #expect(string.contains("\"type\":\"Point\""))
+    }
+
+    @Test
+    func asJsonDataPrettyPrinted() async throws {
+        let point = try #require(Point(jsonString: pointJson))
+        let compact = try #require(point.asJsonData(prettyPrinted: false))
+        let pretty = try #require(point.asJsonData(prettyPrinted: true))
+
+        #expect(compact.count <= pretty.count)
+    }
+
+    @Test
+    func jsonRoundTrip() async throws {
+        let original = Point(Coordinate3D(latitude: 42.0, longitude: -71.0))
+        let json = original.asJson
+        let roundTripped = try #require(Point(json: json))
+
+        #expect(original == roundTripped)
+    }
+
+    @Test
+    func stringRoundTrip() async throws {
+        let original = Point(Coordinate3D(latitude: 42.0, longitude: -71.0))
+        let string = try #require(original.asJsonString())
+        let roundTripped = try #require(Point(jsonString: string))
+
+        #expect(original == roundTripped)
+    }
+
+    @Test
+    func writeToUrl() async throws {
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 100.0))
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_write_\(UUID().uuidString).geojson")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let success = point.write(to: url, prettyPrinted: true)
+        #expect(success)
+
+        let readBack = try #require(Point(contentsOf: url))
+        #expect(point == readBack)
+    }
+
+    @Test
+    func writeToInvalidUrl() async throws {
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 100.0))
+        let url = URL(fileURLWithPath: "/nonexistent/directory/test.geojson")
+
+        let success = point.write(to: url)
+        #expect(!success)
+    }
+
+    @Test
+    func dumpDoesNotCrash() {
+        let point = Point(Coordinate3D(latitude: 0.0, longitude: 100.0))
+
+        point.dump()
+    }
+
+    // MARK: - Sequence asJson
+
+    @Test
+    func sequenceAsJson() async throws {
+        let points = [
+            Point(Coordinate3D(latitude: 0.0, longitude: 100.0)),
+            Point(Coordinate3D(latitude: 1.0, longitude: 101.0)),
+        ]
+        let jsonArray = points.asJson
+
+        #expect(jsonArray.count == 2)
+        #expect(jsonArray[0]["type"] as? String == "Point")
+        #expect(jsonArray[1]["type"] as? String == "Point")
+    }
+
+    // MARK: - Codable edge cases
+
+    @Test
+    func codableWithInvalidDataThrows() async throws {
+        let invalidData = Data([0x00, 0x01, 0x02])
+
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(Point.self, from: invalidData)
+        }
+    }
+
+    @Test
+    func codableWithEmptyJsonObjectThrows() async throws {
+        let emptyData = try #require("{}".data(using: .utf8))
+
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(Point.self, from: emptyData)
+        }
+    }
+
+    @Test
+    func codableWithMismatchedTypeThrows() async throws {
+        // Polygon JSON decoded as Point
+        let polygonJson = """
+        {"type":"Polygon","coordinates":[[[100,0],[101,0],[101,1],[100,1],[100,0]]]}
+        """
+        let data = try #require(polygonJson.data(using: .utf8))
+
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(Point.self, from: data)
+        }
+    }
+
+    @Test
+    func codableCoordinate3DRoundTrip() async throws {
+        let coordinate = Coordinate3D(latitude: 15.0, longitude: 10.0, altitude: 500.0, m: 1234)
+        let data = try JSONEncoder().encode(coordinate)
+        let decoded = try JSONDecoder().decode(Coordinate3D.self, from: data)
+
+        #expect(decoded == coordinate)
+    }
+
+    @Test
+    func codableBoundingBoxRoundTrip() async throws {
+        let box = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let data = try JSONEncoder().encode(box)
+        let decoded = try JSONDecoder().decode(BoundingBox.self, from: data)
+
+        #expect(decoded == box)
+    }
+
+}

--- a/Tests/GISToolsTests/GeoJson/LineSegmentTests.swift
+++ b/Tests/GISToolsTests/GeoJson/LineSegmentTests.swift
@@ -1,0 +1,152 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+@testable import GISTools
+import Testing
+
+struct LineSegmentTests {
+
+    private let a = Coordinate3D(latitude: 0.0, longitude: 0.0)
+    private let b = Coordinate3D(latitude: 10.0, longitude: 10.0)
+
+    @Test
+    func initialization() async throws {
+        let segment = LineSegment(first: a, second: b)
+
+        #expect(segment.first == a)
+        #expect(segment.second == b)
+        #expect(segment.index == nil)
+        #expect(segment.boundingBox == nil)
+    }
+
+    @Test
+    func initializationWithIndex() async throws {
+        let segment = LineSegment(first: a, second: b, index: 3)
+
+        #expect(segment.index == 3)
+    }
+
+    @Test
+    func initializationWithBoundingBox() async throws {
+        let segment = LineSegment(first: a, second: b, calculateBoundingBox: true)
+
+        let expectedBox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        #expect(segment.boundingBox == expectedBox)
+    }
+
+    @Test
+    func coordinates() async throws {
+        let segment = LineSegment(first: a, second: b)
+
+        #expect(segment.coordinates == [a, b])
+    }
+
+    @Test
+    func projection() async throws {
+        let segment = LineSegment(first: a, second: b)
+
+        #expect(segment.projection == .epsg4326)
+    }
+
+    @Test
+    func projection3857() async throws {
+        let a3857 = Coordinate3D(x: 0.0, y: 0.0)
+        let b3857 = Coordinate3D(x: 111_319.5, y: 0.0)
+        let segment = LineSegment(first: a3857, second: b3857)
+
+        #expect(segment.projection == .epsg3857)
+    }
+
+    @Test
+    func projected() async throws {
+        let segment = LineSegment(first: a, second: b)
+        let projected = segment.projected(to: .epsg3857)
+
+        let expectedSecond = b.projected(to: .epsg3857)
+
+        #expect(projected.projection == .epsg3857)
+        #expect(abs(projected.first.x - a.projected(to: .epsg3857).x) < 0.001)
+        #expect(abs(projected.first.y - a.projected(to: .epsg3857).y) < 0.001)
+        #expect(abs(projected.second.x - expectedSecond.x) < 0.001)
+        #expect(abs(projected.second.y - expectedSecond.y) < 0.001)
+    }
+
+    @Test
+    func projectedSameProjection() async throws {
+        let segment = LineSegment(first: a, second: b)
+        let projected = segment.projected(to: .epsg4326)
+
+        #expect(projected.first == segment.first)
+        #expect(projected.second == segment.second)
+    }
+
+    @Test
+    func equatable() async throws {
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: a, second: b)
+        let s3 = LineSegment(first: a, second: Coordinate3D(latitude: 20.0, longitude: 20.0))
+
+        #expect(s1 == s2)
+        #expect(s1 != s3)
+    }
+
+    @Test
+    func hashable() async throws {
+        let s1 = LineSegment(first: a, second: b)
+        let s2 = LineSegment(first: a, second: b)
+
+        let set: Set<LineSegment> = [s1, s2]
+        #expect(set.count == 1)
+    }
+
+    @Test
+    func calculateBoundingBox() async throws {
+        let segment = LineSegment(first: a, second: b)
+        let box = segment.calculateBoundingBox()
+
+        let expectedBox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        #expect(box == expectedBox)
+    }
+
+    @Test
+    func intersectsBoundingBox() async throws {
+        let segment = LineSegment(first: a, second: b)
+        let insideBox = BoundingBox(
+            southWest: Coordinate3D(latitude: 5.0, longitude: 5.0),
+            northEast: Coordinate3D(latitude: 15.0, longitude: 15.0))
+        let outsideBox = BoundingBox(
+            southWest: Coordinate3D(latitude: 20.0, longitude: 20.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 30.0))
+
+        #expect(segment.intersects(insideBox))
+        #expect(!segment.intersects(outsideBox))
+    }
+
+    #if canImport(CoreLocation)
+    @Test
+    func initializationWithCLLocationCoordinate2D() async throws {
+        let first = CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0)
+        let second = CLLocationCoordinate2D(latitude: 10.0, longitude: 10.0)
+        let segment = LineSegment(first: first, second: second)
+
+        #expect(segment.first == Coordinate3D(first))
+        #expect(segment.second == Coordinate3D(second))
+    }
+
+    @Test
+    func initializationWithCLLocation() async throws {
+        let first = CLLocation(latitude: 0.0, longitude: 0.0)
+        let second = CLLocation(latitude: 10.0, longitude: 10.0)
+        let segment = LineSegment(first: first, second: second)
+
+        #expect(segment.first == Coordinate3D(first))
+        #expect(segment.second == Coordinate3D(second))
+    }
+    #endif
+
+}

--- a/Tests/GISToolsTests/GeoJson/MultiPolygonTests.swift
+++ b/Tests/GISToolsTests/GeoJson/MultiPolygonTests.swift
@@ -118,4 +118,51 @@ struct MultiPolygonTests {
         #expect(multiPolygonData == multiPolygon.asJsonData(prettyPrinted: true))
     }
 
+    // Validates that MultiPolygon equality handles shifted ring start vertices.
+    @Test
+    func equatable() async throws {
+        let polygonA = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 101.0),
+            Coordinate3D(latitude: 1.0, longitude: 101.0),
+            Coordinate3D(latitude: 1.0, longitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 100.0),
+        ]]))
+        let polygonB = try #require(Polygon([[
+            Coordinate3D(latitude: 2.0, longitude: 102.0),
+            Coordinate3D(latitude: 2.0, longitude: 103.0),
+            Coordinate3D(latitude: 3.0, longitude: 103.0),
+            Coordinate3D(latitude: 3.0, longitude: 102.0),
+            Coordinate3D(latitude: 2.0, longitude: 102.0),
+        ]]))
+        let polygonBShifted = try #require(Polygon([[
+            Coordinate3D(latitude: 3.0, longitude: 103.0),
+            Coordinate3D(latitude: 3.0, longitude: 102.0),
+            Coordinate3D(latitude: 2.0, longitude: 102.0),
+            Coordinate3D(latitude: 2.0, longitude: 103.0),
+            Coordinate3D(latitude: 3.0, longitude: 103.0),
+        ]]))
+
+        let multiA = MultiPolygon([polygonA, polygonB])!
+        let multiB = MultiPolygon([polygonA, polygonB])!
+        let multiBShifted = MultiPolygon([polygonA, polygonBShifted])!
+
+        // Same polygons → equal
+        #expect(multiA == multiB)
+
+        // Shifted ring start → still equal
+        #expect(multiA == multiBShifted)
+
+        // Different polygons → not equal
+        let polygonC = try #require(Polygon([[
+            Coordinate3D(latitude: 10.0, longitude: 100.0),
+            Coordinate3D(latitude: 10.0, longitude: 101.0),
+            Coordinate3D(latitude: 11.0, longitude: 101.0),
+            Coordinate3D(latitude: 11.0, longitude: 100.0),
+            Coordinate3D(latitude: 10.0, longitude: 100.0),
+        ]]))
+        let multiC = MultiPolygon([polygonA, polygonC])!
+        #expect(multiA != multiC)
+    }
+
 }

--- a/Tests/GISToolsTests/GeoJson/PolygonTests.swift
+++ b/Tests/GISToolsTests/GeoJson/PolygonTests.swift
@@ -146,4 +146,43 @@ struct PolygonTests {
         #expect(polygonWithHolesData == polygonWithHoles.asJsonData(prettyPrinted: true))
     }
 
+    // Validates that Polygon equality handles shifted ring start vertices.
+    @Test
+    func equatable() async throws {
+        let coords: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.0, longitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 101.0),
+            Coordinate3D(latitude: 1.0, longitude: 101.0),
+            Coordinate3D(latitude: 1.0, longitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 100.0)
+        ]
+        let polygonA = try #require(Polygon([coords]))
+        let polygonB = try #require(Polygon([coords]))
+
+        // Same vertices → equal
+        #expect(polygonA == polygonB)
+
+        // Shifted start vertex → still equal
+        let shiftedCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 1.0, longitude: 101.0),
+            Coordinate3D(latitude: 1.0, longitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 101.0),
+            Coordinate3D(latitude: 1.0, longitude: 101.0),
+        ]
+        let polygonShifted = try #require(Polygon([shiftedCoords]))
+        #expect(polygonA == polygonShifted)
+
+        // Different coordinates → not equal
+        let otherCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 10.0, longitude: 100.0),
+            Coordinate3D(latitude: 10.0, longitude: 101.0),
+            Coordinate3D(latitude: 11.0, longitude: 101.0),
+            Coordinate3D(latitude: 11.0, longitude: 100.0),
+            Coordinate3D(latitude: 10.0, longitude: 100.0)
+        ]
+        let polygonC = try #require(Polygon([otherCoords]))
+        #expect(polygonA != polygonC)
+    }
+
 }

--- a/Tests/GISToolsTests/GeoJson/ProjectionTests.swift
+++ b/Tests/GISToolsTests/GeoJson/ProjectionTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import GISTools
 import Testing
 
@@ -67,6 +68,79 @@ struct ProjectionTests {
         let result3 = coordinate3.projected(to: .epsg4326)
         #expect(abs(result3.latitude - 11.350796722383672) < 0.000001)
         #expect(abs(result3.longitude - -73.476562) < 0.000001)
+    }
+
+    @Test
+    func cases() async throws {
+        #expect(Projection.noSRID.srid == 0)
+        #expect(Projection.epsg3857.srid == 3857)
+        #expect(Projection.epsg4326.srid == 4326)
+    }
+
+    @Test
+    func initFromSrid() async throws {
+        #expect(Projection(srid: 0) == .noSRID)
+        #expect(Projection(srid: 4326) == .epsg4326)
+        #expect(Projection(srid: 3857) == .epsg3857)
+    }
+
+    @Test
+    func initFromSridAliases() async throws {
+        #expect(Projection(srid: 102_100) == .epsg3857)
+        #expect(Projection(srid: 102_113) == .epsg3857)
+        #expect(Projection(srid: 900_913) == .epsg3857)
+        #expect(Projection(srid: 3587) == .epsg3857)
+        #expect(Projection(srid: 3785) == .epsg3857)
+        #expect(Projection(srid: 41_001) == .epsg3857)
+        #expect(Projection(srid: 54_004) == .epsg3857)
+    }
+
+    @Test
+    func initFromUnsupportedSrid() async throws {
+        #expect(Projection(srid: 1234) == nil)
+        #expect(Projection(srid: -1) == nil)
+    }
+
+    @Test
+    func description() async throws {
+        #expect(Projection.noSRID.description == "No SRID")
+        #expect(Projection.epsg3857.description == "EPSG:3857")
+        #expect(Projection.epsg4326.description == "EPSG:4326")
+    }
+
+    @Test
+    func sridProperty() async throws {
+        #expect(Projection.noSRID.srid == 0)
+        #expect(Projection.epsg3857.srid == 3857)
+        #expect(Projection.epsg4326.srid == 4326)
+    }
+
+    @Test
+    func equatable() async throws {
+        #expect(Projection.epsg4326 == .epsg4326)
+        #expect(Projection.epsg4326 != .epsg3857)
+        #expect(Projection.noSRID != .epsg4326)
+    }
+
+    @Test
+    func codableRoundTrip() async throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for projection: Projection in [.noSRID, .epsg3857, .epsg4326] {
+            let data = try encoder.encode(projection)
+            let decoded = try decoder.decode(Projection.self, from: data)
+            #expect(decoded == projection)
+        }
+    }
+
+    @Test
+    func codableRawValues() async throws {
+        let encoder = JSONEncoder()
+
+        #expect(String(data: try encoder.encode(Projection.noSRID), encoding: .utf8) == "0")
+        #expect(String(data: try encoder.encode(Projection.epsg3857), encoding: .utf8) == "3857")
+        #expect(String(data: try encoder.encode(Projection.epsg4326), encoding: .utf8) == "4326")
     }
 
 }

--- a/Tests/GISToolsTests/GeoJson/RingTests.swift
+++ b/Tests/GISToolsTests/GeoJson/RingTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct RingTests {
+
+    private let coords: [Coordinate3D] = [
+        Coordinate3D(latitude: 0.0, longitude: 0.0),
+        Coordinate3D(latitude: 0.0, longitude: 10.0),
+        Coordinate3D(latitude: 10.0, longitude: 10.0),
+        Coordinate3D(latitude: 10.0, longitude: 0.0),
+        Coordinate3D(latitude: 0.0, longitude: 0.0),
+    ]
+
+    @Test
+    func initialization() async throws {
+        let ring = try #require(Ring(coords))
+
+        #expect(ring.coordinates == coords)
+    }
+
+    @Test
+    func initializationAutoCloses() async throws {
+        // 3 coordinates → auto-close (append first) → 4 coordinates → valid
+        let threeCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]
+        let ring = try #require(Ring(threeCoords))
+
+        #expect(ring.coordinates.count == 4)
+        #expect(ring.coordinates.last == ring.coordinates.first)
+    }
+
+    @Test
+    func initializationNotEnoughCoordinates() async throws {
+        let oneCoord = [Coordinate3D(latitude: 0.0, longitude: 0.0)]
+        let twoCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]
+
+        #expect(Ring(oneCoord) == nil)
+        #expect(Ring(twoCoords) == nil)
+    }
+
+    @Test
+    func initializationUnchecked() async throws {
+        let ring = Ring(unchecked: coords)
+
+        #expect(ring.coordinates == coords)
+    }
+
+    @Test
+    func lineString() async throws {
+        let ring = try #require(Ring(coords))
+        let lineString = ring.lineString
+
+        #expect(lineString.coordinates == coords)
+    }
+
+    @Test
+    func circumference() async throws {
+        let ring = try #require(Ring(coords))
+
+        // Square perimeter: 4 sides × 10° ≈ 4 × 1_113_195 m at equator
+        // Using Clark's approximate values; just check it's positive and reasonable
+        #expect(ring.circumference > 4_000_000.0)
+        #expect(ring.circumference < 5_000_000.0)
+    }
+
+    @Test
+    func circumferenceEmptyRing() async throws {
+        let ring = Ring(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ])
+
+        #expect(ring.circumference == 0.0)
+    }
+
+    @Test
+    func projection() async throws {
+        let ring = try #require(Ring(coords))
+
+        #expect(ring.projection == .epsg4326)
+    }
+
+    @Test
+    func projected() async throws {
+        let ring = try #require(Ring(coords))
+        let projected = ring.projected(to: .epsg3857)
+
+        #expect(projected.projection == .epsg3857)
+        #expect(projected.coordinates.count == 5)
+    }
+
+    @Test
+    func projectedSameProjection() async throws {
+        let ring = try #require(Ring(coords))
+        let projected = ring.projected(to: .epsg4326)
+
+        #expect(projected.coordinates == ring.coordinates)
+    }
+
+    @Test
+    func intersectsBoundingBox() async throws {
+        let ring = try #require(Ring(coords))
+        let overlappingBox = BoundingBox(
+            southWest: Coordinate3D(latitude: 5.0, longitude: 5.0),
+            northEast: Coordinate3D(latitude: 15.0, longitude: 15.0))
+        let containingBox = BoundingBox(
+            southWest: Coordinate3D(latitude: -1.0, longitude: -1.0),
+            northEast: Coordinate3D(latitude: 11.0, longitude: 11.0))
+        let nonOverlappingBox = BoundingBox(
+            southWest: Coordinate3D(latitude: 20.0, longitude: 20.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 30.0))
+
+        #expect(ring.intersects(overlappingBox))
+        #expect(ring.intersects(containingBox))
+        #expect(!ring.intersects(nonOverlappingBox))
+    }
+
+    @Test
+    func equatableSame() async throws {
+        let ringA = try #require(Ring(coords))
+        let ringB = try #require(Ring(coords))
+
+        #expect(ringA == ringB)
+    }
+
+    @Test
+    func equatableShiftedStart() async throws {
+        let ring = try #require(Ring(coords))
+
+        // Rotate the ring so it starts at a different vertex
+        let shiftedCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]
+        let ringShifted = try #require(Ring(shiftedCoords))
+
+        #expect(ring == ringShifted)
+    }
+
+    @Test
+    func equatableNotEqual() async throws {
+        let ring = try #require(Ring(coords))
+        let otherCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 20.0),
+            Coordinate3D(latitude: 20.0, longitude: 20.0),
+            Coordinate3D(latitude: 20.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]
+        let otherRing = try #require(Ring(otherCoords))
+
+        #expect(ring != otherRing)
+    }
+
+}


### PR DESCRIPTION
- **Comprehensive DocC documentation**: Added missing `- Returns:`, `- Parameter` tags, and documentation comments across the entire codebase — every public function, type, and algorithm now has proper documentation.
- **Bug fixes**: Fixed several correctness issues including FrechetDistance out-of-bounds crash, BooleanParallel circular bearing wrap, RhumbDistance dead anti-meridian compensation, `.noSRID` returning `Double.infinity`, LineSliceAlong single-coordinate crash, TransformTranslate sign stripping, and GeometryCollection reverse preserving element order.
- **Full test coverage**: Every algorithm (62/62) now has a dedicated test file. Added 5 new test suites: BooleanIntersects, PolygonToLine, EnumerateProperties, BoundingBoxPosition, EnumerateCoordinates. Overall 769 tests across 90 suites.
- **WKB / WKT / TWKB binary encoding/decoding**: New coders for Well-Known Binary, Text, and Tiny Well-Known Binary formats, with round-trip tests.
- **Standardised code style**: Consistent parameter labels across all algorithms, fixed camelCase violations in Simplify, removed the redundant duplicate `pointOnSegment` algorithm, improved `Dissolve`, `TileCover`, and `Validatable` implementations.
