### PR TITLE
Ported turf/center-median (#41) with antimeridian support

### DIFF
--- a/Sources/GISTools/Algorithms/Center.swift
+++ b/Sources/GISTools/Algorithms/Center.swift
@@ -99,6 +99,136 @@ extension FeatureCollection {
 
 }
 
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-center-median
+
+extension FeatureCollection {
+
+    /// Takes a ``FeatureCollection`` and calculates the median center using the
+    /// Weiszfeld algorithm. The median center is the point that requires the
+    /// least total travel distance from all points in the dataset.
+    ///
+    /// - Parameters:
+    ///   - weightAttribute: The property name used to weight the center.
+    ///   - tolerance: The convergence threshold in meters (default: `0.001`).
+    ///   - counter: Maximum number of iterations (default: `10`).
+    ///
+    /// - Returns: The median center, or `nil` if the collection is empty.
+    public func centerMedian(
+        weightAttribute: String? = nil,
+        tolerance: Double = 0.001,
+        counter: Int = 10
+    ) -> Point? {
+        guard let meanCenter = centerMean(weightAttribute: weightAttribute) else {
+            return nil
+        }
+
+        var centroids: [(coordinate: Coordinate3D, weight: Double)] = []
+        for feature in features {
+            guard let centroid = feature.centroid else { continue }
+            var weight: Double = 1.0
+            if let weightAttribute {
+                weight = feature.property(for: weightAttribute) ?? 1.0
+            }
+            if weight > 0 {
+                centroids.append((centroid.coordinate, weight))
+            }
+        }
+
+        guard centroids.isNotEmpty else { return nil }
+
+        let minLon = centroids.map(\.coordinate.longitude).min() ?? 0.0
+        let maxLon = centroids.map(\.coordinate.longitude).max() ?? 0.0
+        let spansAntimeridian = (maxLon - minLon) > 180.0
+
+        if spansAntimeridian {
+            centroids = centroids.map { (coordinate, weight) in
+                let adjustedLon = coordinate.longitude < 0
+                    ? coordinate.longitude + 360.0
+                    : coordinate.longitude
+                let adjusted = Coordinate3D(
+                    x: adjustedLon,
+                    y: coordinate.latitude,
+                    projection: projection)
+                return (adjusted, weight)
+            }
+        }
+
+        let initialLon = meanCenter.coordinate.longitude
+        let initialLat = meanCenter.coordinate.latitude
+        let initialCandidate = Coordinate3D(
+            x: spansAntimeridian && initialLon < 0 ? initialLon + 360.0 : initialLon,
+            y: initialLat,
+            projection: projection)
+
+        guard var result = findMedian(
+            candidate: initialCandidate,
+            previousCandidate: Coordinate3D(
+                x: 0.0,
+                y: 0.0,
+                projection: projection),
+            centroids: centroids,
+            tolerance: tolerance,
+            counter: counter) else { return nil }
+
+        if spansAntimeridian && result.coordinate.longitude > 180.0 {
+            result = Point(Coordinate3D(
+                x: result.coordinate.longitude - 360.0,
+                y: result.coordinate.latitude,
+                projection: projection))
+        }
+
+        return result
+    }
+
+    private func findMedian(
+        candidate: Coordinate3D,
+        previousCandidate: Coordinate3D,
+        centroids: [(coordinate: Coordinate3D, weight: Double)],
+        tolerance: Double,
+        counter: Int
+    ) -> Point? {
+        var sumX: Double = 0.0
+        var sumY: Double = 0.0
+        var sumK: Double = 0.0
+
+        for (coordinate, weight) in centroids {
+            var distance = coordinate.distance(from: candidate)
+            if distance == 0 {
+                distance = 1.0
+            }
+            let k = weight / distance
+            sumX += coordinate.longitude * k
+            sumY += coordinate.latitude * k
+            sumK += k
+        }
+
+        guard sumK > 0.0 else { return nil }
+
+        let newCandidate = Coordinate3D(
+            x: sumX / sumK,
+            y: sumY / sumK,
+            projection: projection)
+
+        if counter == 0 || centroids.count == 1 {
+            return Point(newCandidate)
+        }
+
+        let deltaX = abs(newCandidate.longitude - previousCandidate.longitude)
+        let deltaY = abs(newCandidate.latitude - previousCandidate.latitude)
+        if deltaX < tolerance && deltaY < tolerance {
+            return Point(newCandidate)
+        }
+
+        return findMedian(
+            candidate: newCandidate,
+            previousCandidate: candidate,
+            centroids: centroids,
+            tolerance: tolerance,
+            counter: counter - 1)
+    }
+
+}
+
 // Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-center-of-mass
 
 extension GeoJson {

--- a/Tests/GISToolsTests/Algorithms/CenterTests.swift
+++ b/Tests/GISToolsTests/Algorithms/CenterTests.swift
@@ -326,4 +326,121 @@ struct CenterTests {
         #expect(abs(center.coordinate.longitude) > 90.0)
     }
 
+    // MARK: - centerMedian
+
+    // Validates that centerMedian handles points that cross the antimeridian.
+    @Test
+    func centerMedianAntimeridian() async throws {
+        let p1 = Point(Coordinate3D(latitude: 0.0, longitude: 170.0))
+        let p2 = Point(Coordinate3D(latitude: 0.0, longitude: -170.0))
+        let fc = FeatureCollection([Feature(p1), Feature(p2)])
+        let median = try #require(fc.centerMedian())
+
+        // Median should be near the antimeridian (lon ≈ ±180)
+        #expect(abs(median.coordinate.latitude) < 0.01)
+        #expect(abs(median.coordinate.longitude) > 170.0)
+    }
+
+    // Validates that centerMedian handles weighted points crossing the antimeridian.
+    @Test
+    func centerMedianAntimeridianWeighted() async throws {
+        let p1 = Point(Coordinate3D(latitude: 0.0, longitude: 170.0))
+        let p2 = Point(Coordinate3D(latitude: 0.0, longitude: -160.0))
+        let p3 = Point(Coordinate3D(latitude: 0.0, longitude: -175.0))
+        var f1 = Feature(p1)
+        f1.setProperty(10.0, for: "w")
+        let f2 = Feature(p2)
+        let f3 = Feature(p3)
+        let fc = FeatureCollection([f1, f2, f3])
+        let median = try #require(fc.centerMedian(weightAttribute: "w"))
+
+        // p1 at lon=170 with weight 10 should pull median toward the east side
+        #expect(abs(median.coordinate.latitude) < 0.01)
+        #expect(median.coordinate.longitude > 170.0 || median.coordinate.longitude < -170.0)
+    }
+
+    // Validates that the algorithm converges to a valid Point for symmetric data.
+    @Test
+    func centerMedianUnweighted() async throws {
+        let p1 = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let p2 = Point(Coordinate3D(latitude: 10.0, longitude: 10.0))
+        let fc = FeatureCollection([Feature(p1), Feature(p2)])
+
+        let median = try #require(fc.centerMedian())
+        // Should converge to a point between the two inputs
+        #expect(median.coordinate.latitude > 0.0)
+        #expect(median.coordinate.latitude < 10.0)
+        #expect(median.coordinate.longitude > 0.0)
+        #expect(median.coordinate.longitude < 10.0)
+    }
+
+    // Validates that weighted median center shifts toward higher-weighted points.
+    @Test
+    func centerMedianWeighted() async throws {
+        let p1 = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let p2 = Point(Coordinate3D(latitude: 10.0, longitude: 10.0))
+        var f1 = Feature(p1)
+        f1.setProperty(1.0, for: "w")
+        var f2 = Feature(p2)
+        f2.setProperty(9.0, for: "w")
+
+        let fc = FeatureCollection([f1, f2])
+        let median = try #require(fc.centerMedian(weightAttribute: "w"))
+
+        // Heavily weighted toward (10, 10)
+        #expect(abs(median.coordinate.latitude - 10.0) < 0.5)
+        #expect(abs(median.coordinate.longitude - 10.0) < 0.5)
+    }
+
+    // Validates that the median center is less sensitive to outliers than the mean center.
+    @Test
+    func centerMedianLessSensitiveToOutliers() async throws {
+        let points = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 8.0, longitude: 5.0),
+        ]
+        let fc = FeatureCollection(points.map { Feature(Point($0)) })
+        let median = try #require(fc.centerMedian())
+        let mean = try #require(fc.centerMean())
+
+        // Median should be closer to the cluster than the mean
+        let clusterCenter = Coordinate3D(latitude: 1.0 / 3.0, longitude: 1.0 / 3.0)
+        let medianToCluster = median.coordinate.distance(from: clusterCenter)
+        let meanToCluster = mean.coordinate.distance(from: clusterCenter)
+        #expect(medianToCluster < meanToCluster)
+    }
+
+    // Validates that the median center of a single point is the point itself.
+    @Test
+    func centerMedianSinglePoint() async throws {
+        let p = Point(Coordinate3D(latitude: 45.0, longitude: 8.0))
+        let fc = FeatureCollection([Feature(p)])
+        let median = try #require(fc.centerMedian())
+        #expect(median.coordinate.latitude == 45.0)
+        #expect(median.coordinate.longitude == 8.0)
+    }
+
+    // Validates that centerMedian returns nil for an empty feature collection.
+    @Test
+    func centerMedianEmpty() async throws {
+        let fc = FeatureCollection()
+        #expect(fc.centerMedian() == nil)
+    }
+
+    // Validates that centerMedian works correctly with LineString features.
+    @Test
+    func centerMedianLineString() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ]))
+        let fc = FeatureCollection([Feature(ls)])
+        let median = try #require(fc.centerMedian())
+        // Centroid of this LineString is (5, 0)
+        #expect(abs(median.coordinate.latitude - 5.0) < 0.001)
+        #expect(abs(median.coordinate.longitude - 0.0) < 0.001)
+    }
+
 }


### PR DESCRIPTION
## Summary

Ported the turf.js `center-median` algorithm as `FeatureCollection.centerMedian(weightAttribute:tolerance:counter:)` using the Weiszfeld iterative algorithm for computing the geometric median.

## Changes

- **Center.swift**: Added `centerMedian` with antimeridian detection and longitude normalization for coordinates crossing the date line
- **CenterTests.swift**: 8 tests covering unweighted, weighted, outlier sensitivity, single point, empty collection, LineString features, antimeridian crossing, and weighted antimeridian crossing

## Details

The Weiszfeld algorithm iteratively computes the point minimizing the sum of geodesic distances (Haversine) to all input features. Optional weight attribute support matches turf.js behavior. Tolerance and counter parameters control convergence.