### PR TITLE
#107: Add optional gridSize parameter to all algorithms

### DIFF
--- a/Sources/GISTools/Algorithms/BooleanConcave.swift
+++ b/Sources/GISTools/Algorithms/BooleanConcave.swift
@@ -12,13 +12,16 @@ extension GeoJson {
     ///
     /// Non-polygon geometries return `false`.
     ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     /// - Returns: `true` if the geometry is a concave polygon, `false` otherwise.
-    public func isConcave() -> Bool {
-        if let fc = self as? FeatureCollection {
-            return fc.features.contains { $0.isConcave() }
+    public func isConcave(gridSize: Double? = nil) -> Bool {
+        let geoJson = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+
+        if let fc = geoJson as? FeatureCollection {
+            return fc.features.contains { $0.isConcave(gridSize: nil) }
         }
 
-        let geom: GeoJson = (self as? Feature)?.geometry ?? self
+        let geom: GeoJson = (geoJson as? Feature)?.geometry ?? geoJson
 
         guard let polygonGeometry = geom as? PolygonGeometry else { return false }
 

--- a/Sources/GISTools/Algorithms/BooleanCrosses.swift
+++ b/Sources/GISTools/Algorithms/BooleanCrosses.swift
@@ -16,18 +16,23 @@ extension GeoJson {
     ///           LineString / LineString, LineString / Polygon.
     ///
     /// MultiPolygon behaves like Polygon in these comparisons.
-    public func crosses(_ other: GeoJson) -> Bool {
+    ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
+    public func crosses(_ other: GeoJson, gridSize: Double? = nil) -> Bool {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+
         // FeatureCollection: check if any contained feature crosses.
-        if let fc1 = self as? FeatureCollection {
-            return fc1.features.contains { $0.crosses(other) }
+        if let fc1 = snappedSelf as? FeatureCollection {
+            return fc1.features.contains { $0.crosses(snappedOther, gridSize: nil) }
         }
-        if let fc2 = other as? FeatureCollection {
-            return fc2.features.contains { self.crosses($0.geometry) }
+        if let fc2 = snappedOther as? FeatureCollection {
+            return fc2.features.contains { snappedSelf.crosses($0.geometry, gridSize: nil) }
         }
 
         // Anything else
-        let geom1: GeoJson = (self as? Feature)?.geometry ?? self
-        let geom2: GeoJson = (other as? Feature)?.geometry ?? other
+        let geom1: GeoJson = (snappedSelf as? Feature)?.geometry ?? snappedSelf
+        let geom2: GeoJson = (snappedOther as? Feature)?.geometry ?? snappedOther
 
         guard let geometry1 = geom1 as? GeoJsonGeometry,
               let geometry2 = geom2 as? GeoJsonGeometry
@@ -121,7 +126,7 @@ extension GeoJson {
         var foundExtPoint = false
 
         for point in multiPoint.points {
-            if polygonGeometry.contains(point.coordinate, ignoringBoundary: false) {
+            if polygonGeometry.contains(point.coordinate, ignoringBoundary: false, gridSize: nil) {
                 foundIntPoint = true
             }
             else {

--- a/Sources/GISTools/Algorithms/BooleanDisjoint.swift
+++ b/Sources/GISTools/Algorithms/BooleanDisjoint.swift
@@ -10,33 +10,37 @@ extension GeoJson {
     /// Compares two geometries and returns true if they are disjoint.
     ///
     /// - Parameter other: The other geometry
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the geometries don't overlap, `false` otherwise.
-    public func isDisjoint(with other: GeoJson) -> Bool {
-        if let otherBoundingBox = other.boundingBox ?? other.calculateBoundingBox(),
-           !intersects(otherBoundingBox)
+    public func isDisjoint(with other: GeoJson, gridSize: Double? = nil) -> Bool {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+
+        if let otherBoundingBox = snappedOther.boundingBox ?? snappedOther.calculateBoundingBox(),
+           !snappedSelf.intersects(otherBoundingBox)
         {
             return true
         }
 
-        return switch self {
+        return switch snappedSelf {
         case let point as PointGeometry:
-            point.isPointDisjoint(with: other)
+            point.isPointDisjoint(with: snappedOther)
 
         case let lineString as LineStringGeometry:
-            lineString.isLineStringDisjoint(with: other)
+            lineString.isLineStringDisjoint(with: snappedOther)
 
         case let polygon as PolygonGeometry:
-            polygon.isPolygonDisjoint(with: other)
+            polygon.isPolygonDisjoint(with: snappedOther)
 
         case let geometryCollection as GeometryCollection:
-            geometryCollection.geometries.allSatisfy { $0.isDisjoint(with: other) }
+            geometryCollection.geometries.allSatisfy { $0.isDisjoint(with: snappedOther) }
 
         case let feature as Feature:
-            feature.geometry.isDisjoint(with: other)
+            feature.geometry.isDisjoint(with: snappedOther)
 
         case let featureCollection as FeatureCollection:
-            featureCollection.features.allSatisfy { $0.isDisjoint(with: other) }
+            featureCollection.features.allSatisfy { $0.isDisjoint(with: snappedOther) }
 
         default:
             true
@@ -69,7 +73,7 @@ extension PointGeometry {
 
         case let otherPolygon as PolygonGeometry:
             for coordinate in allCoordinates {
-                if otherPolygon.contains(coordinate, ignoringBoundary: false) {
+                if otherPolygon.contains(coordinate, ignoringBoundary: false, gridSize: nil) {
                     return false
                 }
             }
@@ -129,7 +133,7 @@ extension LineStringGeometry {
         case let otherPolygon as PolygonGeometry:
             // Any point inside the polygon
             for coordinate in allCoordinates {
-                if otherPolygon.contains(coordinate, ignoringBoundary: false) {
+                if otherPolygon.contains(coordinate, ignoringBoundary: false, gridSize: nil) {
                     return false
                 }
             }
@@ -189,7 +193,7 @@ extension PolygonGeometry {
                 }
 
                 for coordinate in coordinates {
-                    if otherPolygon.contains(coordinate, ignoringBoundary: false) {
+                    if otherPolygon.contains(coordinate, ignoringBoundary: false, gridSize: nil) {
                         return false
                     }
                 }
@@ -201,7 +205,7 @@ extension PolygonGeometry {
                 }
 
                 for coordinate in coordinates {
-                    if self.contains(coordinate, ignoringBoundary: false) {
+                    if self.contains(coordinate, ignoringBoundary: false, gridSize: nil) {
                         return false
                     }
                 }

--- a/Sources/GISTools/Algorithms/BooleanIntersects.swift
+++ b/Sources/GISTools/Algorithms/BooleanIntersects.swift
@@ -10,10 +10,13 @@ extension GeoJson {
     /// Compares two geometries and returns true if they intersect.
     ///
     /// - Parameter other: The other geometry
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the geometries intersect, `false` otherwise.
-    public func intersects(_ other: GeoJson) -> Bool {
-        !isDisjoint(with: other)
+    public func intersects(_ other: GeoJson, gridSize: Double? = nil) -> Bool {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        return !snappedSelf.isDisjoint(with: snappedOther)
     }
 
 }

--- a/Sources/GISTools/Algorithms/BooleanOverlap.swift
+++ b/Sources/GISTools/Algorithms/BooleanOverlap.swift
@@ -12,17 +12,21 @@ extension PointGeometry {
     ///
     /// - Parameter other: The other Point or MultiPoint
     /// - Parameter tolerance: The tolerance, in meters.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the points overlap, `false` otherwise.
     public func isOverlapping(
         with other: PointGeometry,
-        tolerance: CLLocationDegrees = 0.0
+        tolerance: CLLocationDegrees = 0.0,
+        gridSize: Double? = nil
     ) -> Bool {
-        let other = other.projected(to: projection)
+        let snappedSelf = gridSize.map { (self as! GeoJson).snappedToGrid(tolerance: $0) as! PointGeometry } ?? self
+        let snappedOther = gridSize.map { (other as! GeoJson).snappedToGrid(tolerance: $0) as! PointGeometry } ?? other
+        let other = snappedOther.projected(to: snappedSelf.projection)
 
-        guard !isEqualTo(other) else { return false }
+        guard !snappedSelf.isEqualTo(other) else { return false }
 
-        if let point = self as? Point {
+        if let point = snappedSelf as? Point {
             if let otherPoint = other as? Point {
                 return point == otherPoint
             }
@@ -30,7 +34,7 @@ extension PointGeometry {
                 return otherMultiPoint.coordinates.contains(point.coordinate)
             }
         }
-        else if let multiPoint = self as? MultiPoint {
+        else if let multiPoint = snappedSelf as? MultiPoint {
             if let otherPoint = other as? Point {
                 return multiPoint.coordinates.contains(otherPoint.coordinate)
             }
@@ -53,17 +57,21 @@ extension LineStringGeometry {
     ///
     /// - Parameter other: The other LineString or MultiLineString
     /// - Parameter tolerance: The tolerance, in meters.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the lines overlap, `false` otherwise.
     public func isOverlapping(
         with other: LineStringGeometry,
-        tolerance: CLLocationDegrees = 0.0
+        tolerance: CLLocationDegrees = 0.0,
+        gridSize: Double? = nil
     ) -> Bool {
-        let other = other.projected(to: projection)
+        let snappedSelf = gridSize.map { (self as! GeoJson).snappedToGrid(tolerance: $0) as! LineStringGeometry } ?? self
+        let snappedOther = gridSize.map { (other as! GeoJson).snappedToGrid(tolerance: $0) as! LineStringGeometry } ?? other
+        let other = snappedOther.projected(to: snappedSelf.projection)
 
-        guard !isEqualTo(other) else { return false }
+        guard !snappedSelf.isEqualTo(other) else { return false }
 
-        let tree: RTree<LineSegment> = RTree(lineSegments)
+        let tree: RTree<LineSegment> = RTree(snappedSelf.lineSegments)
 
         for segment in other.lineSegments {
             guard let boundingBox = segment.boundingBox ?? segment.calculateBoundingBox() else { continue }
@@ -87,17 +95,21 @@ extension PolygonGeometry {
     ///
     /// - Parameter other: The other Polygon or MultiPolygon
     /// - Parameter tolerance: The tolerance, in meters.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the polygons overlap, `false` otherwise.
     public func isOverlapping(
         with other: PolygonGeometry,
-        tolerance: CLLocationDegrees = 0.0
+        tolerance: CLLocationDegrees = 0.0,
+        gridSize: Double? = nil
     ) -> Bool {
-        let other = other.projected(to: projection)
+        let snappedSelf = gridSize.map { (self as! GeoJson).snappedToGrid(tolerance: $0) as! PolygonGeometry } ?? self
+        let snappedOther = gridSize.map { (other as! GeoJson).snappedToGrid(tolerance: $0) as! PolygonGeometry } ?? other
+        let other = snappedOther.projected(to: snappedSelf.projection)
 
-        guard !isEqualTo(other) else { return false }
+        guard !snappedSelf.isEqualTo(other) else { return false }
 
-        let tree: RTree<LineSegment> = RTree(lineSegments)
+        let tree: RTree<LineSegment> = RTree(snappedSelf.lineSegments)
 
         for segment in other.lineSegments {
             guard let boundingBox = segment.boundingBox ?? segment.calculateBoundingBox() else { continue }
@@ -121,28 +133,32 @@ extension Feature {
     ///
     /// - Parameter other: The other Feature
     /// - Parameter tolerance: The tolerance, in meters.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the features overlap, `false` otherwise.
     public func isOverlapping(
         with other: Feature,
-        tolerance: CLLocationDegrees = 0.0
+        tolerance: CLLocationDegrees = 0.0,
+        gridSize: Double? = nil
     ) -> Bool {
-        let other = other.projected(to: projection)
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        let other = snappedOther.projected(to: snappedSelf.projection)
 
-        if let first = self.geometry as? PointGeometry,
+        if let first = snappedSelf.geometry as? PointGeometry,
            let second = other.geometry as? PointGeometry
         {
-            return first.isOverlapping(with: second, tolerance: tolerance)
+            return first.isOverlapping(with: second, tolerance: tolerance, gridSize: nil)
         }
-        else if let first = self.geometry as? LineStringGeometry,
+        else if let first = snappedSelf.geometry as? LineStringGeometry,
                 let second = other.geometry as? LineStringGeometry
         {
-            return first.isOverlapping(with: second, tolerance: tolerance)
+            return first.isOverlapping(with: second, tolerance: tolerance, gridSize: nil)
         }
-        else if let first = self.geometry as? PolygonGeometry,
+        else if let first = snappedSelf.geometry as? PolygonGeometry,
                 let second = other.geometry as? PolygonGeometry
         {
-            return first.isOverlapping(with: second, tolerance: tolerance)
+            return first.isOverlapping(with: second, tolerance: tolerance, gridSize: nil)
         }
 
         return false

--- a/Sources/GISTools/Algorithms/BooleanOverlap.swift
+++ b/Sources/GISTools/Algorithms/BooleanOverlap.swift
@@ -20,8 +20,8 @@ extension PointGeometry {
         tolerance: CLLocationDegrees = 0.0,
         gridSize: Double? = nil
     ) -> Bool {
-        let snappedSelf = gridSize.map { (self as! GeoJson).snappedToGrid(tolerance: $0) as! PointGeometry } ?? self
-        let snappedOther = gridSize.map { (other as! GeoJson).snappedToGrid(tolerance: $0) as! PointGeometry } ?? other
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
         let other = snappedOther.projected(to: snappedSelf.projection)
 
         guard !snappedSelf.isEqualTo(other) else { return false }
@@ -65,8 +65,8 @@ extension LineStringGeometry {
         tolerance: CLLocationDegrees = 0.0,
         gridSize: Double? = nil
     ) -> Bool {
-        let snappedSelf = gridSize.map { (self as! GeoJson).snappedToGrid(tolerance: $0) as! LineStringGeometry } ?? self
-        let snappedOther = gridSize.map { (other as! GeoJson).snappedToGrid(tolerance: $0) as! LineStringGeometry } ?? other
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
         let other = snappedOther.projected(to: snappedSelf.projection)
 
         guard !snappedSelf.isEqualTo(other) else { return false }
@@ -103,8 +103,8 @@ extension PolygonGeometry {
         tolerance: CLLocationDegrees = 0.0,
         gridSize: Double? = nil
     ) -> Bool {
-        let snappedSelf = gridSize.map { (self as! GeoJson).snappedToGrid(tolerance: $0) as! PolygonGeometry } ?? self
-        let snappedOther = gridSize.map { (other as! GeoJson).snappedToGrid(tolerance: $0) as! PolygonGeometry } ?? other
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
         let other = snappedOther.projected(to: snappedSelf.projection)
 
         guard !snappedSelf.isEqualTo(other) else { return false }

--- a/Sources/GISTools/Algorithms/BooleanParallel.swift
+++ b/Sources/GISTools/Algorithms/BooleanParallel.swift
@@ -12,15 +12,20 @@ extension LineSegment {
     /// - Parameter other: The other LineSegment
     /// - Parameter tolerance: The tolerance, in degrees
     /// - Parameter undirectedEdge: Whether the segment should be treated as an undirected edge
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the segments are parallel within the tolerance, `false` otherwise.
     public func isParallel(
         to other: LineSegment,
         tolerance: CLLocationDegrees = 0.0,
-        undirectedEdge: Bool = false
+        undirectedEdge: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
-        let azimuth1 = first.rhumbBearing(to: second).bearingToAzimuth
-        let azimuth2 = other.first.rhumbBearing(to: other.second).bearingToAzimuth
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+
+        let azimuth1 = snappedSelf.first.rhumbBearing(to: snappedSelf.second).bearingToAzimuth
+        let azimuth2 = snappedOther.first.rhumbBearing(to: snappedOther.second).bearingToAzimuth
 
         // Normalise the angular difference to [0, 180] so the comparison
         // correctly handles values that straddle the 0°/360° boundary.
@@ -57,21 +62,26 @@ extension LineString {
     ///
     /// - Parameter other: The other LineString
     /// - Parameter tolerance: The tolerance for each pair of segments, in degrees
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the lines are parallel within the tolerance, `false` otherwise.
     public func isParallel(
         to other: LineString,
-        tolerance: CLLocationDegrees = 0.0
+        tolerance: CLLocationDegrees = 0.0,
+        gridSize: Double? = nil
     ) -> Bool {
-        let segments1 = lineSegments
-        let segments2 = other.lineSegments
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+
+        let segments1 = snappedSelf.lineSegments
+        let segments2 = snappedOther.lineSegments
         let count = min(segments1.count, segments2.count)
 
         for index in 0 ..< count {
             let segment1 = segments1[index]
             let segment2 = segments2[index]
 
-            if !segment1.isParallel(to: segment2, tolerance: tolerance) {
+            if !segment1.isParallel(to: segment2, tolerance: tolerance, gridSize: nil) {
                 return false
             }
         }

--- a/Sources/GISTools/Algorithms/BooleanPointInPolygon.swift
+++ b/Sources/GISTools/Algorithms/BooleanPointInPolygon.swift
@@ -11,18 +11,22 @@ extension Ring {
     ///
     /// - Parameter coordinate: The coordinate to check
     /// - Parameter ignoringBoundary: `true` if the ring boundary should be ignored when determining if the coordinate is inside the ring (default `false`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the coordinate is inside the ring, `false` otherwise.
     public func contains(
         _ coordinate: Coordinate3D,
-        ignoringBoundary: Bool = false
+        ignoringBoundary: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
         let coordinate = coordinate.projected(to: projection)
+        let snappedCoordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
+        let snappedCoordinates = gridSize.map { Ring(unchecked: coordinates).snappedToGrid(tolerance: $0).coordinates } ?? coordinates
 
         var isInside = false
 
-        var coordinatesCount = coordinates.count
-        if coordinates.first == coordinates.last {
+        var coordinatesCount = snappedCoordinates.count
+        if snappedCoordinates.first == snappedCoordinates.last {
             coordinatesCount -= 1
         }
 
@@ -32,20 +36,20 @@ extension Ring {
                 j = i
             }
 
-            let xi = coordinates[i].longitude
-            let yi = coordinates[i].latitude
-            let xj = coordinates[j].longitude
-            let yj = coordinates[j].latitude
+            let xi = snappedCoordinates[i].longitude
+            let yi = snappedCoordinates[i].latitude
+            let xj = snappedCoordinates[j].longitude
+            let yj = snappedCoordinates[j].latitude
 
-            let onBoundary = (coordinate.latitude * (xi - xj) + yi * (xj - coordinate.longitude) + yj * (coordinate.longitude - xi) == 0.0)
-                && ((xi - coordinate.longitude) * (xj - coordinate.longitude) <= 0.0)
-                && ((yi - coordinate.latitude) * (yj - coordinate.latitude) <= 0.0)
+            let onBoundary = (snappedCoordinate.latitude * (xi - xj) + yi * (xj - snappedCoordinate.longitude) + yj * (snappedCoordinate.longitude - xi) == 0.0)
+                && ((xi - snappedCoordinate.longitude) * (xj - snappedCoordinate.longitude) <= 0.0)
+                && ((yi - snappedCoordinate.latitude) * (yj - snappedCoordinate.latitude) <= 0.0)
             if onBoundary {
                 return !ignoringBoundary
             }
 
-            let intersect = ((yi > coordinate.latitude) != (yj > coordinate.latitude))
-                && (coordinate.longitude < (xj - xi) * (coordinate.latitude - yi) / (yj - yi) + xi)
+            let intersect = ((yi > snappedCoordinate.latitude) != (yj > snappedCoordinate.latitude))
+                && (snappedCoordinate.longitude < (xj - xi) * (snappedCoordinate.latitude - yi) / (yj - yi) + xi)
             if (intersect) {
                 isInside = !isInside
             }
@@ -58,13 +62,15 @@ extension Ring {
     ///
     /// - Parameter point: The point to check
     /// - Parameter ignoringBoundary: `true` if the ring boundary should be ignored when determining if the point is inside the ring (default `false`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the point is inside the ring, `false` otherwise.
     public func contains(
         _ point: Point,
-        ignoringBoundary: Bool = false
+        ignoringBoundary: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
-        contains(point.coordinate, ignoringBoundary: ignoringBoundary)
+        contains(point.coordinate, ignoringBoundary: ignoringBoundary, gridSize: gridSize)
     }
 
 }
@@ -76,23 +82,28 @@ extension Polygon {
     ///
     /// - Parameter coordinate: The coordinate to check
     /// - Parameter ignoringBoundary: `true` if the polygon boundary should be ignored when determining if the coordinate is inside the polygon (default `false`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the coordinate is inside the polygon, `false` otherwise.
     public func contains(
         _ coordinate: Coordinate3D,
-        ignoringBoundary: Bool = false
+        ignoringBoundary: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
-        if let boundingBox, !boundingBox.contains(coordinate) {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedCoordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
+
+        if let boundingBox = snappedSelf.boundingBox, !boundingBox.contains(snappedCoordinate) {
             return false
         }
 
-        guard let outerRing = outerRing,
-              outerRing.contains(coordinate, ignoringBoundary: ignoringBoundary)
+        guard let outerRing = snappedSelf.outerRing,
+              outerRing.contains(snappedCoordinate, ignoringBoundary: ignoringBoundary)
         else { return false }
 
-        if let innerRings {
+        if let innerRings = snappedSelf.innerRings {
             for ring in innerRings {
-                if ring.contains(coordinate, ignoringBoundary: ignoringBoundary) {
+                if ring.contains(snappedCoordinate, ignoringBoundary: ignoringBoundary) {
                     return false
                 }
             }
@@ -106,13 +117,15 @@ extension Polygon {
     ///
     /// - Parameter point: The point to check
     /// - Parameter ignoringBoundary: `true` if the polygon boundary should be ignored when determining if the point is inside the polygon (default `false`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the point is inside the ring, `false` otherwise.
     public func contains(
         _ point: Point,
-        ignoringBoundary: Bool = false
+        ignoringBoundary: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
-        contains(point.coordinate, ignoringBoundary: ignoringBoundary)
+        contains(point.coordinate, ignoringBoundary: ignoringBoundary, gridSize: gridSize)
     }
 
 }
@@ -124,18 +137,23 @@ extension MultiPolygon {
     ///
     /// - Parameter coordinate: The coordinate to check
     /// - Parameter ignoringBoundary: `true` if the polygon boundaries should be ignored when determining if the coordinate is inside of one of the polygons (default `false`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the polygons, `false` otherwise.
     public func contains(
         _ coordinate: Coordinate3D,
-        ignoringBoundary: Bool = false
+        ignoringBoundary: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
-        if let boundingBox, !boundingBox.contains(coordinate) {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedCoordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
+
+        if let boundingBox = snappedSelf.boundingBox, !boundingBox.contains(snappedCoordinate) {
             return false
         }
 
-        for polygon in polygons {
-            if polygon.contains(coordinate, ignoringBoundary: ignoringBoundary) {
+        for polygon in snappedSelf.polygons {
+            if polygon.contains(snappedCoordinate, ignoringBoundary: ignoringBoundary) {
                 return true
             }
         }
@@ -148,13 +166,15 @@ extension MultiPolygon {
     ///
     /// - Parameter point: The coordinate to check
     /// - Parameter ignoringBoundary: `true` if the polygon boundaries should be ignored when determining if the coordinate is inside of one of the polygons (default `false`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the polygons, `false` otherwise.
     public func contains(
         _ point: Point,
-        ignoringBoundary: Bool = false
+        ignoringBoundary: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
-        contains(point.coordinate, ignoringBoundary: ignoringBoundary)
+        contains(point.coordinate, ignoringBoundary: ignoringBoundary, gridSize: gridSize)
     }
 
 }
@@ -165,16 +185,21 @@ extension GeometryCollection {
     ///
     /// - Parameter coordinate: The coordinate to check
     /// - Parameter ignoringBoundary: `true` if the boundaries should be ignored when determining if the coordinate is inside of one of the geometries (default `false`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the geometries, `false` otherwise.
     public func contains(
         _ coordinate: Coordinate3D,
-        ignoringBoundary: Bool = false
+        ignoringBoundary: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
-        geometries.contains { (geometry) -> Bool in
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedCoordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
+
+        return snappedSelf.geometries.contains { (geometry) -> Bool in
             guard let polygonGeometry = geometry as? PolygonGeometry else { return false }
 
-            return polygonGeometry.contains(coordinate, ignoringBoundary: ignoringBoundary)
+            return polygonGeometry.contains(snappedCoordinate, ignoringBoundary: ignoringBoundary, gridSize: nil)
         }
     }
 
@@ -186,15 +211,20 @@ extension Feature {
     ///
     /// - Parameter coordinate: The coordinate to check
     /// - Parameter ignoringBoundary: `true` if the boundaries should be ignored when determining if the coordinate is inside of the Feature's geometry (default `false`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the Feature's geometry, `false` otherwise.
     public func contains(
         _ coordinate: Coordinate3D,
-        ignoringBoundary: Bool = false
+        ignoringBoundary: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
-        guard let polygonGeometry = geometry as? PolygonGeometry else { return false }
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedCoordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
 
-        return polygonGeometry.contains(coordinate, ignoringBoundary: ignoringBoundary)
+        guard let polygonGeometry = snappedSelf.geometry as? PolygonGeometry else { return false }
+
+        return polygonGeometry.contains(snappedCoordinate, ignoringBoundary: ignoringBoundary, gridSize: nil)
     }
 
 }
@@ -205,13 +235,18 @@ extension FeatureCollection {
     ///
     /// - Parameter coordinate: The coordinate to check
     /// - Parameter ignoringBoundary: `true` if the boundaries should be ignored when determining if the coordinate is inside of one of the geometries (default `false`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the coordinate is inside of one of the geometries, `false` otherwise.
     public func contains(
         _ coordinate: Coordinate3D,
-        ignoringBoundary: Bool = false
+        ignoringBoundary: Bool = false,
+        gridSize: Double? = nil
     ) -> Bool {
-        features.contains(where: { $0.contains(coordinate, ignoringBoundary: ignoringBoundary) })
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedCoordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
+
+        return snappedSelf.features.contains(where: { $0.contains(snappedCoordinate, ignoringBoundary: ignoringBoundary, gridSize: nil) })
     }
 
 }

--- a/Sources/GISTools/Algorithms/BooleanPointOnLine.swift
+++ b/Sources/GISTools/Algorithms/BooleanPointOnLine.swift
@@ -9,38 +9,45 @@ import Foundation
 extension LineSegment {
 
     /// Tests if *Coordinate3D* is on the segment.
-    public func checkIsOnSegment(_ coordinate: Coordinate3D) -> Bool {
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
+    public func checkIsOnSegment(_ coordinate: Coordinate3D, gridSize: Double? = nil) -> Bool {
         let coordinate = coordinate.projected(to: projection)
+        let snapped = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedCoordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
 
-        let ab = sqrt((second.longitude - first.longitude) * (second.longitude - first.longitude)
-            + (second.latitude - first.latitude) * (second.latitude - first.latitude))
-        let ap = sqrt((coordinate.longitude - first.longitude) * (coordinate.longitude - first.longitude)
-            + (coordinate.latitude - first.latitude) * (coordinate.latitude - first.latitude))
-        let pb = sqrt((second.longitude - coordinate.longitude) * (second.longitude - coordinate.longitude)
-            + (second.latitude - coordinate.latitude) * (second.latitude - coordinate.latitude))
+        let ab = sqrt((snapped.second.longitude - snapped.first.longitude) * (snapped.second.longitude - snapped.first.longitude)
+            + (snapped.second.latitude - snapped.first.latitude) * (snapped.second.latitude - snapped.first.latitude))
+        let ap = sqrt((snappedCoordinate.longitude - snapped.first.longitude) * (snappedCoordinate.longitude - snapped.first.longitude)
+            + (snappedCoordinate.latitude - snapped.first.latitude) * (snappedCoordinate.latitude - snapped.first.latitude))
+        let pb = sqrt((snapped.second.longitude - snappedCoordinate.longitude) * (snapped.second.longitude - snappedCoordinate.longitude)
+            + (snapped.second.latitude - snappedCoordinate.latitude) * (snapped.second.latitude - snappedCoordinate.latitude))
 
         return abs(ab - (ap + pb)) < GISTool.equalityDelta
     }
 
     /// Tests if *Point* is on the segment.
-    public func checkIsOnSegment(_ point: Point) -> Bool {
-        checkIsOnSegment(point.coordinate)
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
+    public func checkIsOnSegment(_ point: Point, gridSize: Double? = nil) -> Bool {
+        checkIsOnSegment(point.coordinate, gridSize: gridSize)
     }
 
 }
 
 extension LineStringGeometry {
 
-    /// Tests if *Coordinate3D* is on the segment.
-    public func checkIsOnLine(_ coordinate: Coordinate3D) -> Bool {
-        lineSegments.contains { (segment) in
-            segment.checkIsOnSegment(coordinate)
+    /// Tests if *Coordinate3D* is on the line.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
+    public func checkIsOnLine(_ coordinate: Coordinate3D, gridSize: Double? = nil) -> Bool {
+        let snappedCoordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
+        return lineSegments.contains { (segment) in
+            segment.checkIsOnSegment(snappedCoordinate, gridSize: gridSize)
         }
     }
 
-    /// Tests if *Point* is on the segment.
-    public func checkIsOnLine(_ point: Point) -> Bool {
-        checkIsOnLine(point.coordinate)
+    /// Tests if *Point* is on the line.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
+    public func checkIsOnLine(_ point: Point, gridSize: Double? = nil) -> Bool {
+        checkIsOnLine(point.coordinate, gridSize: gridSize)
     }
 
 }

--- a/Sources/GISTools/Algorithms/BooleanTouches.swift
+++ b/Sources/GISTools/Algorithms/BooleanTouches.swift
@@ -14,18 +14,22 @@ extension GeoJson {
     /// but their interiors are disjoint.
     ///
     /// - Parameter other: The other geometry
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the geometries touch, `false` otherwise.
-    public func touches(_ other: GeoJson) -> Bool {
-        if let fc1 = self as? FeatureCollection {
-            return fc1.features.contains { $0.touches(other) }
+    public func touches(_ other: GeoJson, gridSize: Double? = nil) -> Bool {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+
+        if let fc1 = snappedSelf as? FeatureCollection {
+            return fc1.features.contains { $0.touches(snappedOther) }
         }
-        if let fc2 = other as? FeatureCollection {
-            return fc2.features.contains { self.touches($0) }
+        if let fc2 = snappedOther as? FeatureCollection {
+            return fc2.features.contains { snappedSelf.touches($0) }
         }
 
-        let geom1: GeoJson = (self as? Feature)?.geometry ?? self
-        let geom2: GeoJson = (other as? Feature)?.geometry ?? other
+        let geom1: GeoJson = (snappedSelf as? Feature)?.geometry ?? snappedSelf
+        let geom2: GeoJson = (snappedOther as? Feature)?.geometry ?? snappedOther
 
         guard let geometry1 = geom1 as? GeoJsonGeometry,
               let geometry2 = geom2 as? GeoJsonGeometry

--- a/Sources/GISTools/Algorithms/Buffer.swift
+++ b/Sources/GISTools/Algorithms/Buffer.swift
@@ -38,26 +38,29 @@ extension GeoJson {
     /// - Parameter lineEndStyle: Controls how line ends will be drawn (default round)
     /// - Parameter unionType: How to combine buffered geometries (default individual)
     /// - Parameter steps: The number of steps for the circles (default 64)
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before buffering (default `nil`).
     ///
     /// - Returns: The buffered geometry as a `MultiPolygon`, or `nil` if the buffer could not be computed.
     public func buffered(
         by distance: Double,
         lineEndStyle: BufferLineEndStyle = .round,
         unionType: BufferUnionType = .individual,
-        steps: Int = 64
+        steps: Int = 64,
+        gridSize: Double? = nil
     ) -> MultiPolygon? {
+        let geometry = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
         guard distance != 0.0 else { return nil }
 
         if distance < 0.0 {
             return Self.inset(
-                self,
+                geometry,
                 by: -distance,
                 lineEndStyle: lineEndStyle,
                 unionType: unionType,
                 steps: steps)
         }
         return Self.buffer(
-            self,
+            geometry,
             by: distance,
             lineEndStyle: lineEndStyle,
             unionType: unionType,
@@ -467,26 +470,30 @@ extension LineSegment {
     /// - Parameter lineEndStyle: Controls how line ends will be drawn (default round)
     /// - Parameter unionType: Whether to combine all overlapping buffers into one Polygon (default true)
     /// - Parameter steps: The number of steps for the circles (default 64)
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before buffering (default `nil`).
     ///
     /// - Returns: The buffered line segment as a `MultiPolygon`, or `nil` if the buffer could not be computed.
     public func buffered(
         by distance: Double,
         lineEndStyle: BufferLineEndStyle = .round,
         unionType: BufferUnionType = .individual,
-        steps: Int = 64
+        steps: Int = 64,
+        gridSize: Double? = nil
     ) -> MultiPolygon? {
         guard distance > 0.0 else { return nil }
 
-        let firstBearing = self.bearing
+        let snappedSegment = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+
+        let firstBearing = snappedSegment.bearing
         let leftBearing = (firstBearing - 90.0).truncatingRemainder(dividingBy: 360.0)
         let rightBearing = (firstBearing + 90.0).truncatingRemainder(dividingBy: 360.0)
 
         let corners = [
-            first.destination(distance: distance, bearing: leftBearing),
-            second.destination(distance: distance, bearing: leftBearing),
-            second.destination(distance: distance, bearing: rightBearing),
-            first.destination(distance: distance, bearing: rightBearing),
-            first.destination(distance: distance, bearing: leftBearing),
+            snappedSegment.first.destination(distance: distance, bearing: leftBearing),
+            snappedSegment.second.destination(distance: distance, bearing: leftBearing),
+            snappedSegment.second.destination(distance: distance, bearing: rightBearing),
+            snappedSegment.first.destination(distance: distance, bearing: rightBearing),
+            snappedSegment.first.destination(distance: distance, bearing: leftBearing),
         ]
 
         guard let rectPolygon = Polygon([corners]) else { return nil }
@@ -499,8 +506,8 @@ extension LineSegment {
         }
 
         if lineEndStyle == .round,
-           let firstCircle = first.circle(radius: distance, steps: steps),
-           let secondCircle = second.circle(radius: distance, steps: steps)
+           let firstCircle = snappedSegment.first.circle(radius: distance, steps: steps),
+           let secondCircle = snappedSegment.second.circle(radius: distance, steps: steps)
         {
             polygons.append(firstCircle)
             polygons.append(secondCircle)

--- a/Sources/GISTools/Algorithms/ConcaveHull.swift
+++ b/Sources/GISTools/Algorithms/ConcaveHull.swift
@@ -16,10 +16,12 @@ extension GeoJson {
     ///
     /// - Parameter maxEdgeLength: The maximum edge length in meters for
     ///   a triangle to be included in the hull
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     ///
     /// - Returns: A `MultiPolygon` representing the concave hull
-    public func concaveHull(maxEdgeLength: CLLocationDistance) -> MultiPolygon? {
-        let coords = allCoordinates
+    public func concaveHull(maxEdgeLength: CLLocationDistance, gridSize: Double? = nil) -> MultiPolygon? {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let coords = snappedSelf.allCoordinates
         let unique = Set(coords)
         guard unique.count >= 3 else { return nil }
 

--- a/Sources/GISTools/Algorithms/Kinks.swift
+++ b/Sources/GISTools/Algorithms/Kinks.swift
@@ -12,10 +12,12 @@ extension GeoJson {
     /// Supports ``LineString``, ``MultiLineString``, ``Polygon``,
     /// and ``MultiPolygon``.
     ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     /// - Returns: A ``MultiPoint`` with one point for each
     ///   self-intersection.
-    public func kinks() -> MultiPoint {
-        let geometry = (self as? Feature)?.geometry ?? (self as? GeoJsonGeometry)
+    public func kinks(gridSize: Double? = nil) -> MultiPoint {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let geometry = (snappedSelf as? Feature)?.geometry ?? (snappedSelf as? GeoJsonGeometry)
 
         let coordSets: [[Coordinate3D]]
 

--- a/Sources/GISTools/Algorithms/LineIntersect.swift
+++ b/Sources/GISTools/Algorithms/LineIntersect.swift
@@ -60,30 +60,37 @@ extension LineSegment {
     /// - Parameter other: The other *LineSegment*
     /// - Parameter epsilon: Tolerance for collinearity and on-segment checks
     ///     (in the coordinate system's native units, e.g. degrees for EPSG:4326)
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: `true` if the line segments intersect.
-    public func intersects(_ other: LineSegment, epsilon: Double = 0.0) -> Bool {
-        let other = other.projected(to: projection)
+    public func intersects(
+        _ other: LineSegment,
+        epsilon: Double = 0.0,
+        gridSize: Double? = nil
+    ) -> Bool {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        let other = snappedOther.projected(to: snappedSelf.projection)
 
-        let o1 = orientation(p: first, q: second, r: other.first, epsilon: epsilon)
-        let o2 = orientation(p: first, q: second, r: other.second, epsilon: epsilon)
-        let o3 = orientation(p: other.first, q: other.second, r: first, epsilon: epsilon)
-        let o4 = orientation(p: other.first, q: other.second, r: second, epsilon: epsilon)
+        let o1 = orientation(p: snappedSelf.first, q: snappedSelf.second, r: other.first, epsilon: epsilon)
+        let o2 = orientation(p: snappedSelf.first, q: snappedSelf.second, r: other.second, epsilon: epsilon)
+        let o3 = orientation(p: other.first, q: other.second, r: snappedSelf.first, epsilon: epsilon)
+        let o4 = orientation(p: other.first, q: other.second, r: snappedSelf.second, epsilon: epsilon)
 
         if o1 != o2, o3 != o4 {
             return true
         }
 
-        if o1 == .colinear, onSegment(p: first, q: other.first, r: second, epsilon: epsilon) {
+        if o1 == .colinear, onSegment(p: snappedSelf.first, q: other.first, r: snappedSelf.second, epsilon: epsilon) {
             return true
         }
-        if o2 == .colinear, onSegment(p: first, q: other.second, r: second, epsilon: epsilon) {
+        if o2 == .colinear, onSegment(p: snappedSelf.first, q: other.second, r: snappedSelf.second, epsilon: epsilon) {
             return true
         }
-        if o3 == .colinear, onSegment(p: other.first, q: first, r: other.second, epsilon: epsilon) {
+        if o3 == .colinear, onSegment(p: other.first, q: snappedSelf.first, r: other.second, epsilon: epsilon) {
             return true
         }
-        if o4 == .colinear, onSegment(p: other.first, q: second, r: other.second, epsilon: epsilon) {
+        if o4 == .colinear, onSegment(p: other.first, q: snappedSelf.second, r: other.second, epsilon: epsilon) {
             return true
         }
 
@@ -110,22 +117,26 @@ extension LineSegment {
     /// - Parameter other: The other *LineSegment*
     /// - Parameter epsilon: Tolerance for endpoint parameter checks
     ///     (in the coordinate system's native units, e.g. degrees for EPSG:4326)
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: The intersection point, or `nil`.
     public func intersection(
         _ other: LineSegment,
-        epsilon: Double = 0.0
+        epsilon: Double = 0.0,
+        gridSize: Double? = nil
     ) -> Coordinate3D? {
-        let other = other.projected(to: projection)
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        let other = snappedOther.projected(to: snappedSelf.projection)
 
-        let denominator: Double = ((other.second.latitude - other.first.latitude) * (self.second.longitude - self.first.longitude))
-            - ((other.second.longitude - other.first.longitude) * (self.second.latitude - self.first.latitude))
+        let denominator: Double = ((other.second.latitude - other.first.latitude) * (snappedSelf.second.longitude - snappedSelf.first.longitude))
+            - ((other.second.longitude - other.first.longitude) * (snappedSelf.second.latitude - snappedSelf.first.latitude))
 
         if abs(denominator) > 1e-15 {
-            let numeratorA: Double = ((other.second.longitude - other.first.longitude) * (self.first.latitude - other.first.latitude))
-                - ((other.second.latitude - other.first.latitude) * (self.first.longitude - other.first.longitude))
-            let numeratorB: Double = ((self.second.longitude - self.first.longitude) * (self.first.latitude - other.first.latitude))
-                - ((self.second.latitude - self.first.latitude) * (self.first.longitude - other.first.longitude))
+            let numeratorA: Double = ((other.second.longitude - other.first.longitude) * (snappedSelf.first.latitude - other.first.latitude))
+                - ((other.second.latitude - other.first.latitude) * (snappedSelf.first.longitude - other.first.longitude))
+            let numeratorB: Double = ((snappedSelf.second.longitude - snappedSelf.first.longitude) * (snappedSelf.first.latitude - other.first.latitude))
+                - ((snappedSelf.second.latitude - snappedSelf.first.latitude) * (snappedSelf.first.longitude - other.first.longitude))
 
             let uA: Double = numeratorA / denominator
             let uB: Double = numeratorB / denominator
@@ -135,10 +146,10 @@ extension LineSegment {
                uB >= -epsilon,
                uB <= 1.0 + epsilon
             {
-                let longitude = self.first.longitude + (uA * (self.second.longitude - self.first.longitude))
-                let latitude = self.first.latitude + (uA * (self.second.latitude - self.first.latitude))
+                let longitude = snappedSelf.first.longitude + (uA * (snappedSelf.second.longitude - snappedSelf.first.longitude))
+                let latitude = snappedSelf.first.latitude + (uA * (snappedSelf.second.latitude - snappedSelf.first.latitude))
 
-                return Coordinate3D(x: longitude, y: latitude, projection: projection)
+                return Coordinate3D(x: longitude, y: latitude, projection: snappedSelf.projection)
             }
             return nil
         }
@@ -158,20 +169,27 @@ extension GeoJson {
     /// - Parameter other: The other geometry
     /// - Parameter epsilon: Tolerance passed through to ``LineSegment/intersection(_:epsilon:)``
     ///     (in the coordinate system's native units, e.g. degrees for EPSG:4326)
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: An array of intersecting points.
-    public func intersections(with other: GeoJson, epsilon: Double = 0.0) -> [Point] {
-        let other = other.projected(to: projection)
+    public func intersections(
+        with other: GeoJson,
+        epsilon: Double = 0.0,
+        gridSize: Double? = nil
+    ) -> [Point] {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        let other = snappedOther.projected(to: snappedSelf.projection)
 
         if let otherBoundingBox = other.boundingBox ?? other.calculateBoundingBox(),
-           !intersects(otherBoundingBox)
+           !snappedSelf.intersects(otherBoundingBox)
         {
             return []
         }
 
         var result: Set<Coordinate3D> = []
 
-        if let point = self as? PointGeometry {
+        if let point = snappedSelf as? PointGeometry {
             if let otherPoint = other as? PointGeometry {
                 for coordinate in point.allCoordinates
                     where otherPoint.allCoordinates.contains(coordinate)
@@ -190,9 +208,9 @@ extension GeoJson {
             }
         }
         else {
-            for lineSegment in lineSegments {
+            for lineSegment in snappedSelf.lineSegments {
                 for otherLineSegment in other.lineSegments {
-                    if let intersection = lineSegment.intersection(otherLineSegment, epsilon: epsilon) {
+                    if let intersection = lineSegment.intersection(otherLineSegment, epsilon: epsilon, gridSize: nil) {
                         result.insert(intersection)
                     }
                 }

--- a/Sources/GISTools/Algorithms/LineOverlap.swift
+++ b/Sources/GISTools/Algorithms/LineOverlap.swift
@@ -24,36 +24,40 @@ extension LineSegment {
     /// - Parameters:
     /// - Parameter other: The other *LineSegment*
     /// - Parameter tolerance: The tolerance, in meters
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     ///
     /// - Returns: A ``LineSegmentComparisonResult`` indicating how the segments relate.
     public func compare(
         _ other: LineSegment,
-        tolerance: CLLocationDistance = 0.0
+        tolerance: CLLocationDistance = 0.0,
+        gridSize: Double? = nil
     ) -> LineSegmentComparisonResult {
-        let other = other.projected(to: projection)
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        let other = snappedOther.projected(to: snappedSelf.projection)
         let tolerance = abs(tolerance)
 
-        if (first == other.first && second == other.second)
-            || (first == other.second && second == other.first)
+        if (snappedSelf.first == other.first && snappedSelf.second == other.second)
+            || (snappedSelf.first == other.second && snappedSelf.second == other.first)
         {
             return .equal
         }
         else if tolerance == 0.0 {
-            if other.checkIsOnSegment(first), other.checkIsOnSegment(second) {
+            if other.checkIsOnSegment(snappedSelf.first), other.checkIsOnSegment(snappedSelf.second) {
                 return .thisOnOther
             }
-            else if checkIsOnSegment(other.first), checkIsOnSegment(other.second) {
+            else if snappedSelf.checkIsOnSegment(other.first), snappedSelf.checkIsOnSegment(other.second) {
                 return .otherOnThis
             }
         }
         else if tolerance > 0.0 {
-            if other.nearestCoordinateOnSegment(from: first).distance <= tolerance,
-               other.nearestCoordinateOnSegment(from: second).distance <= tolerance
+            if other.nearestCoordinateOnSegment(from: snappedSelf.first).distance <= tolerance,
+               other.nearestCoordinateOnSegment(from: snappedSelf.second).distance <= tolerance
             {
                 return .thisOnOther
             }
-            else if nearestCoordinateOnSegment(from: other.first).distance <= tolerance,
-                    nearestCoordinateOnSegment(from: other.second).distance <= tolerance
+            else if snappedSelf.nearestCoordinateOnSegment(from: other.first).distance <= tolerance,
+                    snappedSelf.nearestCoordinateOnSegment(from: other.second).distance <= tolerance
             {
                 return .otherOnThis
             }
@@ -71,24 +75,28 @@ extension GeoJson {
     /// - Parameters:
     /// - Parameter other: The other geometry
     /// - Parameter tolerance: The tolerance, in meters
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     ///
     /// - Returns: An array of overlapping line segments.
     public func overlappingSegments(
         with other: GeoJson,
-        tolerance: CLLocationDistance = 0.0
+        tolerance: CLLocationDistance = 0.0,
+        gridSize: Double? = nil
     ) -> [LineSegment] {
-        let other = other.projected(to: projection)
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let snappedOther = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        let other = snappedOther.projected(to: snappedSelf.projection)
         let tolerance = abs(tolerance)
 
         var result: [LineSegment] = []
 
-        let tree: RTree<LineSegment> = RTree(lineSegments)
+        let tree: RTree<LineSegment> = RTree(snappedSelf.lineSegments)
 
         for segment in other.lineSegments {
             guard let boundingBox = segment.boundingBox ?? segment.calculateBoundingBox() else { continue }
 
             for match in tree.search(inBoundingBox: boundingBox) {
-                let comparison = segment.compare(match, tolerance: tolerance)
+                let comparison = segment.compare(match, tolerance: tolerance, gridSize: nil)
 
                 if comparison == .equal {
                     result.append(segment)
@@ -115,21 +123,24 @@ extension GeoJson {
     ///
     /// - Parameter tolerance: The tolerance, in meters. Using `0.0` will only return segments that *exactly* overlap.
     /// - Parameter segmentLength: This value adds intermediate points to the geometry for improved matching, in meters. Choosing this too small might lead to memory explosion.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     ///
     /// - Returns: All segments that at least overlap with one other segment. Each segment will
     ///            appear in the result only once.
     public func overlappingSegments(
         tolerance: CLLocationDistance,
-        segmentLength: Double? = nil
+        segmentLength: Double? = nil,
+        gridSize: Double? = nil
     ) -> MultiLineString? {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
         let tolerance = abs(tolerance)
         let distanceFunction = FrechetDistanceFunction.haversine
 
         guard let line = if let segmentLength, segmentLength > 0.0 {
-            LineString(lineSegments)?.evenlyDivided(segmentLength: segmentLength)
+            LineString(snappedSelf.lineSegments)?.evenlyDivided(segmentLength: segmentLength)
         }
         else {
-            LineString(lineSegments)
+            LineString(snappedSelf.lineSegments)
         }
         else {
             return nil
@@ -223,13 +234,15 @@ extension GeoJson {
     ///
     /// - Parameter tolerance: The tolerance, in meters. Using `0.0` will only count segments that *exactly* overlap.
     /// - Parameter segmentLength: This value adds intermediate points to the geometry for improved matching, in meters. Choosing this too small might lead to memory explosion.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     ///
     /// - Returns: The length of all segments that overlap within `tolerance`.
     public func estimatedOverlap(
         tolerance: CLLocationDistance,
-        segmentLength: Double? = nil
+        segmentLength: Double? = nil,
+        gridSize: Double? = nil
     ) -> Double {
-        guard let result = overlappingSegments(tolerance: tolerance, segmentLength: segmentLength) else { return 0.0 }
+        guard let result = overlappingSegments(tolerance: tolerance, segmentLength: segmentLength, gridSize: gridSize) else { return 0.0 }
 
         return result.length
     }

--- a/Sources/GISTools/Algorithms/LineSlice.swift
+++ b/Sources/GISTools/Algorithms/LineSlice.swift
@@ -14,25 +14,40 @@ extension LineString {
     ///
     /// - Parameter start: The starting point (defaults to the first coordinate if `nil`)
     /// - Parameter end: The stopping point (defaults to the last coordinate if `nil`)
+    /// - Parameter gridSize: An optional grid size for snapping inputs
     ///
     /// - Returns: A `LineString` subsection, or `nil` if the line has fewer than 2 coordinates.
     public func slice(
         start: Coordinate3D? = nil,
-        end: Coordinate3D? = nil
+        end: Coordinate3D? = nil,
+        gridSize: Double? = nil
     ) -> LineString? {
-        guard coordinates.count >= 2 else { return nil }
+        let snappedSelf: LineString
+        let snappedStart: Coordinate3D?
+        let snappedEnd: Coordinate3D?
+        if let gridSize {
+            snappedSelf = self.snappedToGrid(tolerance: gridSize)
+            snappedStart = start.map { $0.snappedToGrid(tolerance: gridSize) }
+            snappedEnd = end.map { $0.snappedToGrid(tolerance: gridSize) }
+        } else {
+            snappedSelf = self
+            snappedStart = start
+            snappedEnd = end
+        }
 
-        let start = start?.projected(to: projection)
-        let end = end?.projected(to: projection)
+        guard snappedSelf.coordinates.count >= 2 else { return nil }
+
+        let start = snappedStart?.projected(to: projection)
+        let end = snappedEnd?.projected(to: projection)
 
         var startVertex: (coordinate: Coordinate3D, index: Int, distance: CLLocationDistance)
         var endVertex: (coordinate: Coordinate3D, index: Int, distance: CLLocationDistance)
 
         // Find a start point
-        if let start = start, let firstVertex = nearestCoordinateOnLine(from: start) {
+        if let start = start, let firstVertex = snappedSelf.nearestCoordinateOnLine(from: start) {
             startVertex = firstVertex
         }
-        else if let start = firstCoordinate {
+        else if let start = snappedSelf.firstCoordinate {
             startVertex = (coordinate: start, index: 0, distance: 0)
         }
         else {
@@ -40,11 +55,11 @@ extension LineString {
         }
 
         // Find an end point
-        if let end = end, let secondVertex = nearestCoordinateOnLine(from: end) {
+        if let end = end, let secondVertex = snappedSelf.nearestCoordinateOnLine(from: end) {
             endVertex = secondVertex
         }
-        else if let end = lastCoordinate {
-            endVertex = (coordinate: end, index: coordinates.count - 1, distance: 0)
+        else if let end = snappedSelf.lastCoordinate {
+            endVertex = (coordinate: end, index: snappedSelf.coordinates.count - 1, distance: 0)
         }
         else {
             return nil
@@ -57,7 +72,7 @@ extension LineString {
         var clipCoordinates: [Coordinate3D] = [startVertex.coordinate]
 
         for index in (startVertex.index + 1) ..< endVertex.index + 1 {
-            clipCoordinates.append(coordinates[index])
+            clipCoordinates.append(snappedSelf.coordinates[index])
         }
 
         if clipCoordinates.last != endVertex.coordinate {
@@ -78,14 +93,16 @@ extension Feature {
     ///
     /// - Parameter start: The starting point
     /// - Parameter end: The stopping point
+    /// - Parameter gridSize: An optional grid size for snapping inputs
     ///
     /// - Returns: A `Feature` subsection, or `nil`.
     public func slice(
         start: Coordinate3D? = nil,
-        end: Coordinate3D? = nil
+        end: Coordinate3D? = nil,
+        gridSize: Double? = nil
     ) -> Feature? {
         guard let lineString = geometry as? LineString,
-              let lineSlice = lineString.slice(start: start, end: end)
+              let lineSlice = lineString.slice(start: start, end: end, gridSize: gridSize)
         else { return nil }
 
         var newFeature = Feature(lineSlice, id: id, properties: properties, calculateBoundingBox: (self.boundingBox != nil))

--- a/Sources/GISTools/Algorithms/NearestPoint.swift
+++ b/Sources/GISTools/Algorithms/NearestPoint.swift
@@ -11,24 +11,32 @@ extension BoundingBox {
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other coordinate
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     ///
     /// - Returns: The nearest coordinate and distance, or `nil`.
     public func nearestCoordinate(
-        from other: Coordinate3D
+        from other: Coordinate3D,
+        gridSize: Double? = nil
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance)? {
-        self.boundingBoxGeometry.nearestCoordinate(from: other)
+        let snappedGeometry = gridSize.map { self.boundingBoxGeometry.snappedToGrid(tolerance: $0) } ?? self.boundingBoxGeometry
+        let other = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        return snappedGeometry.nearestCoordinate(from: other)
     }
 
     /// Takes a reference point and returns the point from the receiver closest to the reference.
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other point
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     ///
     /// - Returns: The nearest point and distance, or `nil`.
     public func nearestPoint(
-        from other: Point
+        from other: Point,
+        gridSize: Double? = nil
     ) -> (point: Point, distance: CLLocationDistance)? {
-        self.boundingBoxGeometry.nearestPoint(from: other)
+        self.nearestCoordinate(from: other.coordinate, gridSize: gridSize).map {
+            (point: Point($0.coordinate), distance: $0.distance)
+        }
     }
 
 }
@@ -39,21 +47,25 @@ extension GeoJson {
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other coordinate
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     ///
     /// - Returns: The nearest coordinate and distance, or `nil`.
     public func nearestCoordinate(
-        from other: Coordinate3D
+        from other: Coordinate3D,
+        gridSize: Double? = nil
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance)? {
-        let other = other.projected(to: projection)
+        let geoJson = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let other = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        let otherProjected = other.projected(to: geoJson.projection)
 
-        let allCoordinates = self.allCoordinates
+        let allCoordinates = geoJson.allCoordinates
         guard !allCoordinates.isEmpty else { return nil }
 
         var bestCoordinate: Coordinate3D = allCoordinates[0]
-        var bestDistance: CLLocationDistance = bestCoordinate.distance(from: other)
+        var bestDistance: CLLocationDistance = bestCoordinate.distance(from: otherProjected)
 
         for coordinate in allCoordinates {
-            let distance = coordinate.distance(from: other)
+            let distance = coordinate.distance(from: otherProjected)
             if distance < bestDistance {
                 bestDistance = distance
                 bestCoordinate = coordinate
@@ -67,12 +79,14 @@ extension GeoJson {
     /// This calculation is geodesic.
     ///
     /// - Parameter other: The other point
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     ///
     /// - Returns: The nearest point and distance, or `nil`.
     public func nearestPoint(
-        from other: Point
+        from other: Point,
+        gridSize: Double? = nil
     ) -> (point: Point, distance: CLLocationDistance)? {
-        if let nearest = nearestCoordinate(from: other.coordinate) {
+        if let nearest = nearestCoordinate(from: other.coordinate, gridSize: gridSize) {
             return (point: Point(nearest.coordinate), distance: nearest.distance)
         }
 

--- a/Sources/GISTools/Algorithms/NearestPointOnFeature.swift
+++ b/Sources/GISTools/Algorithms/NearestPointOnFeature.swift
@@ -6,23 +6,30 @@ import Foundation
 extension BoundingBox {
 
     /// Returns a *Coordinate* guaranteed to be on the surface of the bounding box.
+    /// - Parameter from: The reference coordinate
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     public func nearestCoordinateOnFeature(
-        from other: Coordinate3D
+        from other: Coordinate3D,
+        gridSize: Double? = nil
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance)? {
+        let other = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        let snappedGeometry = gridSize.map { self.boundingBoxGeometry.snappedToGrid(tolerance: $0) } ?? self.boundingBoxGeometry
         if self.contains(other) {
             return (coordinate: other, distance: 0.0)
         }
-        return self.boundingBoxGeometry.nearestCoordinateOnFeature(from: other)
+        return snappedGeometry.nearestCoordinateOnFeature(from: other)
     }
 
     /// Returns a *Point* guaranteed to be on the surface of the bounding box.
+    /// - Parameter from: The reference point
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     public func nearestPointOnFeature(
-        from other: Point
+        from other: Point,
+        gridSize: Double? = nil
     ) -> (point: Point, distance: CLLocationDistance)? {
-        if self.contains(other.coordinate) {
-            return (point: other, distance: 0.0)
+        self.nearestCoordinateOnFeature(from: other.coordinate, gridSize: gridSize).map {
+            (point: Point($0.coordinate), distance: $0.distance)
         }
-        return self.boundingBoxGeometry.nearestPointOnFeature(from: other)
     }
 
 }
@@ -30,54 +37,62 @@ extension BoundingBox {
 extension GeoJson {
 
     /// Returns a *Point* guaranteed to be on the surface of the feature.
+    /// - Parameter from: The reference point
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     public func nearestPointOnFeature(
-        from other: Point
+        from other: Point,
+        gridSize: Double? = nil
     ) -> (point: Point, distance: CLLocationDistance)? {
-        if let nearest = nearestCoordinateOnFeature(from: other.coordinate) {
+        if let nearest = nearestCoordinateOnFeature(from: other.coordinate, gridSize: gridSize) {
             return (point: Point(nearest.coordinate), distance: nearest.distance)
         }
         return nil
     }
 
     /// Returns a *Coordinate* guaranteed to be on the surface of the feature.
+    /// - Parameter from: The reference coordinate
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     public func nearestCoordinateOnFeature(
-        from other: Coordinate3D
+        from other: Coordinate3D,
+        gridSize: Double? = nil
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance)? {
-        let other = other.projected(to: projection)
+        let geoJson = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let other = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        let otherProjected = other.projected(to: geoJson.projection)
 
-        switch self {
+        switch geoJson {
         case let point as Point:
-            return (coordinate: point.coordinate, distance: point.coordinate.distance(from: other))
+            return (coordinate: point.coordinate, distance: point.coordinate.distance(from: otherProjected))
 
         case let multiPoint as MultiPoint:
-            return multiPoint.nearestCoordinate(from: other)
+            return multiPoint.nearestCoordinate(from: otherProjected)
 
         case let lineString as LineString:
-            return nearest(onSegments: lineString.lineSegments, from: other)
+            return nearest(onSegments: lineString.lineSegments, from: otherProjected)
 
         case let multiLineString as MultiLineString:
-            return nearest(onSegments: multiLineString.lineSegments, from: other)
+            return nearest(onSegments: multiLineString.lineSegments, from: otherProjected)
 
         case let polygon as Polygon:
-            if polygon.contains(other) {
-                return (coordinate: other, distance: 0.0)
+            if polygon.contains(otherProjected) {
+                return (coordinate: otherProjected, distance: 0.0)
             }
-            return nearest(onSegments: polygon.lineSegments, from: other)
+            return nearest(onSegments: polygon.lineSegments, from: otherProjected)
 
         case let multiPolygon as MultiPolygon:
-            if multiPolygon.contains(other) {
-                return (coordinate: other, distance: 0.0)
+            if multiPolygon.contains(otherProjected) {
+                return (coordinate: otherProjected, distance: 0.0)
             }
-            return nearest(onSegments: multiPolygon.lineSegments, from: other)
+            return nearest(onSegments: multiPolygon.lineSegments, from: otherProjected)
 
         case let geometryCollection as GeometryCollection:
-            return nearest(onGeometries: geometryCollection.geometries, from: other)
+            return nearest(onGeometries: geometryCollection.geometries, from: otherProjected)
 
         case let feature as Feature:
-            return feature.geometry.nearestCoordinateOnFeature(from: other)
+            return feature.geometry.nearestCoordinateOnFeature(from: otherProjected)
 
         case let featureCollection as FeatureCollection:
-            return nearest(onGeometries: featureCollection.features.map(\.geometry), from: other)
+            return nearest(onGeometries: featureCollection.features.map(\.geometry), from: otherProjected)
 
         default:
             return nil

--- a/Sources/GISTools/Algorithms/NearestPointOnLine.swift
+++ b/Sources/GISTools/Algorithms/NearestPointOnLine.swift
@@ -55,11 +55,17 @@ extension LineSegment {
 extension LineSegment {
 
     /// Calculates the closest coordinate on the segment.
+    /// - Parameter from: The reference coordinate
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     public func nearestCoordinateOnSegment(
-        from other: Coordinate3D
+        from other: Coordinate3D,
+        gridSize: Double? = nil
     ) -> (coordinate: Coordinate3D, distance: CLLocationDistance) {
-        guard let foot: Coordinate3D = perpendicularFoot(from: other, clampToEnds: true) else {
-            return (coordinate: first, distance: 0.0)
+        let segment = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let other = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+
+        guard let foot: Coordinate3D = segment.perpendicularFoot(from: other, clampToEnds: true) else {
+            return (coordinate: segment.first, distance: 0.0)
         }
         let footDistance: CLLocationDistance = other.distance(from: foot)
 
@@ -71,22 +77,28 @@ extension LineSegment {
 extension LineString {
 
     /// Calculates the closest coordinate on the line.
+    /// - Parameter from: The reference coordinate
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     public func nearestCoordinateOnLine(
-        from other: Coordinate3D
+        from other: Coordinate3D,
+        gridSize: Double? = nil
     ) -> (coordinate: Coordinate3D, index: Int, distance: CLLocationDistance)? {
-        guard coordinates.count >= 2 else { return nil }
+        let lineString = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let other = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
 
-        let other = other.projected(to: projection)
+        guard lineString.coordinates.count >= 2 else { return nil }
 
-        var bestCoordinate: Coordinate3D = coordinates[0]
+        let otherProjected = other.projected(to: lineString.projection)
+
+        var bestCoordinate: Coordinate3D = lineString.coordinates[0]
         var bestDistance: CLLocationDistance = .greatestFiniteMagnitude
         var bestIndex: Int = -1
 
-        for (index, segment) in lineSegments.enumerated() {
-            guard let foot: Coordinate3D = segment.perpendicularFoot(from: other, clampToEnds: true) else {
+        for (index, segment) in lineString.lineSegments.enumerated() {
+            guard let foot: Coordinate3D = segment.perpendicularFoot(from: otherProjected, clampToEnds: true) else {
                 continue
             }
-            let footDistance: CLLocationDistance = other.distance(from: foot)
+            let footDistance: CLLocationDistance = otherProjected.distance(from: foot)
 
             if footDistance < bestDistance {
                 bestCoordinate = foot
@@ -95,13 +107,13 @@ extension LineString {
             }
         }
 
-        if let lastCoordinate = lastCoordinate {
-            let lastDistance = lastCoordinate.distance(from: other)
+        if let lastCoordinate = lineString.lastCoordinate {
+            let lastDistance = lastCoordinate.distance(from: otherProjected)
 
             if lastDistance <= bestDistance {
                 bestCoordinate = lastCoordinate
                 bestDistance = lastDistance
-                bestIndex = coordinates.count - 1
+                bestIndex = lineString.coordinates.count - 1
             }
         }
 
@@ -109,10 +121,13 @@ extension LineString {
     }
 
     /// Calculates the closest *Point* on the line.
+    /// - Parameter from: The reference point
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     public func nearestPointOnLine(
-        from other: Point
+        from other: Point,
+        gridSize: Double? = nil
     ) -> (point: Point, index: Int, distance: CLLocationDistance)? {
-        guard let result = nearestCoordinateOnLine(from: other.coordinate) else { return nil }
+        guard let result = nearestCoordinateOnLine(from: other.coordinate, gridSize: gridSize) else { return nil }
         return (point: Point(result.coordinate), index: result.index, distance: result.distance)
     }
 
@@ -121,19 +136,27 @@ extension LineString {
 extension Feature {
 
     /// Calculates the closest coordinate on the line.
+    /// - Parameter from: The reference coordinate
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     public func nearestCoordinateOnLine(
-        from other: Coordinate3D
+        from other: Coordinate3D,
+        gridSize: Double? = nil
     ) -> (coordinate: Coordinate3D, index: Int, distance: CLLocationDistance)? {
-        guard let lineString = geometry as? LineString else { return nil }
-        return lineString.nearestCoordinateOnLine(from: other)
+        let feature = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let other = gridSize.map { other.snappedToGrid(tolerance: $0) } ?? other
+        guard let lineString = feature.geometry as? LineString else { return nil }
+        return lineString.nearestCoordinateOnLine(from: other, gridSize: nil)
     }
 
     /// Calculates the closest *Point* on the line.
+    /// - Parameter from: The reference point
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     public func nearestPointOnLine(
-        from other: Point
+        from other: Point,
+        gridSize: Double? = nil
     ) -> (point: Point, index: Int, distance: CLLocationDistance)? {
         guard let lineString = geometry as? LineString else { return nil }
-        return lineString.nearestPointOnLine(from: other)
+        return lineString.nearestPointOnLine(from: other, gridSize: gridSize)
     }
 
 }

--- a/Sources/GISTools/Algorithms/PointOnFeature.swift
+++ b/Sources/GISTools/Algorithms/PointOnFeature.swift
@@ -20,10 +20,26 @@ extension GeoJson {
         coordinateOnFeature(failOnMiss: false)
     }
 
-    private func coordinateOnFeature(failOnMiss: Bool = false) -> Coordinate3D? {
-        guard let centroidCoordinate = centroid?.coordinate else { return nil }
+    /// Returns a *Point* guaranteed to be on the surface of the feature.
+    /// - Parameter gridSize: A grid size to snap coordinates to before computing the point on feature.
+    public func pointOnFeature(gridSize: Double? = nil) -> Point? {
+        if let coordinate = coordinateOnFeature(failOnMiss: false, gridSize: gridSize) {
+            return Point(coordinate)
+        }
+        return nil
+    }
 
-        switch self {
+    /// Returns a *Coordinate3D* guaranteed to be on the surface of the feature.
+    /// - Parameter gridSize: A grid size to snap coordinates to before computing the coordinate on feature.
+    public func coordinateOnFeature(gridSize: Double? = nil) -> Coordinate3D? {
+        coordinateOnFeature(failOnMiss: false, gridSize: gridSize)
+    }
+
+    private func coordinateOnFeature(failOnMiss: Bool = false, gridSize: Double? = nil) -> Coordinate3D? {
+        let geoJson = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        guard let centroidCoordinate = geoJson.centroid?.coordinate else { return nil }
+
+        switch geoJson {
         case let point as Point:
             return point.coordinate
 
@@ -60,7 +76,7 @@ extension GeoJson {
                     }
                 }
                 let normalized = Polygon(unchecked: normalizedRings, calculateBoundingBox: false)
-                if let coordinate = normalized.coordinateOnFeature(failOnMiss: true) {
+                if let coordinate = normalized.coordinateOnFeature(failOnMiss: true, gridSize: nil) {
                     var result = coordinate
                     if result.longitude > 180.0 {
                         result.longitude -= 360.0
@@ -86,7 +102,7 @@ extension GeoJson {
                     }
                     return Polygon(unchecked: normalizedRings, calculateBoundingBox: false)
                 })
-                if let coordinate = normalized.coordinateOnFeature(failOnMiss: true) {
+                if let coordinate = normalized.coordinateOnFeature(failOnMiss: true, gridSize: nil) {
                     var result = coordinate
                     if result.longitude > 180.0 {
                         result.longitude -= 360.0
@@ -100,17 +116,17 @@ extension GeoJson {
 
         case let geometryCollection as GeometryCollection:
             for geometry in geometryCollection.geometries {
-                if let coordinate = geometry.coordinateOnFeature(failOnMiss: true) {
+                if let coordinate = geometry.coordinateOnFeature(failOnMiss: true, gridSize: nil) {
                     return coordinate
                 }
             }
 
         case let feature as Feature:
-            return feature.geometry.coordinateOnFeature()
+            return feature.geometry.coordinateOnFeature(gridSize: nil)
 
         case let featureCollection as FeatureCollection:
             for feature in featureCollection.features {
-                if let coordinate = feature.geometry.coordinateOnFeature(failOnMiss: true) {
+                if let coordinate = feature.geometry.coordinateOnFeature(failOnMiss: true, gridSize: nil) {
                     return coordinate
                 }
             }

--- a/Sources/GISTools/Algorithms/PointToLineDistance.swift
+++ b/Sources/GISTools/Algorithms/PointToLineDistance.swift
@@ -8,14 +8,19 @@ import Foundation
 extension LineSegment {
 
     /// Returns the minimum distance between the coordinate and the segment.
-    public func distanceFrom(coordinate: Coordinate3D) -> CLLocationDistance {
-        let foot = perpendicularFoot(from: coordinate, clampToEnds: true) ?? first
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    public func distanceFrom(coordinate: Coordinate3D, gridSize: Double? = nil) -> CLLocationDistance {
+        let segment = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let coordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
+
+        let foot = segment.perpendicularFoot(from: coordinate, clampToEnds: true) ?? segment.first
         return foot.distance(from: coordinate)
     }
 
     /// Returns the minimum distance between the *Point* and the segment.
-    public func distanceFrom(point: Point) -> CLLocationDistance {
-        distanceFrom(coordinate: point.coordinate)
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    public func distanceFrom(point: Point, gridSize: Double? = nil) -> CLLocationDistance {
+        distanceFrom(coordinate: point.coordinate, gridSize: gridSize)
     }
 
 }
@@ -24,17 +29,21 @@ extension LineString {
 
     /// Returns the minimum distance between a *Point* and the receiver, being the distance
     /// from a line the minimum distance between the point and any segment of the line.
-    public func distanceFrom(point: Point) -> CLLocationDistance {
-        distanceFrom(coordinate: point.coordinate)
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    public func distanceFrom(point: Point, gridSize: Double? = nil) -> CLLocationDistance {
+        distanceFrom(coordinate: point.coordinate, gridSize: gridSize)
     }
 
     /// Returns the minimum distance between a coordinate and the receiver, being the distance
     /// from a line the minimum distance between the coordinate and any segment of the line.
-    public func distanceFrom(coordinate: Coordinate3D) -> CLLocationDistance {
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    public func distanceFrom(coordinate: Coordinate3D, gridSize: Double? = nil) -> CLLocationDistance {
+        let lineString = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let coordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
         var bestDistance: CLLocationDistance = .greatestFiniteMagnitude
 
-        for segment in lineSegments {
-            let distance = segment.distanceFrom(coordinate: coordinate)
+        for segment in lineString.lineSegments {
+            let distance = segment.distanceFrom(coordinate: coordinate, gridSize: nil)
 
             if distance < bestDistance {
                 bestDistance = distance

--- a/Sources/GISTools/Algorithms/PointsWithinPolygon.swift
+++ b/Sources/GISTools/Algorithms/PointsWithinPolygon.swift
@@ -13,7 +13,7 @@ extension PolygonGeometry {
         guard let gridSize else {
             return coordinates.filter { contains($0, ignoringBoundary: false, gridSize: nil) }
         }
-        let snappedSelf = (self as! GeoJson).snappedToGrid(tolerance: gridSize) as! PolygonGeometry
+        let snappedSelf = self.snappedToGrid(tolerance: gridSize)
         return coordinates.filter { snappedSelf.contains($0.snappedToGrid(tolerance: gridSize), ignoringBoundary: false, gridSize: nil) }
     }
 
@@ -23,7 +23,7 @@ extension PolygonGeometry {
         guard let gridSize else {
             return points.filter { contains($0.coordinate, ignoringBoundary: false, gridSize: nil) }
         }
-        let snappedSelf = (self as! GeoJson).snappedToGrid(tolerance: gridSize) as! PolygonGeometry
+        let snappedSelf = self.snappedToGrid(tolerance: gridSize)
         return points.filter { snappedSelf.contains($0.coordinate.snappedToGrid(tolerance: gridSize), ignoringBoundary: false, gridSize: nil) }
     }
 

--- a/Sources/GISTools/Algorithms/PointsWithinPolygon.swift
+++ b/Sources/GISTools/Algorithms/PointsWithinPolygon.swift
@@ -8,17 +8,23 @@ import Foundation
 extension PolygonGeometry {
 
     /// Finds coordinates that fall within the receiver.
-    public func coordinatesWithin(_ coordinates: [Coordinate3D]) -> [Coordinate3D] {
-        coordinates.filter({ (coordinate) -> Bool in
-            contains(coordinate, ignoringBoundary: false)
-        })
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
+    public func coordinatesWithin(_ coordinates: [Coordinate3D], gridSize: Double? = nil) -> [Coordinate3D] {
+        guard let gridSize else {
+            return coordinates.filter { contains($0, ignoringBoundary: false, gridSize: nil) }
+        }
+        let snappedSelf = (self as! GeoJson).snappedToGrid(tolerance: gridSize) as! PolygonGeometry
+        return coordinates.filter { snappedSelf.contains($0.snappedToGrid(tolerance: gridSize), ignoringBoundary: false, gridSize: nil) }
     }
 
     /// Finds *Point*s that fall within the receiver.
-    public func pointsWithin(_ points: [Point]) -> [Point] {
-        points.filter({ (point) -> Bool in
-            contains(point.coordinate, ignoringBoundary: false)
-        })
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
+    public func pointsWithin(_ points: [Point], gridSize: Double? = nil) -> [Point] {
+        guard let gridSize else {
+            return points.filter { contains($0.coordinate, ignoringBoundary: false, gridSize: nil) }
+        }
+        let snappedSelf = (self as! GeoJson).snappedToGrid(tolerance: gridSize) as! PolygonGeometry
+        return points.filter { snappedSelf.contains($0.coordinate.snappedToGrid(tolerance: gridSize), ignoringBoundary: false, gridSize: nil) }
     }
 
 }

--- a/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
+++ b/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
@@ -13,14 +13,17 @@ extension Polygon {
     /// Uses the polylabel algorithm with a priority-queue grid search.
     ///
     /// - Parameter precision: Precision in degrees (default 1.0).
+    /// - Parameter gridSize: An optional grid size for snapping inputs
     /// - Returns: The pole point, or `nil` if no outer ring exists.
-    public func poleOfInaccessibility(precision: Double = 1.0) -> Point? {
-        guard let outerRing else { return nil }
+    public func poleOfInaccessibility(precision: Double = 1.0, gridSize: Double? = nil) -> Point? {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) as! Polygon } ?? self
 
-        if crossesAntimeridian {
+        guard let outerRing = snappedSelf.outerRing else { return nil }
+
+        if snappedSelf.crossesAntimeridian {
             // Shift negative longitudes to [0, 360) so the polygon is
             // contiguous and the grid-search algorithm works correctly.
-            let normalizedRings = coordinates.map { ring in
+            let normalizedRings = snappedSelf.coordinates.map { ring in
                 ring.map { coord in
                     Coordinate3D(
                         latitude: coord.latitude,
@@ -28,7 +31,7 @@ extension Polygon {
                 }
             }
             let normalized = Polygon(unchecked: normalizedRings, calculateBoundingBox: false)
-            if let pole = normalized.poleOfInaccessibility(precision: precision) {
+            if let pole = normalized.poleOfInaccessibility(precision: precision, gridSize: nil) {
                 var result = pole
                 if result.coordinate.longitude > 180.0 {
                     result = Point(Coordinate3D(
@@ -67,13 +70,13 @@ extension Polygon {
         }
 
         var queue: [PQCell] = []
-        var bestCell = centroidCell()
+        var bestCell = snappedSelf.centroidCell()
 
         let bboxCell = PQCell(
             x: minX + width / 2,
             y: minY + height / 2,
             h: 0,
-            polygon: self)
+            polygon: snappedSelf)
         if bboxCell.d > bestCell.d {
             bestCell = bboxCell
         }
@@ -88,7 +91,7 @@ extension Polygon {
                     x: x + h,
                     y: y + h,
                     h: h,
-                    polygon: self)
+                    polygon: snappedSelf)
                 if cell.max > bestCell.d + precision {
                     insertSorted(&queue, cell)
                 }
@@ -111,10 +114,10 @@ extension Polygon {
             }
 
             h = cell.h / 2
-            let c1 = PQCell(x: cell.x - h, y: cell.y - h, h: h, polygon: self)
-            let c2 = PQCell(x: cell.x + h, y: cell.y - h, h: h, polygon: self)
-            let c3 = PQCell(x: cell.x - h, y: cell.y + h, h: h, polygon: self)
-            let c4 = PQCell(x: cell.x + h, y: cell.y + h, h: h, polygon: self)
+            let c1 = PQCell(x: cell.x - h, y: cell.y - h, h: h, polygon: snappedSelf)
+            let c2 = PQCell(x: cell.x + h, y: cell.y - h, h: h, polygon: snappedSelf)
+            let c3 = PQCell(x: cell.x - h, y: cell.y + h, h: h, polygon: snappedSelf)
+            let c4 = PQCell(x: cell.x + h, y: cell.y + h, h: h, polygon: snappedSelf)
 
             for c in [c1, c2, c3, c4] {
                 if c.d > bestCell.d {

--- a/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
+++ b/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
@@ -16,7 +16,7 @@ extension Polygon {
     /// - Parameter gridSize: An optional grid size for snapping inputs
     /// - Returns: The pole point, or `nil` if no outer ring exists.
     public func poleOfInaccessibility(precision: Double = 1.0, gridSize: Double? = nil) -> Point? {
-        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) as! Polygon } ?? self
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
 
         guard let outerRing = snappedSelf.outerRing else { return nil }
 

--- a/Sources/GISTools/Algorithms/Simplify.swift
+++ b/Sources/GISTools/Algorithms/Simplify.swift
@@ -15,13 +15,16 @@ extension GeoJson {
     /// - Parameters:
     /// - Parameter tolerance: Affects the amount of simplification (in meters)
     /// - Parameter highQuality: Excludes distance-based preprocessing step which leads to highest quality simplification but runs ~10-20 times slower
+    /// - Parameter gridSize: An optional grid size for snapping inputs
     ///
     /// - Returns: A new simplified GeoJson
     public func simplified(
         tolerance: CLLocationDistance = 1.0,
-        highQuality: Bool = false
+        highQuality: Bool = false,
+        gridSize: Double? = nil
     ) -> Self {
-        switch self {
+        let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        switch snappedSelf {
         case let lineString as LineString:
             var newLineString = LineString(Simplify.simplify(coordinates: lineString.coordinates, toleranceInMeters: tolerance, highQuality: highQuality)) ?? lineString
             newLineString.boundingBox = lineString.boundingBox
@@ -75,7 +78,7 @@ extension GeoJson {
             return newFeatureCollection as! Self
 
         default:
-            return self
+            return snappedSelf
         }
     }
 
@@ -86,13 +89,16 @@ extension GeoJson {
     /// - Parameters:
     /// - Parameter tolerance: Affects the amount of simplification (in meters)
     /// - Parameter highQuality: Excludes distance-based preprocessing step which leads to highest quality simplification but runs ~10-20 times slower
+    /// - Parameter gridSize: An optional grid size for snapping inputs
     public mutating func simplify(
         tolerance: CLLocationDistance = 1.0,
-        highQuality: Bool = false
+        highQuality: Bool = false,
+        gridSize: Double? = nil
     ) {
         self = simplified(
             tolerance: tolerance,
-            highQuality: highQuality)
+            highQuality: highQuality,
+            gridSize: gridSize)
     }
 
 }

--- a/Sources/GISTools/Algorithms/SnapToGrid.swift
+++ b/Sources/GISTools/Algorithms/SnapToGrid.swift
@@ -38,6 +38,99 @@ extension GeoJson {
 
 }
 
+// MARK: - Coordinate3D
+
+extension Coordinate3D {
+
+    /// Snaps the coordinate to the nearest grid point with the given spacing.
+    ///
+    /// - Parameter tolerance: Grid spacing in the CRS unit (must be > 0).
+    /// - Returns: A new coordinate snapped to the nearest grid point.
+    public func snappedToGrid(tolerance: Double) -> Coordinate3D {
+        var c = self
+        c.longitude = round(c.longitude / tolerance) * tolerance
+        c.latitude = round(c.latitude / tolerance) * tolerance
+        return c
+    }
+
+    /// Snaps the coordinate to the nearest grid point, mutating in place.
+    ///
+    /// - Parameter tolerance: Grid spacing in the CRS unit (must be > 0).
+    public mutating func snapToGrid(tolerance: Double) {
+        self = snappedToGrid(tolerance: tolerance)
+    }
+
+}
+
+// MARK: - Ring
+
+extension Ring {
+
+    /// Snaps each coordinate to the nearest grid point with the given spacing.
+    ///
+    /// - Parameter tolerance: Grid spacing in the CRS unit (must be > 0).
+    /// - Returns: A new ring with coordinates snapped to the nearest grid point.
+    public func snappedToGrid(tolerance: Double) -> Ring {
+        Ring(unchecked: coordinates.map({ $0.snappedToGrid(tolerance: tolerance) }))
+    }
+
+    /// Snaps each coordinate to the nearest grid point, mutating in place.
+    ///
+    /// - Parameter tolerance: Grid spacing in the CRS unit (must be > 0).
+    public mutating func snapToGrid(tolerance: Double) {
+        self = snappedToGrid(tolerance: tolerance)
+    }
+
+}
+
+// MARK: - LineSegment
+
+extension LineSegment {
+
+    /// Snaps each coordinate to the nearest grid point with the given spacing.
+    ///
+    /// - Parameter tolerance: Grid spacing in the CRS unit (must be > 0).
+    /// - Returns: A new segment with coordinates snapped to the nearest grid point.
+    public func snappedToGrid(tolerance: Double) -> LineSegment {
+        LineSegment(
+            first: first.snappedToGrid(tolerance: tolerance),
+            second: second.snappedToGrid(tolerance: tolerance),
+            index: index,
+            calculateBoundingBox: (boundingBox != nil))
+    }
+
+    /// Snaps each coordinate to the nearest grid point, mutating in place.
+    ///
+    /// - Parameter tolerance: Grid spacing in the CRS unit (must be > 0).
+    public mutating func snapToGrid(tolerance: Double) {
+        self = snappedToGrid(tolerance: tolerance)
+    }
+
+}
+
+// MARK: - BoundingBox
+
+extension BoundingBox {
+
+    /// Snaps each coordinate to the nearest grid point with the given spacing.
+    ///
+    /// - Parameter tolerance: Grid spacing in the CRS unit (must be > 0).
+    /// - Returns: A new bounding box with coordinates snapped to the nearest grid point.
+    public func snappedToGrid(tolerance: Double) -> BoundingBox {
+        BoundingBox(
+            southWest: southWest.snappedToGrid(tolerance: tolerance),
+            northEast: northEast.snappedToGrid(tolerance: tolerance))
+    }
+
+    /// Snaps each coordinate to the nearest grid point, mutating in place.
+    ///
+    /// - Parameter tolerance: Grid spacing in the CRS unit (must be > 0).
+    public mutating func snapToGrid(tolerance: Double) {
+        self = snappedToGrid(tolerance: tolerance)
+    }
+
+}
+
 // MARK: - SnapToGrid namespace
 
 private enum SnapToGrid {
@@ -111,16 +204,16 @@ extension SnapToGrid {
 
     private static func snap(point: Point, tolerance: Double) -> Point {
         let snapped = snapCoordinate(point.coordinate, tolerance: tolerance)
-        var result = Point(snapped)
-        result.boundingBox = point.boundingBox
+        var result = Point(snapped, calculateBoundingBox: (point.boundingBox != nil))
         result.foreignMembers = point.foreignMembers
         return result
     }
 
     private static func snap(multiPoint: MultiPoint, tolerance: Double) -> MultiPoint {
-        guard var result = MultiPoint(multiPoint.coordinates.map({ snapCoordinate($0, tolerance: tolerance) }))
+        guard var result = MultiPoint(
+            multiPoint.coordinates.map({ snapCoordinate($0, tolerance: tolerance) }),
+            calculateBoundingBox: (multiPoint.boundingBox != nil))
         else { return multiPoint }
-        result.boundingBox = multiPoint.boundingBox
         result.foreignMembers = multiPoint.foreignMembers
         return result
     }
@@ -128,8 +221,8 @@ extension SnapToGrid {
     private static func snap(lineString: LineString, tolerance: Double) -> LineString {
         let snapped = lineString.coordinates.map({ snapCoordinate($0, tolerance: tolerance) })
         let cleaned = dedup(snapped)
-        guard var result = LineString(cleaned) else { return lineString }
-        result.boundingBox = lineString.boundingBox
+        guard var result = LineString(cleaned, calculateBoundingBox: (lineString.boundingBox != nil))
+        else { return lineString }
         result.foreignMembers = lineString.foreignMembers
         return result
     }
@@ -138,8 +231,8 @@ extension SnapToGrid {
         let snapped = multiLineString.coordinates.map({ line in
             dedup(line.map({ snapCoordinate($0, tolerance: tolerance) }))
         })
-        guard var result = MultiLineString(snapped) else { return multiLineString }
-        result.boundingBox = multiLineString.boundingBox
+        guard var result = MultiLineString(snapped, calculateBoundingBox: (multiLineString.boundingBox != nil))
+        else { return multiLineString }
         result.foreignMembers = multiLineString.foreignMembers
         return result
     }
@@ -148,8 +241,8 @@ extension SnapToGrid {
         let snapped = polygon.coordinates.map({ ring in
             dedup(ring.map({ snapCoordinate($0, tolerance: tolerance) }))
         })
-        guard var result = Polygon(snapped) else { return polygon }
-        result.boundingBox = polygon.boundingBox
+        guard var result = Polygon(snapped, calculateBoundingBox: (polygon.boundingBox != nil))
+        else { return polygon }
         result.foreignMembers = polygon.foreignMembers
         return result
     }
@@ -160,17 +253,16 @@ extension SnapToGrid {
                 dedup(ring.map({ snapCoordinate($0, tolerance: tolerance) }))
             })
         })
-        guard var result = MultiPolygon(snapped) else { return multiPolygon }
-        result.boundingBox = multiPolygon.boundingBox
+        guard var result = MultiPolygon(snapped, calculateBoundingBox: (multiPolygon.boundingBox != nil))
+        else { return multiPolygon }
         result.foreignMembers = multiPolygon.foreignMembers
         return result
     }
 
     private static func snap(geometryCollection: GeometryCollection, tolerance: Double) -> GeometryCollection {
-        var result = GeometryCollection(geometryCollection.geometries.map({
-            snap($0, tolerance: tolerance) as! GeoJsonGeometry
-        }))
-        result.boundingBox = geometryCollection.boundingBox
+        var result = GeometryCollection(
+            geometryCollection.geometries.map({ snap($0, tolerance: tolerance) as! GeoJsonGeometry }),
+            calculateBoundingBox: (geometryCollection.boundingBox != nil))
         result.foreignMembers = geometryCollection.foreignMembers
         return result
     }
@@ -179,15 +271,16 @@ extension SnapToGrid {
         var result = Feature(
             snap(feature.geometry, tolerance: tolerance) as! GeoJsonGeometry,
             id: feature.id,
-            properties: feature.properties)
-        result.boundingBox = feature.boundingBox
+            properties: feature.properties,
+            calculateBoundingBox: (feature.boundingBox != nil))
         result.foreignMembers = feature.foreignMembers
         return result
     }
 
     private static func snap(featureCollection: FeatureCollection, tolerance: Double) -> FeatureCollection {
-        var result = FeatureCollection(featureCollection.features.map({ snap(feature: $0, tolerance: tolerance) }))
-        result.boundingBox = featureCollection.boundingBox
+        var result = FeatureCollection(
+            featureCollection.features.map({ snap(feature: $0, tolerance: tolerance) }),
+            calculateBoundingBox: (featureCollection.boundingBox != nil))
         result.foreignMembers = featureCollection.foreignMembers
         return result
     }

--- a/Sources/GISTools/Algorithms/Union.swift
+++ b/Sources/GISTools/Algorithms/Union.swift
@@ -8,10 +8,16 @@ extension Polygon {
     /// Returns the union of the receiver with another polygon geometry.
     ///
     /// - Parameter other: The other polygon geometry
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     /// - Returns: A `MultiPolygon` representing the union, or `nil` if the union is empty.
-    public func union(with other: PolygonGeometry) -> MultiPolygon? {
-        var all = self.polygons
-        all.append(contentsOf: other.polygons)
+    public func union(with other: PolygonGeometry, gridSize: Double? = nil) -> MultiPolygon? {
+        let all: [Polygon]
+        if let gridSize {
+            all = [self.snappedToGrid(tolerance: gridSize)]
+                + other.polygons.map { $0.snappedToGrid(tolerance: gridSize) }
+        } else {
+            all = self.polygons + other.polygons
+        }
         return Union.unionPolygons(all)
     }
 
@@ -22,15 +28,23 @@ extension MultiPolygon {
     /// Returns the union of the receiver with another polygon geometry.
     ///
     /// - Parameter other: The other polygon geometry
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     /// - Returns: A `MultiPolygon` representing the union, or `nil` if the union is empty.
-    public func union(with other: PolygonGeometry) -> MultiPolygon? {
-        var all = self.polygons
-        all.append(contentsOf: other.polygons)
+    public func union(with other: PolygonGeometry, gridSize: Double? = nil) -> MultiPolygon? {
+        let all: [Polygon]
+        if let gridSize {
+            all = self.polygons.map { $0.snappedToGrid(tolerance: gridSize) }
+                + other.polygons.map { $0.snappedToGrid(tolerance: gridSize) }
+        } else {
+            all = self.polygons + other.polygons
+        }
         return Union.unionPolygons(all)
     }
 
-    public mutating func formUnion(with other: PolygonGeometry) {
-        guard let merged = union(with: other) else { return }
+    /// Forms the union of the receiver with another polygon geometry in place.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    public mutating func formUnion(with other: PolygonGeometry, gridSize: Double? = nil) {
+        guard let merged = union(with: other, gridSize: gridSize) else { return }
         self = merged
     }
 
@@ -40,9 +54,11 @@ extension FeatureCollection {
 
     /// Returns the union of all polygon features in the collection.
     ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     /// - Returns: A `FeatureCollection` containing the unioned polygon, or `nil` if no polygons exist.
-    public func union() -> FeatureCollection? {
-        let geometries = features
+    public func union(gridSize: Double? = nil) -> FeatureCollection? {
+        let snappedFC = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let geometries = snappedFC.features
             .compactMap { ($0.geometry as? PolygonGeometry)?.polygons }
             .flatMap { $0 }
         guard let result = Union.unionPolygons(geometries) else { return nil }

--- a/Sources/GISTools/GeoJson/GeoJson.swift
+++ b/Sources/GISTools/GeoJson/GeoJson.swift
@@ -181,10 +181,12 @@ public protocol PolygonGeometry: GeoJsonGeometry {
     /// - Parameters:
     ///    - coordinate: The coordinate to test
     ///    - ignoringBoundary: If `true`, points on the boundary are not considered inside
+    ///    - gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     /// - Returns: `true` if the coordinate lies within the polygon
     func contains(
         _ coordinate: Coordinate3D,
-        ignoringBoundary: Bool
+        ignoringBoundary: Bool,
+        gridSize: Double?
     ) -> Bool
 
     /// Check if this `(Multi)Polygon` contains *Point*.
@@ -192,10 +194,12 @@ public protocol PolygonGeometry: GeoJsonGeometry {
     /// - Parameters:
     ///    - point: The point to test
     ///    - ignoringBoundary: If `true`, points on the boundary are not considered inside
+    ///    - gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
     /// - Returns: `true` if the point lies within the polygon
     func contains(
         _ point: Point,
-        ignoringBoundary: Bool
+        ignoringBoundary: Bool,
+        gridSize: Double?
     ) -> Bool
 
 }

--- a/Tests/GISToolsTests/Algorithms/BooleanConcaveTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanConcaveTests.swift
@@ -158,6 +158,27 @@ struct BooleanConcaveTests {
         #expect(!fc.isConcave())
     }
 
+    // MARK: - gridSize
+
+    // Validates that `isConcave(gridSize:)` matches manual pre-snapping.
+    @Test
+    func concaveWithGridSize() async throws {
+        let lShape = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 2.0001),
+            Coordinate3D(latitude: 1.0001, longitude: 2.0001),
+            Coordinate3D(latitude: 1.0001, longitude: 1.0001),
+            Coordinate3D(latitude: 2.0001, longitude: 1.0001),
+            Coordinate3D(latitude: 2.0001, longitude: 0.0001),
+        ]]))
+        let gridSize = 0.001
+
+        let withParam = lShape.isConcave(gridSize: gridSize)
+        let snapped = lShape.snappedToGrid(tolerance: gridSize)
+        let manual = snapped.isConcave()
+        #expect(withParam == manual)
+    }
+
     // MARK: - Antimeridian crossing
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/BooleanCrossesTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanCrossesTests.swift
@@ -313,6 +313,28 @@ struct BooleanCrossesTests {
         #expect(line1.crosses(line2) == line2.crosses(line1))
     }
 
+    // MARK: - gridSize
+
+    // Validates that `crosses(_:gridSize:)` matches manual pre-snapping.
+    @Test
+    func crossesWithGridSize() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 1.0001, longitude: 2.0001),
+            Coordinate3D(latitude: 4.0001, longitude: 2.0001),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 2.0001, longitude: 1.0001),
+            Coordinate3D(latitude: 2.0001, longitude: 4.0001),
+        ]))
+        let gridSize = 0.001
+
+        let withParam = line1.crosses(line2, gridSize: gridSize)
+        let snapped1 = line1.snappedToGrid(tolerance: gridSize)
+        let snapped2 = line2.snappedToGrid(tolerance: gridSize)
+        let manual = snapped1.crosses(snapped2)
+        #expect(withParam == manual)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/BooleanDisjointTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanDisjointTests.swift
@@ -84,6 +84,34 @@ struct BooleanDisjointTests {
         #expect(multiPolygon1.isDisjoint(with: polygon3) == false)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `isDisjoint(with:gridSize:)` matches manual pre-snapping.
+    @Test
+    func disjointWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let point = Point(Coordinate3D(latitude: 5.00005, longitude: 5.00005))
+        let outside = Point(Coordinate3D(latitude: 20.00005, longitude: 20.00005))
+        let gridSize = 0.001
+
+        let withParam = polygon.isDisjoint(with: point, gridSize: gridSize)
+        let snappedPolygon = polygon.snappedToGrid(tolerance: gridSize)
+        let snappedPoint = point.snappedToGrid(tolerance: gridSize)
+        let manual = snappedPolygon.isDisjoint(with: snappedPoint)
+        #expect(withParam == manual)
+
+        let withParamOutside = polygon.isDisjoint(with: outside, gridSize: gridSize)
+        let snappedOutside = outside.snappedToGrid(tolerance: gridSize)
+        let manualOutside = snappedPolygon.isDisjoint(with: snappedOutside)
+        #expect(withParamOutside == manualOutside)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/BooleanIntersectsTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanIntersectsTests.swift
@@ -40,6 +40,48 @@ struct BooleanIntersectsTests {
         #expect(!outsidePoint.intersects(polygon))
     }
 
+    // MARK: - gridSize
+
+    // Validates that `intersects(_:gridSize:)` matches manual pre-snapping.
+    @Test
+    func intersectingGeometriesWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let point = Point(Coordinate3D(latitude: 5.00005, longitude: 5.00005))
+        let gridSize = 0.001
+
+        let withParam = polygon.intersects(point, gridSize: gridSize)
+        let snappedPolygon = polygon.snappedToGrid(tolerance: gridSize)
+        let snappedPoint = point.snappedToGrid(tolerance: gridSize)
+        let manual = snappedPolygon.intersects(snappedPoint)
+        #expect(withParam == manual)
+    }
+
+    // Validates that `intersects(_:gridSize:)` returns correct result when geometries do not intersect.
+    @Test
+    func nonIntersectingGeometriesWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let outsidePoint = Point(Coordinate3D(latitude: 20.00005, longitude: 20.00005))
+        let gridSize = 0.001
+
+        let withParam = polygon.intersects(outsidePoint, gridSize: gridSize)
+        let snappedPolygon = polygon.snappedToGrid(tolerance: gridSize)
+        let snappedOther = outsidePoint.snappedToGrid(tolerance: gridSize)
+        let manual = snappedPolygon.intersects(snappedOther)
+        #expect(withParam == manual)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/BooleanOverlapTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanOverlapTests.swift
@@ -64,6 +64,28 @@ struct BooleanOverlapTests {
         #expect(polygon1.isOverlapping(with: polygon2))
     }
 
+    // MARK: - gridSize
+
+    // Validates that `isOverlapping(with:gridSize:)` matches manual pre-snapping.
+    @Test
+    func overlapWithGridSize() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 2.0001, longitude: 2.0001),
+            Coordinate3D(latitude: 4.0001, longitude: 4.0001),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 6.0001, longitude: 6.0001),
+        ]))
+        let gridSize = 0.001
+
+        let withParam = line1.isOverlapping(with: line2, gridSize: gridSize)
+        let snapped1 = line1.snappedToGrid(tolerance: gridSize)
+        let snapped2 = line2.snappedToGrid(tolerance: gridSize)
+        let manual = snapped1.isOverlapping(with: snapped2)
+        #expect(withParam == manual)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/BooleanParallelTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanParallelTests.swift
@@ -121,6 +121,26 @@ struct BooleanParallelTests {
         #expect(s1.isParallel(to: s2, undirectedEdge: true))
     }
 
+    // MARK: - gridSize
+
+    // Validates that `isParallel(to:tolerance:undirectedEdge:gridSize:)` matches manual pre-snapping.
+    @Test
+    func segmentParallelWithGridSize() async throws {
+        let s1 = LineSegment(
+            first: Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            second: Coordinate3D(latitude: 10.0001, longitude: 0.0001))
+        let s2 = LineSegment(
+            first: Coordinate3D(latitude: 5.0001, longitude: 0.0001),
+            second: Coordinate3D(latitude: 15.0001, longitude: 0.0001))
+        let gridSize = 0.001
+
+        let withParam = s1.isParallel(to: s2, tolerance: 0.1, gridSize: gridSize)
+        let snapped1 = s1.snappedToGrid(tolerance: gridSize)
+        let snapped2 = s2.snappedToGrid(tolerance: gridSize)
+        let manual = snapped1.isParallel(to: snapped2, tolerance: 0.1)
+        #expect(withParam == manual)
+    }
+
     // MARK: - Anti-meridian tests
 
     @Test func segment_antiMeridian_parallel() {

--- a/Tests/GISToolsTests/Algorithms/BooleanPointInPolygonTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanPointInPolygonTests.swift
@@ -219,6 +219,70 @@ struct BooleanPointInPolygonTests {
         #expect(fc.contains(Coordinate3D(latitude: 20.0, longitude: 5.0)) == false)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `contains(gridSize:)` on Polygon matches manual pre-snapping.
+    @Test
+    func polygonContainsWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let coord = Coordinate3D(latitude: 5.00005, longitude: 5.00005)
+        let gridSize = 0.001
+
+        let withParam = polygon.contains(coord, gridSize: gridSize)
+        let snappedPolygon = polygon.snappedToGrid(tolerance: gridSize)
+        let snappedCoord = Point(coord).snappedToGrid(tolerance: gridSize).coordinate
+        let manual = snappedPolygon.contains(snappedCoord)
+        #expect(withParam == manual)
+    }
+
+    // Validates that `contains(gridSize:)` on Feature matches manual pre-snapping.
+    @Test
+    func featureContainsWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let feature = Feature(polygon)
+        let coord = Coordinate3D(latitude: 5.00005, longitude: 5.00005)
+        let gridSize = 0.001
+
+        let withParam = feature.contains(coord, gridSize: gridSize)
+        let snappedFeature = feature.snappedToGrid(tolerance: gridSize)
+        let snappedCoord = Point(coord).snappedToGrid(tolerance: gridSize).coordinate
+        let manual = snappedFeature.contains(snappedCoord)
+        #expect(withParam == manual)
+    }
+
+    // Validates that `contains(gridSize:)` on FeatureCollection matches manual pre-snapping.
+    @Test
+    func featureCollectionContainsWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let fc = FeatureCollection([Feature(polygon)])
+        let coord = Coordinate3D(latitude: 5.00005, longitude: 5.00005)
+        let gridSize = 0.001
+
+        let withParam = fc.contains(coord, gridSize: gridSize)
+        let snappedFc = fc.snappedToGrid(tolerance: gridSize)
+        let snappedCoord = Point(coord).snappedToGrid(tolerance: gridSize).coordinate
+        let manual = snappedFc.contains(snappedCoord)
+        #expect(withParam == manual)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/BooleanPointOnLineTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanPointOnLineTests.swift
@@ -116,6 +116,32 @@ struct BooleanPointOnLineTests {
         #expect(mls.checkIsOnLine(Coordinate3D(latitude: 2.0, longitude: 2.0)) == false)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `checkIsOnLine(_:gridSize:)` and `checkIsOnSegment(_:gridSize:)` match manual pre-snapping.
+    @Test
+    func pointOnLineWithGridSize() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+        ]))
+        let onPoint = Coordinate3D(latitude: 0.0001, longitude: 5.0001)
+        let offPoint = Coordinate3D(latitude: 5.00005, longitude: 5.00005)
+        let gridSize = 0.001
+
+        let withParamOn = ls.checkIsOnLine(onPoint, gridSize: gridSize)
+        let snappedLine = ls.snappedToGrid(tolerance: gridSize)
+        let snappedOn = Point(onPoint).snappedToGrid(tolerance: gridSize).coordinate
+        let manualOn = snappedLine.checkIsOnLine(snappedOn)
+        #expect(withParamOn == manualOn)
+
+        let withParamOff = ls.checkIsOnLine(offPoint, gridSize: gridSize)
+        let snappedOff = Point(offPoint).snappedToGrid(tolerance: gridSize).coordinate
+        let manualOff = snappedLine.checkIsOnLine(snappedOff)
+        #expect(withParamOff == manualOff)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/BooleanTouchesTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanTouchesTests.swift
@@ -480,6 +480,25 @@ struct BooleanTouchesTests {
         #expect(line1.touches(line2) == line2.touches(line1))
     }
 
+    // MARK: - gridSize
+
+    // Validates that `touches(_:gridSize:)` matches manual pre-snapping.
+    @Test
+    func touchesWithGridSize() async throws {
+        let point = Point(Coordinate3D(latitude: 0.0001, longitude: 0.0001))
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+        ]))
+        let gridSize = 0.001
+
+        let withParam = point.touches(line, gridSize: gridSize)
+        let snappedPoint = point.snappedToGrid(tolerance: gridSize)
+        let snappedLine = line.snappedToGrid(tolerance: gridSize)
+        let manual = snappedPoint.touches(snappedLine)
+        #expect(withParam == manual)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/BufferTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BufferTests.swift
@@ -338,6 +338,26 @@ struct BufferTests {
                     steps: params.steps)))
     }
 
+    // MARK: - gridSize
+
+    // Validates that `buffered(gridSize:)` matches manual pre-snapping.
+    @Test
+    func bufferWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let gridSize = 0.001
+
+        let withParam = try #require(polygon.buffered(by: 100_000.0, gridSize: gridSize))
+        let snapped = polygon.snappedToGrid(tolerance: gridSize)
+        let manual = try #require(snapped.buffered(by: 100_000.0))
+        #expect(abs(withParam.area - manual.area) < 1.0)
+    }
+
     // MARK: - Antimeridian tests
 
     // Validates buffer around a point near the antimeridian stays within valid coordinate bounds.

--- a/Tests/GISToolsTests/Algorithms/ConcaveHullTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ConcaveHullTests.swift
@@ -136,4 +136,26 @@ struct ConcaveHullTests {
         }
     }
 
+    // MARK: - gridSize
+
+    // Validates that `concaveHull(maxEdgeLength:gridSize:)` matches manual pre-snapping.
+    @Test
+    func concaveHullWithGridSize() async throws {
+        let maxEdge200km = GISTool.convertToMeters(200, .kilometers)
+        let mp = try #require(MultiPoint([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 1.0001),
+            Coordinate3D(latitude: 1.0001, longitude: 1.0001),
+            Coordinate3D(latitude: 1.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.5001, longitude: 0.5001),
+        ]))
+        let gridSize = 0.001
+
+        let withParam = try #require(mp.concaveHull(maxEdgeLength: maxEdge200km, gridSize: gridSize))
+        let snapped = mp.snappedToGrid(tolerance: gridSize)
+        let manual = try #require(snapped.concaveHull(maxEdgeLength: maxEdge200km))
+        #expect(withParam.polygons.count == manual.polygons.count)
+        #expect(abs(withParam.area - manual.area) < 1.0)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/KinksTests.swift
+++ b/Tests/GISToolsTests/Algorithms/KinksTests.swift
@@ -99,6 +99,26 @@ struct KinksTests {
         #expect(result.points.isEmpty)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `kinks(gridSize:)` matches manual pre-snapping.
+    @Test
+    func kinksWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let gridSize = 0.001
+
+        let withParam = polygon.kinks(gridSize: gridSize)
+        let snapped = polygon.snappedToGrid(tolerance: gridSize)
+        let manual = snapped.kinks()
+        #expect(withParam.points.count == manual.points.count)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/LineIntersectionTests.swift
+++ b/Tests/GISToolsTests/Algorithms/LineIntersectionTests.swift
@@ -336,6 +336,26 @@ struct LineIntersectionTests {
         #expect(!intersections.isEmpty)
     }
 
+    // Validates that `intersection(_:gridSize:)` on LineSegment matches manual pre-snapping.
+    @Test
+    func intersectionWithGridSize() async throws {
+        let s1 = LineSegment(first: Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+                              second: Coordinate3D(latitude: 10.0001, longitude: 10.0001))
+        let s2 = LineSegment(first: Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+                              second: Coordinate3D(latitude: 10.0001, longitude: 0.0001))
+        let gridSize = 0.001
+
+        let withParam = try #require(s1.intersection(s2, gridSize: gridSize))
+        let snap: (Coordinate3D) -> Coordinate3D = {
+            Point($0).snappedToGrid(tolerance: gridSize).coordinate
+        }
+        let snapped1 = LineSegment(first: snap(s1.first), second: snap(s1.second))
+        let snapped2 = LineSegment(first: snap(s2.first), second: snap(s2.second))
+        let manual = try #require(snapped1.intersection(snapped2))
+        #expect(abs(withParam.latitude - manual.latitude) < 1e-10)
+        #expect(abs(withParam.longitude - manual.longitude) < 1e-10)
+    }
+
     // Tests that the boolean intersects method returns true for overlapping collinear segments.
     @Test
     func intersectsCollinearOverlap() async throws {

--- a/Tests/GISToolsTests/Algorithms/LineOverlapTests.swift
+++ b/Tests/GISToolsTests/Algorithms/LineOverlapTests.swift
@@ -122,6 +122,28 @@ struct LineOverlapTests {
         #expect(overlappingSegments2 == result.lineSegments)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `overlappingSegments(with:tolerance:gridSize:)` matches manual pre-snapping.
+    @Test
+    func overlappingSegmentsWithGridSize() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 2.0001, longitude: 2.0001),
+            Coordinate3D(latitude: 4.0001, longitude: 4.0001),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 6.0001, longitude: 6.0001),
+        ]))
+        let gridSize = 0.001
+
+        let withParam = line1.overlappingSegments(with: line2, gridSize: gridSize)
+        let snapped1 = line1.snappedToGrid(tolerance: gridSize)
+        let snapped2 = line2.snappedToGrid(tolerance: gridSize)
+        let manual = snapped1.overlappingSegments(with: snapped2)
+        #expect(withParam == manual)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/LineSliceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/LineSliceTests.swift
@@ -26,6 +26,27 @@ struct LineSliceTests {
         #expect(slice == result)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `slice(start:end:gridSize:)` matches manual pre-snapping.
+    @Test
+    func sliceWithGridSize() async throws {
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+        ]))
+        let start = Coordinate3D(latitude: 2.0001, longitude: 2.0001)
+        let end = Coordinate3D(latitude: 8.0001, longitude: 8.0001)
+        let gridSize = 0.001
+
+        let withParam = lineString.slice(start: start, end: end, gridSize: gridSize)
+        let snappedLine = lineString.snappedToGrid(tolerance: gridSize)
+        let snappedStart = Point(start).snappedToGrid(tolerance: gridSize).coordinate
+        let snappedEnd = Point(end).snappedToGrid(tolerance: gridSize).coordinate
+        let manual = snappedLine.slice(start: snappedStart, end: snappedEnd)
+        #expect(withParam == manual)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/NearestCoordinateOnLineTests.swift
+++ b/Tests/GISToolsTests/Algorithms/NearestCoordinateOnLineTests.swift
@@ -150,6 +150,26 @@ struct NearestCoordinateOnLineTests {
         #expect(nearestCoordinate == result)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `nearestCoordinateOnLine(from:gridSize:)` matches manual pre-snapping.
+    @Test
+    func nearestCoordinateOnLineWithGridSize() async throws {
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+        ]))
+        let point = Coordinate3D(latitude: 0.0001, longitude: 10.0001)
+        let gridSize = 0.001
+
+        let withParam = try #require(lineString.nearestCoordinateOnLine(from: point, gridSize: gridSize))
+        let snappedLine = lineString.snappedToGrid(tolerance: gridSize)
+        let snappedPoint = Point(point).snappedToGrid(tolerance: gridSize).coordinate
+        let manual = try #require(snappedLine.nearestCoordinateOnLine(from: snappedPoint))
+        #expect(withParam.coordinate == manual.coordinate)
+        #expect(withParam.index == manual.index)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/NearestPointOnFeatureTests.swift
+++ b/Tests/GISToolsTests/Algorithms/NearestPointOnFeatureTests.swift
@@ -81,6 +81,29 @@ struct NearestPointOnFeatureTests {
         #expect(result.coordinate == Coordinate3D(latitude: 10.0, longitude: 0.0))
     }
 
+    // MARK: - gridSize
+
+    // Validates that `nearestCoordinateOnFeature(from:gridSize:)` matches manual pre-snapping.
+    @Test
+    func nearestOnFeatureWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let ref = Coordinate3D(latitude: 5.00005, longitude: 5.00005)
+        let gridSize = 0.001
+
+        let withParam = try #require(polygon.nearestCoordinateOnFeature(from: ref, gridSize: gridSize))
+        let snappedPolygon = polygon.snappedToGrid(tolerance: gridSize)
+        let snappedRef = Point(ref).snappedToGrid(tolerance: gridSize).coordinate
+        let manual = try #require(snappedPolygon.nearestCoordinateOnFeature(from: snappedRef))
+        #expect(withParam.coordinate == manual.coordinate)
+        #expect(abs(withParam.distance - manual.distance) < 1e-10)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/NearestPointTests.swift
+++ b/Tests/GISToolsTests/Algorithms/NearestPointTests.swift
@@ -53,6 +53,44 @@ struct NearestPointTests {
         #expect(ls.nearestCoordinate(from: Coordinate3D(latitude: 0.0, longitude: 0.0)) == nil)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `nearestCoordinate(from:gridSize:)` matches manual pre-snapping.
+    @Test
+    func nearestPointWithGridSize() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+        ]))
+        let ref = Coordinate3D(latitude: 0.0001, longitude: 10.0001)
+        let gridSize = 0.001
+
+        let withParam = try #require(ls.nearestCoordinate(from: ref, gridSize: gridSize))
+        let snappedLine = ls.snappedToGrid(tolerance: gridSize)
+        let snappedRef = Point(ref).snappedToGrid(tolerance: gridSize).coordinate
+        let manual = try #require(snappedLine.nearestCoordinate(from: snappedRef))
+        #expect(withParam.coordinate == manual.coordinate)
+        #expect(withParam.distance == manual.distance)
+    }
+
+    // Validates that `nearestPoint(from:gridSize:)` on Feature matches manual pre-snapping.
+    @Test
+    func nearestPointFeatureWithGridSize() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+        ]))
+        let feature = Feature(ls)
+        let ref = Point(Coordinate3D(latitude: 0.0001, longitude: 10.0001))
+        let gridSize = 0.001
+
+        let withParam = try #require(feature.nearestPoint(from: ref, gridSize: gridSize))
+        let snappedFeature = feature.snappedToGrid(tolerance: gridSize)
+        let snappedRef = ref.snappedToGrid(tolerance: gridSize)
+        let manual = try #require(snappedFeature.nearestPoint(from: snappedRef))
+        #expect(withParam.point.coordinate == manual.point.coordinate)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/PointOnFeatureTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PointOnFeatureTests.swift
@@ -90,8 +90,7 @@ struct PointOnFeatureTests {
         let withParam = try #require(polygon.coordinateOnFeature(gridSize: gridSize))
         let snapped = polygon.snappedToGrid(tolerance: gridSize)
         let manual = try #require(snapped.coordinateOnFeature)
-        #expect(withParam.latitude.isFinite)
-        #expect(withParam.longitude.isFinite)
+        #expect(withParam == manual)
     }
 
     // MARK: - Antimeridian

--- a/Tests/GISToolsTests/Algorithms/PointOnFeatureTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PointOnFeatureTests.swift
@@ -73,6 +73,27 @@ struct PointOnFeatureTests {
         #expect(result.coordinate == Coordinate3D(latitude: 5.0, longitude: 5.0))
     }
 
+    // MARK: - gridSize
+
+    // Validates that `coordinateOnFeature(gridSize:)` matches manual pre-snapping.
+    @Test
+    func pointOnFeatureWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let gridSize = 0.001
+
+        let withParam = try #require(polygon.coordinateOnFeature(gridSize: gridSize))
+        let snapped = polygon.snappedToGrid(tolerance: gridSize)
+        let manual = try #require(snapped.coordinateOnFeature)
+        #expect(withParam.latitude.isFinite)
+        #expect(withParam.longitude.isFinite)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/PointToLineDistanceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PointToLineDistanceTests.swift
@@ -12,6 +12,25 @@ struct PointToLineDistanceTests {
         #expect(lineString.distanceFrom(coordinate: coordinate) == 111_195.0802335329)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `distanceFrom(coordinate:gridSize:)` matches manual pre-snapping.
+    @Test
+    func pointToLineDistanceWithGridSize() async throws {
+        let coordinate = Coordinate3D(latitude: 0.0001, longitude: 0.0001)
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 1.0001, longitude: 1.0001),
+            Coordinate3D(latitude: 1.0001, longitude: -1.0001),
+        ]))
+        let gridSize = 0.001
+
+        let withParam = lineString.distanceFrom(coordinate: coordinate, gridSize: gridSize)
+        let snappedLine = lineString.snappedToGrid(tolerance: gridSize)
+        let snappedCoord = Point(coordinate).snappedToGrid(tolerance: gridSize).coordinate
+        let manual = snappedLine.distanceFrom(coordinate: snappedCoord)
+        #expect(withParam == manual)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/PointsWithinPolygonTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PointsWithinPolygonTests.swift
@@ -86,6 +86,32 @@ struct PointsWithinPolygonTests {
         #expect(result.isEmpty)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `coordinatesWithin(_:gridSize:)` matches manual pre-snapping.
+    @Test
+    func coordinatesWithinWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let candidates = [
+            Coordinate3D(latitude: 5.00005, longitude: 5.00005),
+            Coordinate3D(latitude: 15.00005, longitude: 5.00005),
+        ]
+        let gridSize = 0.001
+
+        let withParam = polygon.coordinatesWithin(candidates, gridSize: gridSize)
+        let snappedPolygon = polygon.snappedToGrid(tolerance: gridSize)
+        let manual = snappedPolygon.coordinatesWithin(candidates)
+        // Compare counts only — coordinatesWithin returns original (unsnapped) coordinates
+        #expect(withParam.count == manual.count)
+        #expect(withParam.count == 1)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/PoleOfInaccessibilityTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PoleOfInaccessibilityTests.swift
@@ -77,6 +77,27 @@ struct PoleOfInaccessibilityTests {
         #expect(polygon.poleOfInaccessibility() == nil)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `poleOfInaccessibility(gridSize:)` matches manual pre-snapping.
+    @Test
+    func poleWithGridSize() async throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let gridSize = 0.001
+
+        let withParam = try #require(polygon.poleOfInaccessibility(gridSize: gridSize))
+        let snappedPolygon = polygon.snappedToGrid(tolerance: gridSize)
+        let manual = try #require(snappedPolygon.poleOfInaccessibility())
+        #expect(abs(withParam.coordinate.latitude - manual.coordinate.latitude) < 1e-10)
+        #expect(abs(withParam.coordinate.longitude - manual.coordinate.longitude) < 1e-10)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/SimplifyTests.swift
+++ b/Tests/GISToolsTests/Algorithms/SimplifyTests.swift
@@ -36,6 +36,24 @@ struct SimplifyTests {
         #expect(abs(startDate.timeIntervalSinceNow) < 0.5)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `simplified(tolerance:highQuality:gridSize:)` matches manual pre-snapping.
+    @Test
+    func simplifyWithGridSize() async throws {
+        let lineString = try #require(LineString([
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 5.0001, longitude: 5.0001),
+            Coordinate3D(latitude: 10.0001, longitude: 10.0001),
+        ]))
+        let gridSize = 0.001
+
+        let withParam = lineString.simplified(tolerance: 1.0, gridSize: gridSize)
+        let snapped = lineString.snappedToGrid(tolerance: gridSize)
+        let manual = snapped.simplified(tolerance: 1.0)
+        #expect(withParam.coordinates == manual.coordinates)
+    }
+
     // MARK: - Antimeridian
 
     @Test

--- a/Tests/GISToolsTests/Algorithms/SnapToGridTests.swift
+++ b/Tests/GISToolsTests/Algorithms/SnapToGridTests.swift
@@ -220,4 +220,144 @@ struct SnapToGridTests {
         #expect(snapped.coordinates[1].longitude == -174.0)
     }
 
+    // MARK: - Coordinate3D
+
+    @Test
+    func coordinate3DSnappedToGrid() async throws {
+        let coord = Coordinate3D(latitude: 1.3, longitude: 2.7)
+        let snapped = coord.snappedToGrid(tolerance: 1.0)
+
+        #expect(snapped.latitude == 1.0)
+        #expect(snapped.longitude == 3.0)
+    }
+
+    @Test
+    func coordinate3DSnapToGridMutating() async throws {
+        var coord = Coordinate3D(latitude: 1.3, longitude: 2.7)
+        coord.snapToGrid(tolerance: 1.0)
+
+        #expect(coord.latitude == 1.0)
+        #expect(coord.longitude == 3.0)
+    }
+
+    @Test
+    func coordinate3DSnapToGridNoChange() async throws {
+        let coord = Coordinate3D(latitude: 2.0, longitude: 4.0)
+        let snapped = coord.snappedToGrid(tolerance: 2.0)
+
+        #expect(snapped.latitude == 2.0)
+        #expect(snapped.longitude == 4.0)
+    }
+
+    @Test
+    func coordinate3DSnapToGridPreservesAltitude() async throws {
+        let coord = Coordinate3D(latitude: 1.3, longitude: 2.7, altitude: 42.0)
+        let snapped = coord.snappedToGrid(tolerance: 1.0)
+
+        #expect(snapped.altitude == 42.0)
+    }
+
+    // MARK: - Ring
+
+    @Test
+    func ringSnappedToGrid() async throws {
+        let ring = Ring(unchecked: [
+            Coordinate3D(latitude: 0.1, longitude: 0.2),
+            Coordinate3D(latitude: 1.7, longitude: 0.3),
+            Coordinate3D(latitude: 1.8, longitude: 1.9),
+            Coordinate3D(latitude: 0.2, longitude: 1.8),
+            Coordinate3D(latitude: 0.1, longitude: 0.2),
+        ])
+        let snapped = ring.snappedToGrid(tolerance: 1.0)
+
+        let coords = snapped.coordinates
+        #expect(coords[0] == Coordinate3D(latitude: 0.0, longitude: 0.0))
+        #expect(coords[1] == Coordinate3D(latitude: 2.0, longitude: 0.0))
+        #expect(coords[2] == Coordinate3D(latitude: 2.0, longitude: 2.0))
+        #expect(coords[3] == Coordinate3D(latitude: 0.0, longitude: 2.0))
+        #expect(coords[4] == Coordinate3D(latitude: 0.0, longitude: 0.0))
+    }
+
+    @Test
+    func ringSnapToGridMutating() async throws {
+        var ring = Ring(unchecked: [
+            Coordinate3D(latitude: 0.1, longitude: 0.2),
+            Coordinate3D(latitude: 1.7, longitude: 0.3),
+            Coordinate3D(latitude: 0.2, longitude: 1.8),
+            Coordinate3D(latitude: 0.1, longitude: 0.2),
+        ])
+        ring.snapToGrid(tolerance: 1.0)
+
+        #expect(ring.coordinates[0] == Coordinate3D(latitude: 0.0, longitude: 0.0))
+        #expect(ring.coordinates[1] == Coordinate3D(latitude: 2.0, longitude: 0.0))
+        #expect(ring.coordinates[2] == Coordinate3D(latitude: 0.0, longitude: 2.0))
+    }
+
+    // MARK: - LineSegment
+
+    @Test
+    func lineSegmentSnappedToGrid() async throws {
+        let segment = LineSegment(
+            first: Coordinate3D(latitude: 0.3, longitude: 0.2),
+            second: Coordinate3D(latitude: 1.7, longitude: 1.9))
+        let snapped = segment.snappedToGrid(tolerance: 1.0)
+
+        #expect(snapped.first.latitude == 0.0)
+        #expect(snapped.first.longitude == 0.0)
+        #expect(snapped.second.latitude == 2.0)
+        #expect(snapped.second.longitude == 2.0)
+    }
+
+    @Test
+    func lineSegmentSnapToGridMutating() async throws {
+        var segment = LineSegment(
+            first: Coordinate3D(latitude: 0.3, longitude: 0.2),
+            second: Coordinate3D(latitude: 1.7, longitude: 1.9))
+        segment.snapToGrid(tolerance: 1.0)
+
+        #expect(segment.first.latitude == 0.0)
+        #expect(segment.first.longitude == 0.0)
+        #expect(segment.second.latitude == 2.0)
+        #expect(segment.second.longitude == 2.0)
+    }
+
+    @Test
+    func lineSegmentSnapPreservesIndex() async throws {
+        let segment = LineSegment(
+            first: Coordinate3D(latitude: 0.3, longitude: 0.2),
+            second: Coordinate3D(latitude: 1.7, longitude: 1.9),
+            index: 3)
+        let snapped = segment.snappedToGrid(tolerance: 1.0)
+
+        #expect(snapped.index == 3)
+    }
+
+    // MARK: - BoundingBox
+
+    @Test
+    func boundingBoxSnappedToGrid() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 1.3, longitude: 2.7),
+            northEast: Coordinate3D(latitude: 5.6, longitude: 8.4))
+        let snapped = bbox.snappedToGrid(tolerance: 1.0)
+
+        #expect(snapped.southWest.latitude == 1.0)
+        #expect(snapped.southWest.longitude == 3.0)
+        #expect(snapped.northEast.latitude == 6.0)
+        #expect(snapped.northEast.longitude == 8.0)
+    }
+
+    @Test
+    func boundingBoxSnapToGridMutating() async throws {
+        var bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 1.3, longitude: 2.7),
+            northEast: Coordinate3D(latitude: 5.6, longitude: 8.4))
+        bbox.snapToGrid(tolerance: 1.0)
+
+        #expect(bbox.southWest.latitude == 1.0)
+        #expect(bbox.southWest.longitude == 3.0)
+        #expect(bbox.northEast.latitude == 6.0)
+        #expect(bbox.northEast.longitude == 8.0)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/UnionTests.swift
+++ b/Tests/GISToolsTests/Algorithms/UnionTests.swift
@@ -281,6 +281,35 @@ struct UnionTests {
         #expect(fc.union() != nil)
     }
 
+    // MARK: - gridSize
+
+    // Validates that `union(with:gridSize:)` matches manual pre-snapping.
+    @Test
+    func unionWithGridSize() async throws {
+        let p1 = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 5.0001, longitude: 0.0001),
+            Coordinate3D(latitude: 5.0001, longitude: 5.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 5.0001),
+            Coordinate3D(latitude: 0.0001, longitude: 0.0001),
+        ]]))
+        let p2 = try #require(Polygon([[
+            Coordinate3D(latitude: 2.0001, longitude: 2.0001),
+            Coordinate3D(latitude: 7.0001, longitude: 2.0001),
+            Coordinate3D(latitude: 7.0001, longitude: 7.0001),
+            Coordinate3D(latitude: 2.0001, longitude: 7.0001),
+            Coordinate3D(latitude: 2.0001, longitude: 2.0001),
+        ]]))
+        let gridSize = 0.001
+
+        let withParam = try #require(p1.union(with: p2, gridSize: gridSize))
+        let snapped1 = p1.snappedToGrid(tolerance: gridSize)
+        let snapped2 = p2.snappedToGrid(tolerance: gridSize)
+        let manual = try #require(snapped1.union(with: snapped2))
+        #expect(abs(withParam.area - manual.area) < 1.0)
+        #expect(withParam.polygons.count == manual.polygons.count)
+    }
+
     // MARK: - Antimeridian
 
     @Test


### PR DESCRIPTION
Adds an optional `gridSize: Double? = nil` parameter to every algorithm method. When non-nil, inputs are snapped to a grid of the given size before computation, ensuring consistent results from slightly different coordinate representations.

### Changes
- All 24 algorithm files updated with `gridSize` parameter + coordinate snapping
- `PolygonGeometry` protocol updated with `gridSize:` on `contains` methods
- `SnapToGrid.swift`: bounding-box caching bug fixed; new `snappedToGrid`/\`snapToGrid` extensions on `Coordinate3D`, `Ring`, `LineSegment`, `BoundingBox`
- 30 `gridSize` equivalence tests added across all algorithm test files

Closes #107 