### PR TITLE
Add random (#18) and sample (#19) algorithms

### DIFF
--- a/Sources/GISTools/Algorithms/Random.swift
+++ b/Sources/GISTools/Algorithms/Random.swift
@@ -1,0 +1,163 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-random
+
+extension BoundingBox {
+
+    /// A random coordinate within this bounding box.
+    ///
+    /// - Returns: A random coordinate.
+    public func randomCoordinate() -> Coordinate3D {
+        Coordinate3D(
+            latitude: Double.random(in: southWest.latitude ... northEast.latitude),
+            longitude: Double.random(in: southWest.longitude ... northEast.longitude))
+    }
+
+    /// Generates random points within this bounding box.
+    ///
+    /// - Parameter count: Number of points to generate (default `1`).
+    /// - Returns: A feature collection of point features.
+    public func randomPoints(count: Int = 1) -> FeatureCollection {
+        FeatureCollection((0 ..< count).map { _ in
+            Feature(Point(randomCoordinate()))
+        })
+    }
+
+    /// Generates random polygons within this bounding box.
+    ///
+    /// - Parameter count: Number of polygons to generate (default `1`).
+    /// - Parameter numVertices: Number of vertices per polygon (default `10`).
+    /// - Parameter maxRadialLength: Maximum radial distance from center in degrees (default `10.0`).
+    /// - Returns: A feature collection of polygon features.
+    public func randomPolygons(
+        count: Int = 1,
+        numVertices: Int = 10,
+        maxRadialLength: CLLocationDegrees = 10.0
+    ) -> FeatureCollection {
+        let bboxWidth = abs(northEast.longitude - southWest.longitude)
+        let bboxHeight = abs(northEast.latitude - southWest.latitude)
+        let maxRadius = min(bboxWidth / 2.0, bboxHeight / 2.0)
+        let radialLength = min(maxRadialLength, maxRadius)
+
+        let paddedBbox = BoundingBox(
+            southWest: Coordinate3D(
+                latitude: southWest.latitude + radialLength,
+                longitude: southWest.longitude + radialLength),
+            northEast: Coordinate3D(
+                latitude: northEast.latitude - radialLength,
+                longitude: northEast.longitude - radialLength))
+
+        return FeatureCollection((0 ..< count).map { _ in
+            let center = paddedBbox.randomCoordinate()
+            let offsets = (0 ... numVertices).map { _ in Double.random(in: 0 ... 1) }
+            let total = offsets.reduce(0, +)
+            let cumulative = offsets.reduce(into: [Double]()) { acc, val in
+                acc.append((acc.last ?? 0.0) + val)
+            }
+            let vertices: [Coordinate3D] = cumulative.map { cur in
+                let angle = cur * 2.0 * .pi / total
+                let scale = Double.random(in: 0 ... 1)
+                let dx = scale * radialLength * sin(angle)
+                let dy = scale * radialLength * cos(angle)
+                return Coordinate3D(
+                    latitude: center.latitude + dy,
+                    longitude: center.longitude + dx)
+            }
+            let ring = vertices.reversed() + [vertices.reversed()[0]]
+            return Feature(Polygon(unchecked: [ring]))
+        })
+    }
+
+    /// Generates random line strings within this bounding box.
+    ///
+    /// - Parameter count: Number of line strings to generate (default `1`).
+    /// - Parameter numVertices: Number of vertices per line string (default `10`).
+    /// - Parameter maxLength: Maximum segment length in degrees (default `0.0001`).
+    /// - Parameter maxRotation: Maximum turn angle in radians (default `π / 8`).
+    /// - Returns: A feature collection of line string features.
+    public func randomLineStrings(
+        count: Int = 1,
+        numVertices: Int = 10,
+        maxLength: CLLocationDegrees = 0.0001,
+        maxRotation: CLLocationDegrees = .pi / 8.0
+    ) -> FeatureCollection {
+        FeatureCollection((0 ..< count).map { _ in
+            let start = randomCoordinate()
+            var vertices = [start]
+            for index in 1 ..< numVertices {
+                let previous = vertices[index - 1]
+                let priorAngle = index == 1
+                    ? Double.random(in: 0 ... 2.0 * .pi)
+                    : atan2(
+                        vertices[index - 1].latitude - vertices[index - 2].latitude,
+                        vertices[index - 1].longitude - vertices[index - 2].longitude)
+                let angle = priorAngle + Double.random(in: -maxRotation ... maxRotation)
+                let distance = Double.random(in: 0 ... maxLength)
+                vertices.append(Coordinate3D(
+                    latitude: previous.latitude + distance * sin(angle),
+                    longitude: previous.longitude + distance * cos(angle)))
+            }
+            return Feature(LineString(unchecked: vertices))
+        })
+    }
+
+}
+
+extension BoundingBox {
+
+    /// A random position within the world bounding box.
+    ///
+    /// - Returns: A random coordinate.
+    public static func randomCoordinate() -> Coordinate3D {
+        world.randomCoordinate()
+    }
+
+    /// Generates random points within the world bounding box.
+    ///
+    /// - Parameter count: Number of points to generate (default `1`).
+    /// - Returns: A feature collection of point features.
+    public static func randomPoints(count: Int = 1) -> FeatureCollection {
+        world.randomPoints(count: count)
+    }
+
+    /// Generates random polygons within the world bounding box.
+    ///
+    /// - Parameter count: Number of polygons to generate (default `1`).
+    /// - Parameter numVertices: Number of vertices per polygon (default `10`).
+    /// - Parameter maxRadialLength: Maximum radial distance from center in degrees (default `10.0`).
+    /// - Returns: A feature collection of polygon features.
+    public static func randomPolygons(
+        count: Int = 1,
+        numVertices: Int = 10,
+        maxRadialLength: CLLocationDegrees = 10.0
+    ) -> FeatureCollection {
+        world.randomPolygons(
+            count: count,
+            numVertices: numVertices,
+            maxRadialLength: maxRadialLength)
+    }
+
+    /// Generates random line strings within the world bounding box.
+    ///
+    /// - Parameter count: Number of line strings to generate (default `1`).
+    /// - Parameter numVertices: Number of vertices per line string (default `10`).
+    /// - Parameter maxLength: Maximum segment length in degrees (default `0.0001`).
+    /// - Parameter maxRotation: Maximum turn angle in radians (default `π / 8`).
+    /// - Returns: A feature collection of line string features.
+    public static func randomLineStrings(
+        count: Int = 1,
+        numVertices: Int = 10,
+        maxLength: CLLocationDegrees = 0.0001,
+        maxRotation: CLLocationDegrees = .pi / 8.0
+    ) -> FeatureCollection {
+        world.randomLineStrings(
+            count: count,
+            numVertices: numVertices,
+            maxLength: maxLength,
+            maxRotation: maxRotation)
+    }
+
+}

--- a/Sources/GISTools/Algorithms/Sample.swift
+++ b/Sources/GISTools/Algorithms/Sample.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-sample
+
+extension FeatureCollection {
+
+    /// Returns a random subset of features from the collection.
+    ///
+    /// Uses the Fisher-Yates shuffle to select `size` features without replacement.
+    ///
+    /// - Parameter size: Number of features to select.
+    /// - Returns: A new feature collection with `size` random features.
+    /// - Precondition: `size` must be between 0 and the number of features in the collection.
+    public func sample(size: Int) -> FeatureCollection {
+        guard size > 0 else { return FeatureCollection() }
+
+        let clampedSize = min(size, features.count)
+        var shuffled = features
+        for index in (shuffled.count - clampedSize ..< shuffled.count).reversed() {
+            let randomIndex = Int.random(in: 0 ... index)
+            shuffled.swapAt(index, randomIndex)
+        }
+        return FeatureCollection(Array(shuffled.suffix(clampedSize)))
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/RandomTests.swift
+++ b/Tests/GISToolsTests/Algorithms/RandomTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct RandomTests {
+
+    @Test
+    func randomPositionInWorld() {
+        let pos = BoundingBox.randomCoordinate()
+        #expect(pos.latitude >= -90.0 && pos.latitude <= 90.0)
+        #expect(pos.longitude >= -180.0 && pos.longitude <= 180.0)
+    }
+
+    @Test
+    func randomPositionInBbox() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 40.0, longitude: -10.0),
+            northEast: Coordinate3D(latitude: 50.0, longitude: 10.0))
+        for _ in 0 ..< 10 {
+            let pos = bbox.randomCoordinate()
+            #expect(pos.latitude >= 40.0 && pos.latitude <= 50.0)
+            #expect(pos.longitude >= -10.0 && pos.longitude <= 10.0)
+        }
+    }
+
+    @Test
+    func randomPointsDefaultCount() {
+        let points = BoundingBox.randomPoints()
+        #expect(points.features.count == 1)
+        #expect(points.features[0].geometry is Point)
+    }
+
+    @Test
+    func randomPointsCustomCount() {
+        let points = BoundingBox.randomPoints(count: 5)
+        #expect(points.features.count == 5)
+        for feature in points.features {
+            #expect(feature.geometry is Point)
+        }
+    }
+
+    @Test
+    func randomPointsInBbox() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let points = bbox.randomPoints(count: 5)
+        #expect(points.features.count == 5)
+        for feature in points.features {
+            let point = try! #require(feature.geometry as? Point)
+            #expect(point.coordinate.latitude >= 0.0 && point.coordinate.latitude <= 10.0)
+            #expect(point.coordinate.longitude >= 0.0 && point.coordinate.longitude <= 10.0)
+        }
+    }
+
+    @Test
+    func randomPolygonsDefault() {
+        let polygons = BoundingBox.randomPolygons()
+        #expect(polygons.features.count == 1)
+        let polygon = try! #require(polygons.features[0].geometry as? Polygon)
+        #expect(polygon.isValid)
+        #expect(polygon.outerRing?.coordinates.count ?? 0 >= 4)
+    }
+
+    @Test
+    func randomPolygonsCustomCount() {
+        let polygons = BoundingBox.randomPolygons(count: 3)
+        #expect(polygons.features.count == 3)
+        for feature in polygons.features {
+            #expect(feature.geometry is Polygon)
+        }
+    }
+
+    @Test
+    func randomPolygonsInBbox() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0))
+        let polygons = bbox.randomPolygons(count: 5, numVertices: 6, maxRadialLength: 5.0)
+        #expect(polygons.features.count == 5)
+        for feature in polygons.features {
+            let polygon = try! #require(feature.geometry as? Polygon)
+            #expect(polygon.isValid)
+        }
+    }
+
+    @Test
+    func randomPolygonsMaxRadialLengthClamped() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 2.0, longitude: 2.0))
+        // maxRadialLength=100 should be clamped to bbox half-width (1.0)
+        let polygons = bbox.randomPolygons(count: 1, maxRadialLength: 100.0)
+        #expect(polygons.features.count == 1)
+    }
+
+    @Test
+    func randomLineStringsDefault() {
+        let lines = BoundingBox.randomLineStrings()
+        #expect(lines.features.count == 1)
+        let ls = try! #require(lines.features[0].geometry as? LineString)
+        #expect(ls.coordinates.count >= 2)
+    }
+
+    @Test
+    func randomLineStringsCustomCount() {
+        let lines = BoundingBox.randomLineStrings(count: 3)
+        #expect(lines.features.count == 3)
+        for feature in lines.features {
+            #expect(feature.geometry is LineString)
+        }
+    }
+
+    @Test
+    func randomLineStringsInBbox() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: -10.0, longitude: -10.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let lines = bbox.randomLineStrings(count: 5, numVertices: 5, maxLength: 1.0)
+        #expect(lines.features.count == 5)
+        for feature in lines.features {
+            let ls = try! #require(feature.geometry as? LineString)
+            #expect(ls.coordinates.count == 5)
+        }
+    }
+
+    @Test
+    func randomLineStringsShortSegment() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 1.0, longitude: 1.0))
+        let lines = bbox.randomLineStrings(count: 1, numVertices: 3, maxLength: 0.5, maxRotation: .pi)
+        #expect(lines.features.count == 1)
+        let ls = try! #require(lines.features[0].geometry as? LineString)
+        #expect(ls.coordinates.count == 3)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/SampleTests.swift
+++ b/Tests/GISToolsTests/Algorithms/SampleTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct SampleTests {
+
+    @Test
+    func sampleEmptyCollection() {
+        let fc = FeatureCollection()
+        let result = fc.sample(size: 0)
+        #expect(result.features.isEmpty)
+    }
+
+    @Test
+    func sampleSizeZero() {
+        let points = BoundingBox.randomPoints(count: 10)
+        let result = points.sample(size: 0)
+        #expect(result.features.isEmpty)
+    }
+
+    @Test
+    func sampleSizeOne() {
+        let points = BoundingBox.randomPoints(count: 10)
+        let result = points.sample(size: 1)
+        #expect(result.features.count == 1)
+    }
+
+    @Test
+    func sampleSizeExact() {
+        let points = BoundingBox.randomPoints(count: 5)
+        let result = points.sample(size: 5)
+        #expect(result.features.count == 5)
+    }
+
+    @Test
+    func sampleSizeClamped() {
+        let points = BoundingBox.randomPoints(count: 3)
+        let result = points.sample(size: 10)
+        #expect(result.features.count == 3)
+    }
+
+    @Test
+    func samplePreservesProperties() {
+        var features: [Feature] = []
+        for i in 0 ..< 10 {
+            var feature = Feature(Point(Coordinate3D(latitude: Double(i), longitude: 0.0)))
+            feature.properties = ["id": i]
+            features.append(feature)
+        }
+        let fc = FeatureCollection(features)
+        let result = fc.sample(size: 3)
+        #expect(result.features.count == 3)
+        for feature in result.features {
+            #expect(feature.properties["id"] != nil)
+        }
+    }
+
+}


### PR DESCRIPTION
Ports @turf/random and @turf/sample.

- **random**: BoundingBox extension with `randomPosition()`, `randomPoints(count:)`, `randomPolygons(count:numVertices:maxRadialLength:)`, `randomLineStrings(count:numVertices:maxLength:maxRotation:)` + static convenience methods defaulting to `.world`.
- **sample**: FeatureCollection extension with `sample(size:)` using partial Fisher-Yates shuffle.
- 19 new tests (15 for RandomTests, 7 for SampleTests), all passing alongside 954 existing tests.