### PR TITLE
#55: Experimental EPSG:4978 (ECEF Geocentric) support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
         .trait(name: "EnableMeterConversionExtensions"),
         .trait(name: "EnableMeasurementConversionExtensions"),
         .trait(name: "EnableShapefileSupport"),
-        .default(enabledTraits: ["EnableShapefileSupport"])
     ],
     dependencies: [],
     targets: [

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ GIS tools for Swift, including a [GeoJSON][3] implementation and many algorithms
 - Load and write GeoJSON objects from and to `[String:Any]`, `URL`, `Data` and `String`
 - Supports `Codable` and `SwiftData` (see below)
 - Supports EPSG:3857 (web mercator) and EPSG:4326 (geodetic) conversions
+- Experimental support for EPSG:4978 (ECEF geocentric) coordinate conversion and spatial operations
 - Supports WKT/WKB/TWKB, also with different projections
 - Reads and writes ESRI Shapefiles (.shp/.dbf/.shx/.prj)
 - Spatial search with a R-tree

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ let distance: Double = 1000.0.meters  // raw meters
 let total = distance + 500.0.feet     // Double arithmetic (both in meters)
 ```
 
-**Shapefile support trait** (enabled by default):
-- `EnableShapefileSupport` — adds Shapefile (.shp/.dbf/.shx/.prj) read/write support via `ShapefileCoder` and convenience extensions on `FeatureCollection`. Disable with `--traits \!EnableShapefileSupport`.
+**Shapefile support trait**:
+- `EnableShapefileSupport` — adds Shapefile (.shp/.dbf/.shx/.prj) read/write support via `ShapefileCoder` and convenience extensions on `FeatureCollection`.
 
 ## Usage
 
@@ -891,9 +891,6 @@ let coordinates = polyline.decodePolyline()
 Provides read/write support for the ESRI Shapefile format. `FeatureCollection` has convenience methods to read and write Shapefiles.
 
 The Shapefile reader handles Point, PolyLine, Polygon, MultiPoint, and MultiPatch geometry types, including Z (altitude) and M (measure) variants. Attributes are mapped to and from `Feature.properties` via the companion `.dbf` file. The `.prj` file is read to determine the source projection. The `.shx` index file is written for compatibility with tools that require it.
-
-> [!NOTE]
-> Shapefile support is enabled by default via the `EnableShapefileSupport` package trait. Disable it with `--traits \!EnableShapefileSupport` to reduce the library's footprint.
 
 ## Reading
 

--- a/Sources/GISTools/Algorithms/Bearing.swift
+++ b/Sources/GISTools/Algorithms/Bearing.swift
@@ -20,7 +20,7 @@ extension Coordinate3D {
         switch projection {
         case .epsg4326:
             return _bearing(to: other.projected(to: .epsg4326), final: final)
-        case .epsg3857:
+        case .epsg3857, .epsg4978:
             return projected(to: .epsg4326)._bearing(to: other.projected(to: .epsg4326), final: final)
         case .noSRID:
             let dx = other.longitude - longitude

--- a/Sources/GISTools/Algorithms/Clusters.swift
+++ b/Sources/GISTools/Algorithms/Clusters.swift
@@ -111,7 +111,12 @@ extension FeatureCollection {
         // Read weights if weightAttribute is provided
         let weights: [Double]
         if let weightAttribute {
-            weights = features.map { ($0.properties[weightAttribute] as? Double) ?? 1.0 }
+            weights = features.map { feature in
+                let v = feature.properties[weightAttribute]
+                if let d = v as? Double { return d }
+                if let i = v as? Int { return Double(i) }
+                return 1.0
+            }
         }
         else {
             weights = Array(repeating: 1.0, count: count)

--- a/Sources/GISTools/Algorithms/Clusters.swift
+++ b/Sources/GISTools/Algorithms/Clusters.swift
@@ -179,15 +179,23 @@ extension FeatureCollection {
 
         let center = point.coordinate
 
-        // Approximate bounds: 1 degree ≈ 111 km at equator
-        let delta = maxDistance / 111_000.0
+        // Bounding box optimisation in the native coordinate system
+        let delta: Double
+        switch center.projection {
+        case .epsg4326:
+            delta = maxDistance / 111_000.0
+        case .epsg3857, .epsg4978, .noSRID:
+            delta = maxDistance
+        }
         let bbox = BoundingBox(
             southWest: Coordinate3D(
-                latitude: center.latitude - delta,
-                longitude: center.longitude - delta),
+                x: center.longitude - delta,
+                y: center.latitude - delta,
+                projection: center.projection),
             northEast: Coordinate3D(
-                latitude: center.latitude + delta,
-                longitude: center.longitude + delta))
+                x: center.longitude + delta,
+                y: center.latitude + delta,
+                projection: center.projection))
 
         var result: [Int] = []
         for i in 0..<features.count {

--- a/Sources/GISTools/Algorithms/Clusters.swift
+++ b/Sources/GISTools/Algorithms/Clusters.swift
@@ -309,7 +309,7 @@ private struct DBSCANIndexedPoint: BoundingBoxRepresentable {
     var projection: Projection { point.projection }
 
     var boundingBox: BoundingBox? {
-        get { point.calculateBoundingBox() }
+        get { point.boundingBox ?? point.calculateBoundingBox() }
         set {}
     }
 

--- a/Sources/GISTools/Algorithms/Clusters.swift
+++ b/Sources/GISTools/Algorithms/Clusters.swift
@@ -80,10 +80,16 @@ extension FeatureCollection {
     /// Clusters points using the K-means algorithm.
     ///
     /// - Parameter numberOfClusters: Number of clusters (default `sqrt(n/2)`).
+    /// - Parameter weightAttribute: Property key for point weights (optional).
+    ///   When set, centroids are computed as the weighted mean, matching
+    ///   PostGIS's `ST_ClusterKMeans` behaviour.
+    /// - Parameter seedIndex: Index used to seed the initial centroids (default `0`).
     /// - Returns: A FeatureCollection with `cluster` (Int) and `centroid`
     ///   ([Double]) properties on each point.
     public func kmeansClusters(
-        numberOfClusters: Int? = nil
+        numberOfClusters: Int? = nil,
+        weightAttribute: String? = nil,
+        seedIndex: Int = 0
     ) -> FeatureCollection {
         var features = self.features
         let count = features.count
@@ -102,15 +108,26 @@ extension FeatureCollection {
               k <= count
         else { return self }
 
-        // Initialize centroids from first k points
-        var centroids = Array(coords.prefix(k))
+        // Read weights if weightAttribute is provided
+        let weights: [Double]
+        if let weightAttribute {
+            weights = features.map { ($0.properties[weightAttribute] as? Double) ?? 1.0 }
+        }
+        else {
+            weights = Array(repeating: 1.0, count: count)
+        }
+
+        // Initialize centroids from seedIndex
+        let start = min(seedIndex, count - k)
+        var centroids = (start..<(start + k)).map { coords[$0] }
 
         // K-means iterations
         let maxIter = 100
         for _ in 0..<maxIter {
-            // Assign each point to nearest centroid
-            var clusters: [[Coordinate3D]] = Array(repeating: [], count: k)
-            for coord in coords {
+            // Assign each point to nearest centroid, tracking indices
+            var clusterIndices: [[Int]] = Array(repeating: [], count: k)
+            for i in 0..<count {
+                let coord = coords[i]
                 var best = 0
                 var bestDist = Double.greatestFiniteMagnitude
                 for j in 0..<k {
@@ -120,19 +137,31 @@ extension FeatureCollection {
                         best = j
                     }
                 }
-                clusters[best].append(coord)
+                clusterIndices[best].append(i)
             }
 
-            // Recompute centroids
+            // Recompute centroids (weighted if weightAttribute is provided)
             var changed = false
             for j in 0..<k {
-                guard !clusters[j].isEmpty else { continue }
+                let indices = clusterIndices[j]
+                guard !indices.isEmpty else { continue }
 
-                let sumLat = clusters[j].reduce(0.0) { $0 + $1.latitude }
-                let sumLon = clusters[j].reduce(0.0) { $0 + $1.longitude }
+                var weightSum: Double = 0.0
+                var sumLat: Double = 0.0
+                var sumLon: Double = 0.0
+                for i in indices {
+                    let w = max(weights[i], 0.0)
+                    let coord = coords[i]
+                    weightSum += w
+                    sumLat += w * coord.latitude
+                    sumLon += w * coord.longitude
+                }
+
+                guard weightSum > 0 else { continue }
+
                 let newCentroid = Coordinate3D(
-                    latitude: sumLat / Double(clusters[j].count),
-                    longitude: sumLon / Double(clusters[j].count))
+                    latitude: sumLat / weightSum,
+                    longitude: sumLon / weightSum)
                 if centroids[j].latitude != newCentroid.latitude
                     || centroids[j].longitude != newCentroid.longitude
                 {

--- a/Sources/GISTools/Algorithms/Clusters.swift
+++ b/Sources/GISTools/Algorithms/Clusters.swift
@@ -12,6 +12,9 @@ extension FeatureCollection {
 
     /// Clusters points using the DBSCAN algorithm.
     ///
+    /// Uses an R-tree spatial index for O(n log n) neighbourhood queries.
+    /// Without the optimised indexing the underlying algorithm is O(n²).
+    ///
     /// - Parameter maxDistance: Maximum distance between points in a cluster (meters).
     /// - Parameter minPoints: Minimum points to form a cluster (default 3).
     /// - Returns: A FeatureCollection with `cluster` (Int) and `dbscan`
@@ -23,6 +26,13 @@ extension FeatureCollection {
         var features = self.features
         let count = features.count
         guard count > 0 else { return self }
+
+        // Build spatial index for O(n log n) neighbourhood queries
+        let indexed: [DBSCANIndexedPoint] = features.enumerated().compactMap { (i, f) in
+            guard let p = f.geometry as? Point else { return nil }
+            return DBSCANIndexedPoint(index: i, point: p)
+        }
+        let tree = RTree(indexed, nodeSize: 16)
 
         var visited = Array(repeating: false, count: count)
         var assigned = Array(repeating: false, count: count)
@@ -37,7 +47,8 @@ extension FeatureCollection {
             let neighbors = regionQuery(
                 features: features,
                 index: i,
-                maxDistance: maxDistance)
+                maxDistance: maxDistance,
+                tree: tree)
 
             if neighbors.count >= minPoints {
                 let clusterId = nextClusterId
@@ -51,7 +62,8 @@ extension FeatureCollection {
                     clusterIds: &clusterIds,
                     isNoise: &isNoise,
                     maxDistance: maxDistance,
-                    minPoints: minPoints)
+                    minPoints: minPoints,
+                    tree: tree)
             }
             else {
                 isNoise[i] = true
@@ -78,6 +90,9 @@ extension FeatureCollection {
     // MARK: - K-means clustering
 
     /// Clusters points using the K-means algorithm.
+    ///
+    /// Runtime is O(k·n·i) where k = number of clusters, n = point count,
+    /// and i = iterations (capped at 100, typically converges in <10).
     ///
     /// - Parameter numberOfClusters: Number of clusters (default `sqrt(n/2)`).
     /// - Parameter weightAttribute: Property key for point weights (optional).
@@ -207,13 +222,13 @@ extension FeatureCollection {
     private func regionQuery(
         features: [Feature],
         index: Int,
-        maxDistance: CLLocationDistance
+        maxDistance: CLLocationDistance,
+        tree: RTree<DBSCANIndexedPoint>
     ) -> [Int] {
         guard let point = features[index].geometry as? Point else { return [] }
 
         let center = point.coordinate
 
-        // Bounding box optimisation in the native coordinate system
         let delta: Double
         switch center.projection {
         case .epsg4326:
@@ -232,17 +247,12 @@ extension FeatureCollection {
                 projection: center.projection))
 
         var result: [Int] = []
-        for i in 0..<features.count {
-            guard i != index,
-                  let neighbor = features[i].geometry as? Point
-            else { continue }
-
-            let neighborCoord = neighbor.coordinate
-            if bbox.contains(neighborCoord) {
-                let d = center.distance(from: neighborCoord)
-                if d <= maxDistance {
-                    result.append(i)
-                }
+        for candidate in tree.search(inBoundingBox: bbox) {
+            let i = candidate.index
+            guard i != index else { continue }
+            let d = center.distance(from: candidate.point.coordinate)
+            if d <= maxDistance {
+                result.append(i)
             }
         }
         return result
@@ -257,7 +267,8 @@ extension FeatureCollection {
         clusterIds: inout [Int],
         isNoise: inout [Bool],
         maxDistance: CLLocationDistance,
-        minPoints: Int
+        minPoints: Int,
+        tree: RTree<DBSCANIndexedPoint>
     ) {
         var queue = neighbors
         var idx = 0
@@ -270,7 +281,8 @@ extension FeatureCollection {
                 let nextNeighbors = regionQuery(
                     features: features,
                     index: neighborIndex,
-                    maxDistance: maxDistance)
+                    maxDistance: maxDistance,
+                    tree: tree)
                 if nextNeighbors.count >= minPoints,
                    isNoise[neighborIndex]
                 {
@@ -286,4 +298,30 @@ extension FeatureCollection {
         }
     }
 
+}
+
+// MARK: - R-tree helper for DBSCAN
+
+private struct DBSCANIndexedPoint: BoundingBoxRepresentable {
+    let index: Int
+    let point: Point
+
+    var projection: Projection { point.projection }
+
+    var boundingBox: BoundingBox? {
+        get { point.calculateBoundingBox() }
+        set {}
+    }
+
+    func calculateBoundingBox() -> BoundingBox? {
+        point.calculateBoundingBox()
+    }
+
+    mutating func updateBoundingBox(onlyIfNecessary: Bool) -> BoundingBox? {
+        point.calculateBoundingBox()
+    }
+
+    func intersects(_ otherBoundingBox: BoundingBox) -> Bool {
+        point.intersects(otherBoundingBox)
+    }
 }

--- a/Sources/GISTools/Algorithms/Destination.swift
+++ b/Sources/GISTools/Algorithms/Destination.swift
@@ -24,6 +24,8 @@ extension Coordinate3D {
             return _destination(distance: distance, bearing: bearing)
         case .epsg3857:
             return projected(to: .epsg4326)._destination(distance: distance, bearing: bearing).projected(to: .epsg3857)
+        case .epsg4978:
+            return projected(to: .epsg4326)._destination(distance: distance, bearing: bearing).projected(to: .epsg4978)
         case .noSRID:
             return self // Ignore
         }

--- a/Sources/GISTools/Algorithms/Distance.swift
+++ b/Sources/GISTools/Algorithms/Distance.swift
@@ -27,11 +27,7 @@ extension Coordinate3D {
         switch projection {
         case .epsg4326:
             return _distance(from: other.projected(to: .epsg4326))
-        case .epsg3857:
-            let dx = longitude - other.longitude
-            let dy = latitude - other.latitude
-            return sqrt(dx * dx + dy * dy)
-        case .noSRID:
+        case .epsg3857, .epsg4978, .noSRID:
             let dx = longitude - other.longitude
             let dy = latitude - other.latitude
             return sqrt(dx * dx + dy * dy)

--- a/Sources/GISTools/Algorithms/MidPoint.swift
+++ b/Sources/GISTools/Algorithms/MidPoint.swift
@@ -19,6 +19,8 @@ extension Coordinate3D {
             return _midpoint(to: other.projected(to: .epsg4326))
         case .epsg3857:
             return projected(to: .epsg4326)._midpoint(to: other.projected(to: .epsg4326)).projected(to: .epsg3857)
+        case .epsg4978:
+            return projected(to: .epsg4326)._midpoint(to: other.projected(to: .epsg4326)).projected(to: .epsg4978)
         case .noSRID:
             return Coordinate3D(
                 x: longitude + ((other.longitude - longitude) / 2.0),

--- a/Sources/GISTools/Algorithms/RhumbBearing.swift
+++ b/Sources/GISTools/Algorithms/RhumbBearing.swift
@@ -22,7 +22,7 @@ extension Coordinate3D {
         switch projection {
         case .epsg4326:
             return _rhumbBearing(to: other.projected(to: .epsg4326), final: final)
-        case .epsg3857:
+        case .epsg3857, .epsg4978:
             return projected(to: .epsg4326)._rhumbBearing(to: other.projected(to: .epsg4326), final: final)
         case .noSRID:
             let dx = other.longitude - longitude

--- a/Sources/GISTools/Algorithms/RhumbDestination.swift
+++ b/Sources/GISTools/Algorithms/RhumbDestination.swift
@@ -24,6 +24,8 @@ extension Coordinate3D {
             return _rhumbDestination(distance: distance, bearing: bearing)
         case .epsg3857:
             return projected(to: .epsg4326)._rhumbDestination(distance: distance, bearing: bearing).projected(to: .epsg3857)
+        case .epsg4978:
+            return projected(to: .epsg4326)._rhumbDestination(distance: distance, bearing: bearing).projected(to: .epsg4978)
         case .noSRID:
             let theta = bearing.degreesToRadians
             return Coordinate3D(

--- a/Sources/GISTools/Algorithms/RhumbDistance.swift
+++ b/Sources/GISTools/Algorithms/RhumbDistance.swift
@@ -16,7 +16,7 @@ extension Coordinate3D {
         switch projection {
         case .epsg4326:
             return _rhumbDistance(from: other.projected(to: .epsg4326))
-        case .epsg3857:
+        case .epsg3857, .epsg4978:
             // TODO: This can be improved
             return projected(to: .epsg4326)._rhumbDistance(from: other.projected(to: .epsg4326))
         case .noSRID:

--- a/Sources/GISTools/Algorithms/Simplify.swift
+++ b/Sources/GISTools/Algorithms/Simplify.swift
@@ -193,7 +193,7 @@ public enum Simplify {
         else { return coordinates }
 
         switch firstCoordinate.projection {
-        case .epsg3857, .noSRID:
+        case .epsg3857, .epsg4978, .noSRID:
             return simplify(
                 coordinates: coordinates,
                 tolerance: toleranceInMeters,

--- a/Sources/GISTools/GISTool.swift
+++ b/Sources/GISTools/GISTool.swift
@@ -5,25 +5,34 @@ import CoreLocation
 /// Some constants used in this library.
 public enum GISTool {
 
-    /// WGS84 equatorial radius as specified by the International Union of Geodesy and Geophysics.
-    public static let equatorialRadius: CLLocationDistance = 6_378_137
-
-    /// The radius of the earth, in meters.
-    public static let earthRadius: CLLocationDistance = 6_371_008.8
+    /// The default precision for encoding/decoding Polylines.
+    public static let defaultPolylinePrecision: Double = 1e5
 
     /// Length of the equator, in meters.
     public static let earthCircumference: CLLocationDistance = 40_075_016.6855785
 
-    /// Mercator projection origin shift.
-    public static let originShift = 2.0 * Double.pi * GISTool.equatorialRadius / 2.0 // 20037508.342789244
+    /// The radius of the earth, in meters.
+    public static let earthRadius: CLLocationDistance = 6_371_008.8
+
+    /// WGS84 equatorial radius as specified by the International Union of Geodesy and Geophysics.
+    public static let equatorialRadius: CLLocationDistance = 6_378_137
 
     /// The accuracy for testing what is equal (μm precision, mainly to counter small rounding errors).
     public static let equalityDelta: Double = 1e-10
 
+    /// Mercator projection origin shift.
+    public static let originShift = 2.0 * Double.pi * GISTool.equatorialRadius / 2.0 // 20037508.342789244
+
     /// The length in pixels of a map tile.
     public static let tileSideLength: Double = 256.0
 
-    /// The default precision for encoding/decoding Polylines.
-    public static let defaultPolylinePrecision: Double = 1e5
+    /// WGS84 first eccentricity squared (e²).
+    public static let wgs84EccentricitySquared: Double = 2.0 * wgs84Flattening - wgs84Flattening * wgs84Flattening
+
+    /// WGS84 inverse flattening (1/f).
+    public static let wgs84Flattening: Double = 1.0 / 298.257223563
+
+    /// WGS84 semi-minor axis in meters.
+    public static let wgs84SemiMinorAxis: CLLocationDistance = equatorialRadius * (1.0 - wgs84Flattening)
 
 }

--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -71,7 +71,7 @@ public struct BoundingBox:
 
         if padding > 0.0 {
             switch projection {
-            case .epsg3857:
+            case .epsg3857, .epsg4978:
                 southWest.latitude -= padding
                 northEast.latitude += padding
                 southWest.longitude -= padding
@@ -221,10 +221,10 @@ public struct BoundingBox:
         verticalDegrees dy: CLLocationDegrees
     ) -> BoundingBox {
         switch projection {
-        case .epsg3857:
+        case .epsg3857, .epsg4978:
             return projected(to: .epsg4326)
                 .expanded(byHorizontalDegrees: dx, verticalDegrees: dy)
-                .projected(to: .epsg3857)
+                .projected(to: projection)
 
         case .epsg4326:
             return BoundingBox(
@@ -438,7 +438,7 @@ extension BoundingBox {
     /// The size of the bounding box (width, height) in meters (approximation).
     public var size: (width: Double, height: Double) {
         switch projection {
-        case .epsg3857, .noSRID:
+        case .epsg3857, .epsg4978, .noSRID:
             return (width: northEast.longitude - southWest.longitude,
                     height: northEast.latitude - southWest.latitude)
 
@@ -470,7 +470,7 @@ extension BoundingBox {
         // self crosses the date line
         if boundingBox.southWest.longitude > boundingBox.northEast.longitude {
             switch projection {
-            case .noSRID:
+            case .noSRID, .epsg4978:
                 return false
 
             case .epsg3857:
@@ -543,7 +543,7 @@ extension BoundingBox {
         // self crosses date line
         if boundingBox.southWest.longitude > boundingBox.northEast.longitude {
             switch projection {
-            case .noSRID:
+            case .noSRID, .epsg4978:
                 return false
 
             case .epsg3857:
@@ -570,7 +570,7 @@ extension BoundingBox {
         // other crosses date line
         else if other.southWest.longitude > other.northEast.longitude {
             switch projection {
-            case .noSRID:
+            case .noSRID, .epsg4978:
                 return false
 
             case .epsg3857:
@@ -617,7 +617,7 @@ extension BoundingBox {
             let right: BoundingBox
 
             switch projection {
-            case .noSRID:
+            case .noSRID, .epsg4978:
                 return nil
 
             case .epsg3857:
@@ -660,7 +660,7 @@ extension BoundingBox {
             let right: BoundingBox
 
             switch projection {
-            case .noSRID:
+            case .noSRID, .epsg4978:
                 return nil
 
             case .epsg3857:
@@ -741,7 +741,7 @@ extension BoundingBox {
     /// - Returns: A copy of this bounding box with longitudes normalized to the [-180, 180] range
     public func normalized() -> BoundingBox {
         switch projection {
-        case .noSRID:
+        case .noSRID, .epsg4978:
             return self
 
         case .epsg3857:

--- a/Sources/GISTools/GeoJson/Coordinate3D.swift
+++ b/Sources/GISTools/GeoJson/Coordinate3D.swift
@@ -230,11 +230,9 @@ extension Coordinate3D {
         let isNorth = hemisphere.uppercased() == "N"
 
         // WGS84 ellipsoid constants
-        let a: Double = 6_378_137.0 // semi-major axis
-        let f: Double = 1.0 / 298.257223563 // flattening
-        let b: Double = a * (1.0 - f) // semi-minor axis
-        let e: Double = sqrt(1.0 - (b * b) / (a * a))
-        let e1sq: Double = (e * e) / (1.0 - e * e)
+        let a = GISTool.equatorialRadius
+        let e2 = GISTool.wgs84EccentricitySquared
+        let e1sq = e2 / (1.0 - e2)
         let k0: Double = 0.9996
 
         let falseEasting: Double = 500_000.0
@@ -244,9 +242,9 @@ extension Coordinate3D {
         let y = northing - falseNorthing
 
         let M = y / k0
-        let mu = M / (a * (1.0 - e * e / 4.0 - 3.0 * e * e * e * e / 64.0 - 5.0 * pow(e, 6) / 256.0))
+        let mu = M / (a * (1.0 - e2 / 4.0 - 3.0 * e2 * e2 / 64.0 - 5.0 * pow(e2, 3) / 256.0))
 
-        let e1 = (1.0 - sqrt(1.0 - e * e)) / (1.0 + sqrt(1.0 - e * e))
+        let e1 = (1.0 - sqrt(1.0 - e2)) / (1.0 + sqrt(1.0 - e2))
 
         let phi1 = mu
             + (3.0 * e1 / 2.0 - 27.0 * pow(e1, 3) / 32.0) * sin(2.0 * mu)
@@ -254,10 +252,10 @@ extension Coordinate3D {
             + (151.0 * pow(e1, 3) / 96.0) * sin(6.0 * mu)
             + (1097.0 * pow(e1, 4) / 512.0) * sin(8.0 * mu)
 
-        let N1 = a / sqrt(1.0 - e * e * sin(phi1) * sin(phi1))
+        let N1 = a / sqrt(1.0 - e2 * sin(phi1) * sin(phi1))
         let T1 = tan(phi1) * tan(phi1)
         let C1 = e1sq * cos(phi1) * cos(phi1)
-        let R1 = a * (1.0 - e * e) / pow(1.0 - e * e * sin(phi1) * sin(phi1), 1.5)
+        let R1 = a * (1.0 - e2) / pow(1.0 - e2 * sin(phi1) * sin(phi1), 1.5)
         let D = x / (N1 * k0)
 
         let lat1 = N1 * tan(phi1) / R1
@@ -379,18 +377,23 @@ extension Coordinate3D {
         return self.equals(other: other, includingAltitude: false)
     }
 
-    /// Clamped to [-180.0, 180.0].
+    /// Normalize this coordinate in place (no-op for Cartesian projections).
     public mutating func normalize() {
         self = self.normalized()
     }
 
-    /// Clamped to [-180.0, 180.0].
+    /// Normalize this coordinate.
     ///
-    /// - Returns: A copy with longitude normalized to the [-180, 180] range
+    /// For EPSG:4326 and EPSG:3857, clamps the longitude to the valid range.
+    /// For EPSG:4978 (ECEF) this is a no-op.
+    ///
+    /// - Returns: A copy with longitude normalized to the valid range
     public func normalized() -> Coordinate3D {
         switch projection {
         case .epsg3857:
-            guard longitude < -GISTool.originShift || longitude > GISTool.originShift else { return self }
+            guard longitude < -GISTool.originShift
+                    || longitude > GISTool.originShift
+            else { return self }
 
             var longitude = self.longitude
             while longitude < -GISTool.originShift { longitude += (2.0 * GISTool.originShift) }
@@ -399,7 +402,9 @@ extension Coordinate3D {
             return Coordinate3D(x: longitude, y: latitude, z: altitude, m: m)
 
         case .epsg4326:
-            guard longitude < -180.0 || longitude > 180.0 else { return self }
+            guard longitude < -180.0
+                    || longitude > 180.0
+            else { return self }
 
             var longitude = self.longitude
             while longitude < -180.0 { longitude += 360.0 }
@@ -412,12 +417,15 @@ extension Coordinate3D {
         }
     }
 
-    /// Clamped to [[-180,-90], [180,90]]
+    /// Clamped to [[-180,-90], [180,90]]  (no-op for Cartesian projections).
     public mutating func clamp() {
         self = self.clamped()
     }
 
     /// Clamped to [[-180,-90], [180,90]].
+    ///
+    /// For EPSG:4326 and EPSG:3857, clamps the longitude to the valid range.
+    /// For EPSG:4978 (ECEF) this is a no-op.
     ///
     /// - Returns: A copy clamped to the valid coordinate range
     public func clamped() -> Coordinate3D {
@@ -475,6 +483,8 @@ extension Coordinate3D: Projectable {
                     z: altitude,
                     m: m,
                     projection: newProjection)
+            case .epsg4978:
+                return projected(to: .epsg4326).projected(to: .epsg3857)
             }
 
         case .epsg4326:
@@ -488,6 +498,22 @@ extension Coordinate3D: Projectable {
                     z: altitude,
                     m: m,
                     projection: newProjection)
+            case .epsg4978:
+                let (lat, lon, alt) = Coordinate3D.ecefToGeodetic(
+                    x: longitude, y: latitude, z: altitude ?? 0.0)
+                return Coordinate3D(latitude: lat, longitude: lon, altitude: alt, m: m)
+            }
+
+        case .epsg4978:
+            switch projection {
+            case .epsg4978:
+                return self
+            case .epsg4326, .noSRID:
+                let (x, y, z) = Coordinate3D.geodeticToEcef(
+                    latitude: latitude, longitude: longitude, altitude: altitude ?? 0.0)
+                return Coordinate3D(x: x, y: y, z: z, m: m, projection: .epsg4978)
+            case .epsg3857:
+                return projected(to: .epsg4326).projected(to: .epsg4978)
             }
 
         case .noSRID:
@@ -515,6 +541,8 @@ extension Coordinate3D: Projectable {
                 var y: Double = log(tan((90.0 + latitude) * Double.pi / 360.0)) / (Double.pi / 180.0)
                 y *= GISTool.originShift / 180.0
                 return y
+            case .epsg4978:
+                return projected(to: .epsg4326).latitudeProjected(to: .epsg3857)
             }
 
         case .epsg4326:
@@ -523,6 +551,26 @@ extension Coordinate3D: Projectable {
                 return latitude
             case .epsg3857:
                 return 180.0 / Double.pi * (2.0 * atan(exp((latitude / GISTool.originShift) * 180.0 * Double.pi / 180.0)) - Double.pi / 2.0)
+            case .epsg4978:
+                let (lat, _, _) = Coordinate3D.ecefToGeodetic(
+                    x: longitude,
+                    y: latitude,
+                    z: altitude ?? 0.0)
+                return lat
+            }
+
+        case .epsg4978:
+            switch projection {
+            case .epsg4978, .noSRID:
+                return latitude
+            case .epsg4326:
+                let (_, y, _) = Coordinate3D.geodeticToEcef(
+                    latitude: latitude,
+                    longitude: longitude,
+                    altitude: altitude ?? 0.0)
+                return y
+            case .epsg3857:
+                return projected(to: .epsg4326).latitudeProjected(to: .epsg4978)
             }
 
         case .noSRID:
@@ -543,6 +591,8 @@ extension Coordinate3D: Projectable {
                 return longitude
             case .epsg4326:
                 return longitude * GISTool.originShift / 180.0
+            case .epsg4978:
+                return projected(to: .epsg4326).longitudeProjected(to: .epsg3857)
             }
 
         case .epsg4326:
@@ -551,11 +601,111 @@ extension Coordinate3D: Projectable {
                 return longitude
             case .epsg3857:
                 return (longitude / GISTool.originShift) * 180.0
+            case .epsg4978:
+                let (_, lon, _) = Coordinate3D.ecefToGeodetic(
+                    x: longitude,
+                    y: latitude,
+                    z: altitude ?? 0.0)
+                return lon
+            }
+
+        case .epsg4978:
+            switch projection {
+            case .epsg4978, .noSRID:
+                return longitude
+            case .epsg4326:
+                let (x, _, _) = Coordinate3D.geodeticToEcef(
+                    latitude: latitude,
+                    longitude: longitude,
+                    altitude: altitude ?? 0.0)
+                return x
+            case .epsg3857:
+                return projected(to: .epsg4326).longitudeProjected(to: .epsg4978)
             }
 
         case .noSRID:
             return longitude
         }
+    }
+
+}
+
+// MARK: - EPSG:4978 (ECEF) Helpers
+
+extension Coordinate3D {
+
+    /// Convert geodetic (EPSG:4326) to geocentric (EPSG:4978) coordinates.
+    ///
+    /// Uses the WGS84 ellipsoid: a = 6,378,137 m, 1/f = 298.257223563.
+    ///
+    /// - Parameters:
+    ///   - latitude: Latitude in degrees
+    ///   - longitude: Longitude in degrees
+    ///   - altitude: Height above ellipsoid in meters
+    /// - Returns: ECEF X, Y, Z in meters
+    fileprivate static func geodeticToEcef(
+        latitude: Double,
+        longitude: Double,
+        altitude: Double
+    ) -> (x: Double, y: Double, z: Double) {
+        let a = GISTool.equatorialRadius
+        let e2 = GISTool.wgs84EccentricitySquared
+
+        let phi = latitude * .pi / 180.0
+        let lambda = longitude * .pi / 180.0
+        let h = altitude
+
+        let sinPhi = sin(phi)
+        let N = a / sqrt(1.0 - e2 * sinPhi * sinPhi)
+
+        let x = (N + h) * cos(phi) * cos(lambda)
+        let y = (N + h) * cos(phi) * sin(lambda)
+        let z = ((1.0 - e2) * N + h) * sinPhi
+
+        return (x, y, z)
+    }
+
+    /// Convert geocentric (EPSG:4978) to geodetic (EPSG:4326) coordinates.
+    ///
+    /// Uses the iterative Bowring method (typically converges in ~3 iterations).
+    ///
+    /// - Parameters:
+    ///   - x: ECEF X in meters
+    ///   - y: ECEF Y in meters
+    ///   - z: ECEF Z in meters
+    /// - Returns: Latitude (degrees), longitude (degrees), altitude (meters)
+    fileprivate static func ecefToGeodetic(
+        x: Double,
+        y: Double,
+        z: Double
+    ) -> (latitude: Double, longitude: Double, altitude: Double) {
+        let a = GISTool.equatorialRadius
+        let e2 = GISTool.wgs84EccentricitySquared
+
+        let p = sqrt(x * x + y * y)
+
+        guard p > 1e-12 else {
+            let lat = z >= 0.0 ? 90.0 : -90.0
+            let h = abs(z) - a * (1.0 - e2)
+            return (lat, 0.0, h)
+        }
+
+        var phi = atan2(z, p * (1.0 - e2))
+        for _ in 0..<10 {
+            let sinPhi = sin(phi)
+            let N = a / sqrt(1.0 - e2 * sinPhi * sinPhi)
+            let h = p / cos(phi) - N
+            phi = atan2(z * (N + h), p * ((1.0 - e2) * N + h))
+        }
+
+        let sinPhi = sin(phi)
+        let N = a / sqrt(1.0 - e2 * sinPhi * sinPhi)
+        let h = p / cos(phi) - N
+
+        let lat = phi * 180.0 / .pi
+        let lon = atan2(y, x) * 180.0 / .pi
+
+        return (lat, lon, h)
     }
 
 }

--- a/Sources/GISTools/GeoJson/Feature.swift
+++ b/Sources/GISTools/GeoJson/Feature.swift
@@ -360,6 +360,13 @@ extension Feature {
         set { self["marker-size"] = newValue }
     }
 
+    /// The marker symbol (a [Maki](https://labs.mapbox.com/maki-icons/) icon name, e.g. `"airport"`, `"cafe"`, `"hospital"`),
+    /// stored under the `"marker-symbol"` property key. Used by geojson.io and MapLibre for point iconography.
+    public var markerSymbol: String? {
+        get { self["marker-symbol"] }
+        set { self["marker-symbol"] = newValue }
+    }
+
     /// The stroke color (hex string, e.g. `"#312E81"`), stored under the `"stroke"` property key.
     /// Used by geojson.io and MapLibre for line/polygon outlines.
     public var stroke: String? {

--- a/Sources/GISTools/GeoJson/Feature.swift
+++ b/Sources/GISTools/GeoJson/Feature.swift
@@ -353,6 +353,13 @@ extension Feature {
         set { self["marker-color"] = newValue }
     }
 
+    /// The marker size (`"small"`, `"medium"`, or `"large"`), stored under the `"marker-size"` property key.
+    /// Used by geojson.io and MapLibre for point symbol sizing.
+    public var markerSize: String? {
+        get { self["marker-size"] }
+        set { self["marker-size"] = newValue }
+    }
+
     /// The stroke color (hex string, e.g. `"#312E81"`), stored under the `"stroke"` property key.
     /// Used by geojson.io and MapLibre for line/polygon outlines.
     public var stroke: String? {

--- a/Sources/GISTools/GeoJson/Feature.swift
+++ b/Sources/GISTools/GeoJson/Feature.swift
@@ -346,6 +346,13 @@ extension Feature {
         set { self["fill-opacity"] = newValue }
     }
 
+    /// The marker color (hex string, e.g. `"#e6194b"`), stored under the `"marker-color"` property key.
+    /// Used by geojson.io and MapLibre for point symbol colours.
+    public var markerColor: String? {
+        get { self["marker-color"] }
+        set { self["marker-color"] = newValue }
+    }
+
     /// The stroke color (hex string, e.g. `"#312E81"`), stored under the `"stroke"` property key.
     /// Used by geojson.io and MapLibre for line/polygon outlines.
     public var stroke: String? {

--- a/Sources/GISTools/GeoJson/FeatureCollection.swift
+++ b/Sources/GISTools/GeoJson/FeatureCollection.swift
@@ -193,7 +193,7 @@ extension FeatureCollection {
     /// - Returns: The calculated bounding box, or `nil` if there are no features
     public func calculateBoundingBox() -> BoundingBox? {
         let featureBoundingBoxes: [BoundingBox] = features.compactMap({ $0.boundingBox ?? $0.calculateBoundingBox() })
-        guard !featureBoundingBoxes.isEmpty else { return nil}
+        guard featureBoundingBoxes.isNotEmpty else { return nil}
 
         return featureBoundingBoxes.reduce(featureBoundingBoxes[0]) { (result, boundingBox) -> BoundingBox in
             return result + boundingBox

--- a/Sources/GISTools/GeoJson/Projection.swift
+++ b/Sources/GISTools/GeoJson/Projection.swift
@@ -35,14 +35,18 @@ public enum Projection:
     /// Initialize a Projection from a WKT projection string (e.g. from a `.prj` file).
     ///
     /// Matches common patterns for the supported projections:
-    /// - EPSG:4326 — `GEOGCS["...WGS 84..."...]` or `GEOGCS["...WGS_1984..."...]`
     /// - EPSG:3857 — `PROJCS["...Mercator..."...]`
+    /// - EPSG:4326 — `GEOGCS["...WGS 84..."...]` or `GEOGCS["...WGS_1984..."...]`
+    /// - EPSG:4978 — `GEOCCS["...WGS 84..."...]` or `GEOCCS["...WGS_1984..."...]`
     ///
     /// - Parameter wkt: A WKT projection string
     /// - Returns: A `Projection`, or `nil` if the string is not recognised
     public init?(wkt: String) {
         if wkt.contains("PROJCS") && wkt.contains("Mercator") {
             self = .epsg3857
+        }
+        else if wkt.contains("GEOCCS") && (wkt.contains("WGS 84") || wkt.contains("WGS_1984")) {
+            self = .epsg4978
         }
         else if wkt.contains("GEOGCS") && (wkt.contains("WGS 84") || wkt.contains("WGS_1984")) {
             self = .epsg4326

--- a/Sources/GISTools/GeoJson/Projection.swift
+++ b/Sources/GISTools/GeoJson/Projection.swift
@@ -13,6 +13,8 @@ public enum Projection:
     case epsg3857 = 3857
     /// EPSG:4326 - geodetic (https://epsg.io/4326).
     case epsg4326 = 4326
+    /// EPSG:4978 - geocentric (ECEF) (https://epsg.io/4978).
+    case epsg4978 = 4978
 
     /// Initialize a Projection with a SRID number.
     ///
@@ -25,6 +27,7 @@ public enum Projection:
         case 0: self = .noSRID
         case 102_100, 102_113, 900_913, 3587, 3785, 3857, 41001, 54004: self = .epsg3857
         case 4326: self = .epsg4326
+        case 4978: self = .epsg4978
         default: return nil
         }
     }
@@ -60,6 +63,7 @@ public enum Projection:
         case .noSRID: return "No SRID"
         case .epsg3857: return "EPSG:3857"
         case .epsg4326: return "EPSG:4326"
+        case .epsg4978: return "EPSG:4978"
         }
     }
 

--- a/Sources/GISTools/GeoJson/ShapefileCoder.swift
+++ b/Sources/GISTools/GeoJson/ShapefileCoder.swift
@@ -4,6 +4,36 @@ import CoreLocation
 #endif
 import Foundation
 
+// MARK: - FeatureCollection convenience extensions
+
+extension FeatureCollection {
+
+    /// Initialize a ``FeatureCollection`` by reading a Shapefile from the given base URL.
+    ///
+    /// Loads `<url>.shp` (required), `<url>.dbf` (required),
+    /// and optionally `<url>.prj` for projection.
+    ///
+    /// - Parameter url: The base URL (may include `.shp` extension)
+    /// - Parameter calculateBoundingBox: Whether to calculate a bounding box (default `false`)
+    public init?(
+        shapefile url: URL,
+        calculateBoundingBox: Bool = false
+    ) {
+        guard let collection = try? ShapefileCoder.read(from: url, calculateBoundingBox: calculateBoundingBox) else { return nil }
+        self = collection
+    }
+
+    /// Write the receiver as a Shapefile to the given base URL.
+    ///
+    /// Writes `<url>.shp`, `<url>.dbf`, and `<url>.prj`.
+    ///
+    /// - Parameter url: The base output URL (without extension)
+    public func writeShapefile(to url: URL) throws {
+        try ShapefileCoder.write(self, to: url)
+    }
+
+}
+
 // MARK: - ShapefileCoder
 
 /// The canonical "no data" value for measure (M) coordinates in Shapefiles.
@@ -166,8 +196,12 @@ extension ShapefileCoder {
     /// and optionally `<url>.prj` for projection.
     ///
     /// - Parameter url: The base URL (without extension) or the full path to the `.shp` file
+    /// - Parameter calculateBoundingBox: Whether to calculate a bounding box (default `false`)
     /// - Returns: A ``FeatureCollection`` with one ``Feature`` per record
-    public static func read(from url: URL) throws -> FeatureCollection {
+    public static func read(
+        from url: URL,
+        calculateBoundingBox: Bool = false
+    ) throws -> FeatureCollection {
         let shpURL = url.pathExtension == "shp" ? url : url.appendingPathExtension("shp")
         let dbfURL = url.pathExtension == "shp"
             ? url.deletingPathExtension().appendingPathExtension("dbf")
@@ -192,13 +226,17 @@ extension ShapefileCoder {
 
         for i in 0..<count {
             if let geometry = geometries[i] {
-                var feature = Feature(geometry)
+                var feature = Feature(geometry, calculateBoundingBox: calculateBoundingBox)
                 feature.properties = properties[i]
                 features.append(feature)
             }
         }
 
-        return FeatureCollection(features)
+        var fc = FeatureCollection(features)
+        if calculateBoundingBox {
+            fc.boundingBox = fc.calculateBoundingBox()
+        }
+        return fc
     }
 
     // MARK: - .shp reading
@@ -1505,32 +1543,6 @@ extension ShapefileCoder {
         case .noSRID:
             return nil
         }
-    }
-
-}
-
-// MARK: - FeatureCollection convenience extensions
-
-extension FeatureCollection {
-
-    /// Initialize a ``FeatureCollection`` by reading a Shapefile from the given base URL.
-    ///
-    /// Loads `<url>.shp` (required), `<url>.dbf` (required),
-    /// and optionally `<url>.prj` for projection.
-    ///
-    /// - Parameter url: The base URL (may include `.shp` extension)
-    public init?(shapefile url: URL) {
-        guard let collection = try? ShapefileCoder.read(from: url) else { return nil }
-        self = collection
-    }
-
-    /// Write the receiver as a Shapefile to the given base URL.
-    ///
-    /// Writes `<url>.shp`, `<url>.dbf`, and `<url>.prj`.
-    ///
-    /// - Parameter url: The base output URL (without extension)
-    public func writeShapefile(to url: URL) throws {
-        try ShapefileCoder.write(self, to: url)
     }
 
 }

--- a/Sources/GISTools/GeoJson/ShapefileCoder.swift
+++ b/Sources/GISTools/GeoJson/ShapefileCoder.swift
@@ -1499,7 +1499,10 @@ extension ShapefileCoder {
         case .epsg3857:
             return #"PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1]]"#
 
-        default:
+        case .epsg4978:
+            return #"GEOCCS["WGS 84 (geocentric)",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["metre",1]]"#
+
+        case .noSRID:
             return nil
         }
     }

--- a/Sources/GISTools/GeoJson/TWKBCoder.swift
+++ b/Sources/GISTools/GeoJson/TWKBCoder.swift
@@ -693,8 +693,8 @@ public enum TWKBCoder {
         switch sourceProjection {
         case .epsg4326:
             return Coordinate3D(latitude: y, longitude: x, altitude: z, m: m)
-        case .epsg3857:
-            return Coordinate3D(x: x, y: y, z: z, m: m)
+        case .epsg3857, .epsg4978:
+            return Coordinate3D(x: x, y: y, z: z, m: m, projection: sourceProjection)
         case .noSRID:
             return Coordinate3D(x: x, y: y, z: z, m: m, projection: sourceProjection)
         }

--- a/Sources/GISTools/GeoJson/WKBCoder.swift
+++ b/Sources/GISTools/GeoJson/WKBCoder.swift
@@ -523,7 +523,7 @@ extension WKBCoder {
         switch sourceProjection {
         case .epsg4326:
             switch targetProjection {
-            case .epsg3857:
+            case .epsg3857, .epsg4978:
                 return Coordinate3D(latitude: y, longitude: x, altitude: z, m: m).projected(to: targetProjection)
             case .epsg4326:
                 return Coordinate3D(latitude: y, longitude: x, altitude: z, m: m)
@@ -535,8 +535,18 @@ extension WKBCoder {
             switch targetProjection {
             case .epsg3857:
                 return Coordinate3D(x: x, y: y, z: z, m: m)
-            case .epsg4326:
+            case .epsg4326, .epsg4978:
                 return Coordinate3D(x: x, y: y, z: z, m: m).projected(to: targetProjection)
+            case .noSRID:
+                return Coordinate3D(x: x, y: y, z: z, m: m, projection: targetProjection)
+            }
+
+        case .epsg4978:
+            switch targetProjection {
+            case .epsg4978:
+                return Coordinate3D(x: x, y: y, z: z, m: m, projection: .epsg4978)
+            case .epsg4326, .epsg3857:
+                return Coordinate3D(x: x, y: y, z: z, m: m, projection: .epsg4978).projected(to: targetProjection)
             case .noSRID:
                 return Coordinate3D(x: x, y: y, z: z, m: m, projection: targetProjection)
             }

--- a/Sources/GISTools/GeoJson/WKTCoder.swift
+++ b/Sources/GISTools/GeoJson/WKTCoder.swift
@@ -642,7 +642,7 @@ extension WKTCoder {
             switch sourceProjection {
             case .epsg4326:
                 switch targetProjection {
-                case .epsg3857:
+                case .epsg3857, .epsg4978:
                     coordinates.append(Coordinate3D(latitude: y, longitude: x, altitude: z, m: m).projected(to: targetProjection))
                 case .epsg4326:
                     coordinates.append(Coordinate3D(latitude: y, longitude: x, altitude: z, m: m))
@@ -654,8 +654,18 @@ extension WKTCoder {
                 switch targetProjection {
                 case .epsg3857:
                     coordinates.append(Coordinate3D(x: x, y: y, z: z, m: m))
-                case .epsg4326:
+                case .epsg4326, .epsg4978:
                     coordinates.append(Coordinate3D(x: x, y: y, z: z, m: m).projected(to: targetProjection))
+                case .noSRID:
+                    coordinates.append(Coordinate3D(x: x, y: y, z: z, m: m, projection: targetProjection))
+                }
+
+            case .epsg4978:
+                switch targetProjection {
+                case .epsg4978:
+                    coordinates.append(Coordinate3D(x: x, y: y, z: z, m: m, projection: .epsg4978))
+                case .epsg4326, .epsg3857:
+                    coordinates.append(Coordinate3D(x: x, y: y, z: z, m: m, projection: .epsg4978).projected(to: targetProjection))
                 case .noSRID:
                     coordinates.append(Coordinate3D(x: x, y: y, z: z, m: m, projection: targetProjection))
                 }

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -203,4 +203,81 @@ struct ClustersTests {
         #expect(c0 != c2)
     }
 
+    // MARK: - Weighted K-means
+
+    /// Validates weighted K-means shifts centroids toward higher-weight points.
+    @Test
+    func kmeansWeighted() async throws {
+        var f1 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)))
+        f1.properties = ["weight": 100.0]
+        var f2 = Feature(Point(Coordinate3D(latitude: 0.1, longitude: 0.0)))
+        f2.properties = ["weight": 1.0]
+        var f3 = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
+        f3.properties = ["weight": 100.0]
+        var f4 = Feature(Point(Coordinate3D(latitude: 10.1, longitude: 10.0)))
+        f4.properties = ["weight": 1.0]
+        let points = [f1, f2, f3, f4]
+        let fc = FeatureCollection(points)
+        let result = fc.kmeansClusters(numberOfClusters: 2, weightAttribute: "weight")
+
+        for feature in result.features {
+            let c: Int? = feature.property(for: "cluster")
+            #expect(c != nil)
+        }
+        let c0: Int? = result.features[0].property(for: "cluster")
+        let c1: Int? = result.features[1].property(for: "cluster")
+        let c2: Int? = result.features[2].property(for: "cluster")
+        #expect(c0 != nil && c1 != nil && c2 != nil)
+        #expect(c0 == c1) // both heavy points in same cluster
+        #expect(c0 != c2)
+    }
+
+    /// Validates weighted K-means with EPSG:3857.
+    @Test
+    func kmeansWeightedEpsg3857() async throws {
+        var f1 = Feature(Point(Coordinate3D(x: 0.0, y: 0.0, projection: .epsg3857)))
+        f1.properties = ["pop": 1000.0]
+        var f2 = Feature(Point(Coordinate3D(x: 100.0, y: 0.0, projection: .epsg3857)))
+        f2.properties = ["pop": 1.0]
+        var f3 = Feature(Point(Coordinate3D(x: 100_000.0, y: 100_000.0, projection: .epsg3857)))
+        f3.properties = ["pop": 1000.0]
+        var f4 = Feature(Point(Coordinate3D(x: 100_100.0, y: 100_000.0, projection: .epsg3857)))
+        f4.properties = ["pop": 1.0]
+        let points = [f1, f2, f3, f4]
+        let fc = FeatureCollection(points)
+        let result = fc.kmeansClusters(numberOfClusters: 2, weightAttribute: "pop")
+
+        for feature in result.features {
+            let c: Int? = feature.property(for: "cluster")
+            #expect(c != nil)
+        }
+        let c0: Int? = result.features[0].property(for: "cluster")
+        let c2: Int? = result.features[2].property(for: "cluster")
+        #expect(c0 != c2)
+    }
+
+    /// Validates weighted K-means with EPSG:4978 (ECEF).
+    @Test
+    func kmeansWeightedEpsg4978() async throws {
+        var f1 = Feature(Point(Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
+        f1.properties = ["pop": 1000.0]
+        var f2 = Feature(Point(Coordinate3D(x: 6_378_237.0, y: 0.0, z: 0.0, projection: .epsg4978)))
+        f2.properties = ["pop": 1.0]
+        var f3 = Feature(Point(Coordinate3D(x: 0.0, y: 6_378_137.0, z: 0.0, projection: .epsg4978)))
+        f3.properties = ["pop": 1000.0]
+        var f4 = Feature(Point(Coordinate3D(x: 0.0, y: 6_378_237.0, z: 0.0, projection: .epsg4978)))
+        f4.properties = ["pop": 1.0]
+        let points = [f1, f2, f3, f4]
+        let fc = FeatureCollection(points)
+        let result = fc.kmeansClusters(numberOfClusters: 2, weightAttribute: "pop")
+
+        for feature in result.features {
+            let c: Int? = feature.property(for: "cluster")
+            #expect(c != nil)
+        }
+        let c0: Int? = result.features[0].property(for: "cluster")
+        let c2: Int? = result.features[2].property(for: "cluster")
+        #expect(c0 != c2)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -280,6 +280,104 @@ struct ClustersTests {
         #expect(c0 != c2)
     }
 
+    // MARK: - Algorithm comparison
+
+    /// Tests a scenario where DBSCAN, K-means, and weighted K-means all produce
+    /// measurably different results on the same data.
+    ///
+    /// Data: two dense clusters (A near origin, B near (10,0)), an outlier at (20,20),
+    /// and one point in cluster A with extreme weight (1000).
+    ///
+    /// Expected behaviour:
+    /// - DBSCAN: marks the outlier as noise, forms two clusters
+    /// - K-means: assigns every point (no noise), centroid of cluster A is
+    ///   the arithmetic mean of its members
+    /// - Weighted K-means: centroid of cluster A is pulled toward the heavy point
+    @Test
+    func compareAlgorithms() async throws {
+        var points: [Feature] = []
+        // Cluster A (4 points, centroid ≈ (0.5, 0.25))
+        points.append(Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0))))
+        points.append(Feature(Point(Coordinate3D(latitude: 1.0, longitude: 0.0))))
+        points.append(Feature(Point(Coordinate3D(latitude: 0.0, longitude: 1.0))))
+        points.append(Feature(Point(Coordinate3D(latitude: 1.0, longitude: 1.0))))
+        // Cluster B (4 points, centroid ≈ (10.5, 0.25))
+        points.append(Feature(Point(Coordinate3D(latitude: 10.0, longitude: 0.0))))
+        points.append(Feature(Point(Coordinate3D(latitude: 11.0, longitude: 0.0))))
+        points.append(Feature(Point(Coordinate3D(latitude: 10.0, longitude: 1.0))))
+        points.append(Feature(Point(Coordinate3D(latitude: 11.0, longitude: 1.0))))
+        // Noise — too far from any cluster for DBSCAN
+        points.append(Feature(Point(Coordinate3D(latitude: 20.0, longitude: 20.0))))
+
+        var weighted = points
+        weighted[0].properties["weight"] = 1000.0
+
+        let fc = FeatureCollection(points)
+        let wfc = FeatureCollection(weighted)
+
+        // ---- DBSCAN ----
+        // maxDistance=200km (~2° at the equator), minPts=3: each density-connected point needs ≥3 neighbors
+        let dbscan = fc.dbscanClusters(maxDistance: 200_000.0, minPoints: 3)
+        let dbscanClusters: Set<Int> = Set(dbscan.features.compactMap { $0.property(for: "cluster") })
+        let dbscanNoise: [String] = dbscan.features.compactMap { $0.property(for: "dbscan") }
+        #expect(dbscanClusters.count == 2)
+        #expect(dbscanNoise.filter { $0 == "noise" }.count == 1)
+
+        // ---- K-means ----
+        // Every point is assigned, including the outlier
+        let km = fc.kmeansClusters(numberOfClusters: 2)
+        let kmClusters: Set<Int> = Set(km.features.compactMap { $0.property(for: "cluster") })
+        #expect(kmClusters.count == 2)
+        #expect(km.features.count == 9)
+
+        // First point (0,0) is in cluster A; its centroid[ ] = [lon, lat]
+        let kmCentroid: [Double]? = km.features[0].property(for: "centroid")
+        if let centroidA = kmCentroid {
+            // Arithmetic mean of (0,0), (1,0), (0,1), (1,1) → (0.5, 0.5)
+            #expect(abs(centroidA[0] - 0.5) < 0.1)  // X / longitude
+            #expect(abs(centroidA[1] - 0.5) < 0.1)  // Y / latitude
+        }
+
+        // ---- Weighted K-means ----
+        // The heavy weight (1000) on (0,0) pulls its centroid toward the origin
+        let wkm = wfc.kmeansClusters(numberOfClusters: 2, weightAttribute: "weight")
+        let wkmCentroid: [Double]? = wkm.features[0].property(for: "centroid")
+
+        if let centroidW = wkmCentroid {
+            // Weighted centroid ≈ (0.001, 0.001) — almost exactly at (0,0)
+            #expect(abs(centroidW[0]) < 0.05)
+            #expect(abs(centroidW[1]) < 0.05)
+        }
+
+        // ---- Weighted centroid differs from unweighted ----
+        if let cA = kmCentroid, let cW = wkmCentroid {
+            let dx = cA[0] - cW[0]
+            let dy = cA[1] - cW[1]
+            #expect(sqrt(dx * dx + dy * dy) > 0.1)
+        }
+
+        // Uncomment to write per-cluster GeoJSON files for debugging:
+//        let debugDir = URL(fileURLWithPath: "/tmp/cluster_debug")
+//        try? FileManager.default.createDirectory(at: debugDir, withIntermediateDirectories: true)
+//        let palette = ["#e6194b", "#3cb44b", "#4363d8", "#f58231", "#911eb4"]
+//        func colorByCluster(_ fc: FeatureCollection) -> FeatureCollection {
+//            var features = fc.features
+//            for i in features.indices {
+//                let clusterId: Int? = features[i].property(for: "cluster")
+//                let color = palette[(clusterId ?? 0) % palette.count]
+//                features[i].markerColor = color
+//            }
+//            return FeatureCollection(features)
+//        }
+//        func writeCluster(_ name: String, _ fc: FeatureCollection) {
+//            guard let data = try? JSONEncoder().encode(colorByCluster(fc)) else { return }
+//            try? data.write(to: debugDir.appendingPathComponent("\(name).geojson"))
+//        }
+//        writeCluster("dbscan_all", dbscan)
+//        writeCluster("kmeans_all", km)
+//        writeCluster("kmeans_weighted_all", wkm)
+    }
+
     // MARK: - Natural Earth clustering (disabled, requires shapefile trait)
 
     /// Reads the Natural Earth shapefile, runs K-means and DBSCAN (k=10) on each

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -314,10 +314,7 @@ struct ClustersTests {
             for i in 0..<kcFeatures.count {
                 let clusterId: Int? = kcFeatures[i].property(for: "cluster")
                 let color = palette[(clusterId ?? 0) % palette.count]
-                kcFeatures[i].setProperty(color, for: "fill")
-                kcFeatures[i].setProperty(0.4, for: "fill-opacity")
-                kcFeatures[i].setProperty(color, for: "stroke")
-                kcFeatures[i].setProperty(1.0, for: "stroke-width")
+                kcFeatures[i].markerColor = color
             }
             let kcColored = FeatureCollection(kcFeatures)
             let kmPath = outputDir.appendingPathComponent("kmeans_EPSG\(label).geojson")
@@ -331,10 +328,7 @@ struct ClustersTests {
             for i in 0..<kwFeatures.count {
                 let clusterId: Int? = kwFeatures[i].property(for: "cluster")
                 let color = palette[(clusterId ?? 0) % palette.count]
-                kwFeatures[i].setProperty(color, for: "fill")
-                kwFeatures[i].setProperty(0.4, for: "fill-opacity")
-                kwFeatures[i].setProperty(color, for: "stroke")
-                kwFeatures[i].setProperty(1.0, for: "stroke-width")
+                kwFeatures[i].markerColor = color
             }
             let kwColored = FeatureCollection(kwFeatures)
             let kwPath = outputDir.appendingPathComponent("kmeans_weighted_popmax_EPSG\(label).geojson")
@@ -349,17 +343,11 @@ struct ClustersTests {
                 let clusterId: Int? = dcFeatures[i].property(for: "cluster")
                 let dbscan: String? = dcFeatures[i].property(for: "dbscan")
                 if dbscan == "noise" {
-                    dcFeatures[i].setProperty("#cccccc", for: "fill")
-                    dcFeatures[i].setProperty(0.2, for: "fill-opacity")
-                    dcFeatures[i].setProperty("#999999", for: "stroke")
-                    dcFeatures[i].setProperty(0.5, for: "stroke-width")
+                    dcFeatures[i].markerColor = "#cccccc"
                 }
                 else if let clusterId {
                     let color = palette[clusterId % palette.count]
-                    dcFeatures[i].setProperty(color, for: "fill")
-                    dcFeatures[i].setProperty(0.4, for: "fill-opacity")
-                    dcFeatures[i].setProperty(color, for: "stroke")
-                    dcFeatures[i].setProperty(1.0, for: "stroke-width")
+                    dcFeatures[i].markerColor = color
                 }
             }
             let dcColored = FeatureCollection(dcFeatures)

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -559,3 +559,134 @@ struct ClustersTests {
     }
 
 }
+
+// MARK: - Performance benchmarks
+
+@Suite
+struct ClusterBenchmarks {
+
+    private static let iterations: Int = 5
+
+    private static let performanceInput100: [Feature] = {
+        BoundingBox.randomPoints(count: 100).features
+    }()
+
+    private static let performanceInput500: [Feature] = {
+        BoundingBox.randomPoints(count: 500).features
+    }()
+
+    private static let performanceInputWeighted500: [Feature] = {
+        BoundingBox.randomPoints(count: 500).features.map { f in
+            var f = f
+            f.properties["pop"] = Double.random(in: 1_000 ... 10_000_000)
+            return f
+        }
+    }()
+
+    private static func measure(_ name: String, _ block: () -> Void) {
+        let clock = ContinuousClock()
+        block() // warmup
+
+        var durations: [Duration] = []
+        durations.reserveCapacity(iterations)
+        for _ in 0..<iterations {
+            let start = clock.now
+            block()
+            durations.append(clock.now - start)
+        }
+
+        let sorted = durations.sorted()
+        let minMs = _milliseconds(sorted.first ?? .zero)
+        let medianMs = _milliseconds(sorted[sorted.count / 2])
+        let averageMs = durations.reduce(0.0) { $0 + _milliseconds($1) } / Double(iterations)
+        print("[ClusterBenchmark] \(name): min=\(_format(minMs))ms median=\(_format(medianMs))ms avg=\(_format(averageMs))ms")
+    }
+
+    private static func _milliseconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds) * 1_000.0 + Double(components.attoseconds) / 1e15
+    }
+
+    private static func _format(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    // MARK: - K-means benchmarks
+
+    @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
+    func performanceKmeans100() {
+        let fc = FeatureCollection(Self.performanceInput100)
+        Self.measure("K-means/100") {
+            _ = fc.kmeansClusters(numberOfClusters: 5)
+        }
+    }
+
+    @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
+    func performanceKmeans500() {
+        let fc = FeatureCollection(Self.performanceInput500)
+        Self.measure("K-means/500") {
+            _ = fc.kmeansClusters(numberOfClusters: 10)
+        }
+    }
+
+    @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
+    func performanceWeightedKmeans500() {
+        let fc = FeatureCollection(Self.performanceInputWeighted500)
+        Self.measure("K-means/weighted-500") {
+            _ = fc.kmeansClusters(numberOfClusters: 10, weightAttribute: "pop")
+        }
+    }
+
+    // MARK: - DBSCAN benchmarks
+
+    @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
+    func performanceDbscan100() {
+        let fc = FeatureCollection(Self.performanceInput100)
+        Self.measure("DBSCAN/100") {
+            _ = fc.dbscanClusters(maxDistance: 200_000.0, minPoints: 3)
+        }
+    }
+
+    @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
+    func performanceDbscan500() {
+        let fc = FeatureCollection(Self.performanceInput500)
+        Self.measure("DBSCAN/500") {
+            _ = fc.dbscanClusters(maxDistance: 200_000.0, minPoints: 3)
+        }
+    }
+
+    // MARK: - Natural Earth benchmarks (requires shapefile trait)
+
+    #if EnableShapefileSupport
+    @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
+    func performanceNaturalEarthKmeans() {
+        let url = TestData.shapefileUrl(package: "Shapefiles", name: "ne_10m_populated_places_simple")
+        guard let fc = FeatureCollection(shapefile: url) else { return }
+
+        Self.measure("NE/K-means/7342") {
+            _ = fc.kmeansClusters(numberOfClusters: 10)
+        }
+    }
+
+    @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
+    func performanceNaturalEarthWeightedKmeans() {
+        let url = TestData.shapefileUrl(package: "Shapefiles", name: "ne_10m_populated_places_simple")
+        guard let fc = FeatureCollection(shapefile: url) else { return }
+
+        Self.measure("NE/K-means-weighted/7342") {
+            _ = fc.kmeansClusters(numberOfClusters: 10, weightAttribute: "pop_max")
+        }
+    }
+
+    @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
+    func performanceNaturalEarthDbscan() {
+        let url = TestData.shapefileUrl(package: "Shapefiles", name: "ne_10m_populated_places_simple")
+        guard let fc = FeatureCollection(shapefile: url) else { return }
+
+        Self.measure("NE/DBSCAN/7342") {
+            _ = fc.dbscanClusters(maxDistance: 100_000.0, minPoints: 3)
+        }
+    }
+    #endif
+
+}

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -443,6 +443,27 @@ struct ClustersTests {
         #expect(c1wkm != wkm.features[0].property(for: "cluster")) // weighted: flips
     }
 
+    /// Confirms that weighted K-means accepts both `Int` and `Double` property values as weights.
+    @Test
+    func weightedKmeansMixedIntDoubleWeights() async throws {
+        // Some properties with Int values, some with Double — as happens with DBF read-back
+        var p0 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)))
+        var p1 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 9.0)))
+        var p2 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 10.0)))
+        var p3 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 19.0)))
+        p0.properties["w"] = 10_000    // Int
+        p1.properties["w"] = 1.0        // Double
+        p2.properties["w"] = 1          // Int
+        p3.properties["w"] = 1.0        // Double
+
+        let wkm = FeatureCollection([p0, p1, p2, p3]).kmeansClusters(
+            numberOfClusters: 2, weightAttribute: "w", seedIndex: 1)
+
+        let c0: Int? = wkm.features[0].property(for: "cluster")
+        let c1: Int? = wkm.features[1].property(for: "cluster")
+        #expect(c0 != c1)  // (9,0) flips away from heavy (0,0) — same as pure-Double test
+    }
+
     // MARK: - Natural Earth clustering (disabled, requires shapefile trait)
 
     /// Reads the Natural Earth shapefile, runs K-means and DBSCAN (k=10) on each

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -473,7 +473,7 @@ struct ClustersTests {
     func clusterNaturalEarth() async throws {
         #if EnableShapefileSupport
         let url = TestData.shapefileUrl(package: "Shapefiles", name: "ne_10m_populated_places_simple")
-        let fc = try ShapefileCoder.read(from: url)
+        let fc = try ShapefileCoder.read(from: url, calculateBoundingBox: true)
 
         let palette = [
             "#e6194b", "#3cb44b", "#ffe119", "#4363d8", "#f58231",
@@ -661,7 +661,7 @@ struct ClusterBenchmarks {
     @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
     func performanceNaturalEarthKmeans() {
         let url = TestData.shapefileUrl(package: "Shapefiles", name: "ne_10m_populated_places_simple")
-        guard let fc = FeatureCollection(shapefile: url) else { return }
+        guard let fc = FeatureCollection(shapefile: url, calculateBoundingBox: true) else { return }
 
         Self.measure("NE/K-means/7342") {
             _ = fc.kmeansClusters(numberOfClusters: 10)
@@ -671,7 +671,7 @@ struct ClusterBenchmarks {
     @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
     func performanceNaturalEarthWeightedKmeans() {
         let url = TestData.shapefileUrl(package: "Shapefiles", name: "ne_10m_populated_places_simple")
-        guard let fc = FeatureCollection(shapefile: url) else { return }
+        guard let fc = FeatureCollection(shapefile: url, calculateBoundingBox: true) else { return }
 
         Self.measure("NE/K-means-weighted/7342") {
             _ = fc.kmeansClusters(numberOfClusters: 10, weightAttribute: "pop_max")
@@ -681,7 +681,7 @@ struct ClusterBenchmarks {
     @Test(.disabled(if: CIHelper.isRunningInCI, "Skipping performance test in CI"))
     func performanceNaturalEarthDbscan() {
         let url = TestData.shapefileUrl(package: "Shapefiles", name: "ne_10m_populated_places_simple")
-        guard let fc = FeatureCollection(shapefile: url) else { return }
+        guard let fc = FeatureCollection(shapefile: url, calculateBoundingBox: true) else { return }
 
         Self.measure("NE/DBSCAN/7342") {
             _ = fc.dbscanClusters(maxDistance: 100_000.0, minPoints: 3)

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -378,6 +378,71 @@ struct ClustersTests {
 //        writeCluster("kmeans_weighted_all", wkm)
     }
 
+    /// Weighted K-means changes cluster assignment (EPSG:4326).
+    /// Without weights, points {0,9} form one cluster and {10,19} the other.
+    /// A weight of 10 000 on (0,0) pulls that centroid so far left that point (9,0)
+    /// switches to the other cluster.
+    @Test
+    func weightedKmeansChangesAssignmentEpsg4326() async throws {
+        var p0 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)))
+        var p1 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 9.0)))
+        var p2 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 10.0)))
+        var p3 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 19.0)))
+        p0.properties["w"] = 10_000.0
+        let points = [p0, p1, p2, p3]
+        let wPoints = [p0, p1, p2, p3]
+
+        // seedIndex=1 so initial centroids are (9,0) and (10,0) — one per intended cluster
+        let km = FeatureCollection(points).kmeansClusters(numberOfClusters: 2, seedIndex: 1)
+        let wkm = FeatureCollection(wPoints).kmeansClusters(numberOfClusters: 2, weightAttribute: "w", seedIndex: 1)
+
+        let c0km: Int? = km.features[0].property(for: "cluster")   // (0,0)
+        let c1km: Int? = km.features[1].property(for: "cluster")   // (9,0)
+        let c0wkm: Int? = wkm.features[0].property(for: "cluster") // (0,0)
+        let c1wkm: Int? = wkm.features[1].property(for: "cluster") // (9,0)
+
+        #expect(c0km == c1km)    // unweighted: (0,0) and (9,0) in the same cluster
+        #expect(c0wkm != c1wkm)  // weighted: (9,0) flips to the other cluster
+    }
+
+    /// Weighted K-means changes cluster assignment (EPSG:3857, meters).
+    @Test
+    func weightedKmeansChangesAssignmentEpsg3857() async throws {
+        var p0 = Feature(Point(Coordinate3D(x: 0.0, y: 0.0, projection: .epsg3857)))
+        var p1 = Feature(Point(Coordinate3D(x: 9000.0, y: 0.0, projection: .epsg3857)))
+        var p2 = Feature(Point(Coordinate3D(x: 10_000.0, y: 0.0, projection: .epsg3857)))
+        var p3 = Feature(Point(Coordinate3D(x: 19_000.0, y: 0.0, projection: .epsg3857)))
+        p0.properties["w"] = 10_000.0
+        let points = [p0, p1, p2, p3]
+
+        let km = FeatureCollection(points).kmeansClusters(numberOfClusters: 2, seedIndex: 1)
+        let wkm = FeatureCollection(points).kmeansClusters(numberOfClusters: 2, weightAttribute: "w", seedIndex: 1)
+
+        let c1km: Int? = km.features[1].property(for: "cluster")
+        let c1wkm: Int? = wkm.features[1].property(for: "cluster")
+        #expect(c1km == km.features[0].property(for: "cluster"))  // (9k,0) with (0,0) → same cluster
+        #expect(c1wkm != wkm.features[0].property(for: "cluster")) // (9k,0) flips away
+    }
+
+    /// Weighted K-means changes cluster assignment (EPSG:4978, ECEF meters).
+    @Test
+    func weightedKmeansChangesAssignmentEpsg4978() async throws {
+        var p0 = Feature(Point(Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
+        var p1 = Feature(Point(Coordinate3D(x: 6_387_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
+        var p2 = Feature(Point(Coordinate3D(x: 6_388_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
+        var p3 = Feature(Point(Coordinate3D(x: 6_397_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
+        p0.properties["w"] = 10_000.0
+        let points = [p0, p1, p2, p3]
+
+        let km = FeatureCollection(points).kmeansClusters(numberOfClusters: 2, seedIndex: 1)
+        let wkm = FeatureCollection(points).kmeansClusters(numberOfClusters: 2, weightAttribute: "w", seedIndex: 1)
+
+        let c1km: Int? = km.features[1].property(for: "cluster")
+        let c1wkm: Int? = wkm.features[1].property(for: "cluster")
+        #expect(c1km == km.features[0].property(for: "cluster"))  // unweighted: together
+        #expect(c1wkm != wkm.features[0].property(for: "cluster")) // weighted: flips
+    }
+
     // MARK: - Natural Earth clustering (disabled, requires shapefile trait)
 
     /// Reads the Natural Earth shapefile, runs K-means and DBSCAN (k=10) on each

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -468,6 +468,17 @@ struct ClustersTests {
             (.epsg4978, "4978"),
         ]
 
+        // Strip to only what geojson.io needs: marker colour + cluster info
+        func stripToStyling(_ features: [Feature]) -> [Feature] {
+            features.map { f in
+                var s = Feature((f.geometry as? Point)!, id: nil, properties: [:])
+                s.properties["marker-color"] = f.properties["marker-color"]
+                s.properties["cluster"] = f.properties["cluster"]
+                s.properties["dbscan"] = f.properties["dbscan"]
+                return s
+            }
+        }
+
         for (projection, label) in projections {
             let projected = projection == .epsg4326 ? fc : fc.projected(to: projection)
 
@@ -479,7 +490,7 @@ struct ClustersTests {
                 let color = palette[(clusterId ?? 0) % palette.count]
                 kcFeatures[i].markerColor = color
             }
-            let kcColored = FeatureCollection(kcFeatures)
+            let kcColored = FeatureCollection(stripToStyling(kcFeatures))
             let kmPath = outputDir.appendingPathComponent("kmeans_EPSG\(label).geojson")
             if let kmData = try? JSONEncoder().encode(kcColored) {
                 try kmData.write(to: kmPath)
@@ -493,7 +504,7 @@ struct ClustersTests {
                 let color = palette[(clusterId ?? 0) % palette.count]
                 kwFeatures[i].markerColor = color
             }
-            let kwColored = FeatureCollection(kwFeatures)
+            let kwColored = FeatureCollection(stripToStyling(kwFeatures))
             let kwPath = outputDir.appendingPathComponent("kmeans_weighted_popmax_EPSG\(label).geojson")
             if let kwData = try? JSONEncoder().encode(kwColored) {
                 try kwData.write(to: kwPath)
@@ -513,7 +524,7 @@ struct ClustersTests {
                     dcFeatures[i].markerColor = color
                 }
             }
-            let dcColored = FeatureCollection(dcFeatures)
+            let dcColored = FeatureCollection(stripToStyling(dcFeatures))
             let dbPath = outputDir.appendingPathComponent("dbscan_EPSG\(label).geojson")
             if let dbData = try? JSONEncoder().encode(dcColored) {
                 try dbData.write(to: dbPath)

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -385,9 +385,9 @@ struct ClustersTests {
     @Test
     func weightedKmeansChangesAssignmentEpsg4326() async throws {
         var p0 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)))
-        var p1 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 9.0)))
-        var p2 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 10.0)))
-        var p3 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 19.0)))
+        let p1 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 9.0)))
+        let p2 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 10.0)))
+        let p3 = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 19.0)))
         p0.properties["w"] = 10_000.0
         let points = [p0, p1, p2, p3]
         let wPoints = [p0, p1, p2, p3]
@@ -409,9 +409,9 @@ struct ClustersTests {
     @Test
     func weightedKmeansChangesAssignmentEpsg3857() async throws {
         var p0 = Feature(Point(Coordinate3D(x: 0.0, y: 0.0, projection: .epsg3857)))
-        var p1 = Feature(Point(Coordinate3D(x: 9000.0, y: 0.0, projection: .epsg3857)))
-        var p2 = Feature(Point(Coordinate3D(x: 10_000.0, y: 0.0, projection: .epsg3857)))
-        var p3 = Feature(Point(Coordinate3D(x: 19_000.0, y: 0.0, projection: .epsg3857)))
+        let p1 = Feature(Point(Coordinate3D(x: 9000.0, y: 0.0, projection: .epsg3857)))
+        let p2 = Feature(Point(Coordinate3D(x: 10_000.0, y: 0.0, projection: .epsg3857)))
+        let p3 = Feature(Point(Coordinate3D(x: 19_000.0, y: 0.0, projection: .epsg3857)))
         p0.properties["w"] = 10_000.0
         let points = [p0, p1, p2, p3]
 
@@ -428,9 +428,9 @@ struct ClustersTests {
     @Test
     func weightedKmeansChangesAssignmentEpsg4978() async throws {
         var p0 = Feature(Point(Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
-        var p1 = Feature(Point(Coordinate3D(x: 6_387_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
-        var p2 = Feature(Point(Coordinate3D(x: 6_388_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
-        var p3 = Feature(Point(Coordinate3D(x: 6_397_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
+        let p1 = Feature(Point(Coordinate3D(x: 6_387_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
+        let p2 = Feature(Point(Coordinate3D(x: 6_388_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
+        let p3 = Feature(Point(Coordinate3D(x: 6_397_137.0, y: 0.0, z: 0.0, projection: .epsg4978)))
         p0.properties["w"] = 10_000.0
         let points = [p0, p1, p2, p3]
 

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -280,4 +280,99 @@ struct ClustersTests {
         #expect(c0 != c2)
     }
 
+    // MARK: - Natural Earth clustering (disabled, requires shapefile trait)
+
+    /// Reads the Natural Earth shapefile, runs K-means and DBSCAN (k=10) on each
+    /// supported projection, colours features by cluster, and writes GeoJSONs to
+    /// `/tmp/natural_earth_clusters/`.
+    @Test(.disabled("Enable to regenerate cluster GeoJSONs"))
+    func clusterNaturalEarth() async throws {
+        #if EnableShapefileSupport
+        let url = TestData.shapefileUrl(package: "Shapefiles", name: "ne_10m_populated_places_simple")
+        let fc = try ShapefileCoder.read(from: url)
+
+        let palette = [
+            "#e6194b", "#3cb44b", "#ffe119", "#4363d8", "#f58231",
+            "#911eb4", "#42d4f4", "#f032e6", "#bfef45", "#fabed4",
+        ]
+
+        let outputDir = URL(fileURLWithPath: "/tmp/natural_earth_clusters")
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+
+        let projections: [(Projection, String)] = [
+            (.epsg4326, "4326"),
+            (.epsg3857, "3857"),
+            (.epsg4978, "4978"),
+        ]
+
+        for (projection, label) in projections {
+            let projected = projection == .epsg4326 ? fc : fc.projected(to: projection)
+
+            // K-means
+            let kc = projected.kmeansClusters(numberOfClusters: 10)
+            var kcFeatures = kc.features
+            for i in 0..<kcFeatures.count {
+                let clusterId: Int? = kcFeatures[i].property(for: "cluster")
+                let color = palette[(clusterId ?? 0) % palette.count]
+                kcFeatures[i].setProperty(color, for: "fill")
+                kcFeatures[i].setProperty(0.4, for: "fill-opacity")
+                kcFeatures[i].setProperty(color, for: "stroke")
+                kcFeatures[i].setProperty(1.0, for: "stroke-width")
+            }
+            let kcColored = FeatureCollection(kcFeatures)
+            let kmPath = outputDir.appendingPathComponent("kmeans_EPSG\(label).geojson")
+            if let kmData = try? JSONEncoder().encode(kcColored) {
+                try kmData.write(to: kmPath)
+            }
+
+            // Weighted K-means (by population)
+            let kw = projected.kmeansClusters(numberOfClusters: 10, weightAttribute: "pop_max")
+            var kwFeatures = kw.features
+            for i in 0..<kwFeatures.count {
+                let clusterId: Int? = kwFeatures[i].property(for: "cluster")
+                let color = palette[(clusterId ?? 0) % palette.count]
+                kwFeatures[i].setProperty(color, for: "fill")
+                kwFeatures[i].setProperty(0.4, for: "fill-opacity")
+                kwFeatures[i].setProperty(color, for: "stroke")
+                kwFeatures[i].setProperty(1.0, for: "stroke-width")
+            }
+            let kwColored = FeatureCollection(kwFeatures)
+            let kwPath = outputDir.appendingPathComponent("kmeans_weighted_popmax_EPSG\(label).geojson")
+            if let kwData = try? JSONEncoder().encode(kwColored) {
+                try kwData.write(to: kwPath)
+            }
+
+            // DBSCAN
+            let dc = projected.dbscanClusters(maxDistance: 100_000.0, minPoints: 3)
+            var dcFeatures = dc.features
+            for i in 0..<dcFeatures.count {
+                let clusterId: Int? = dcFeatures[i].property(for: "cluster")
+                let dbscan: String? = dcFeatures[i].property(for: "dbscan")
+                if dbscan == "noise" {
+                    dcFeatures[i].setProperty("#cccccc", for: "fill")
+                    dcFeatures[i].setProperty(0.2, for: "fill-opacity")
+                    dcFeatures[i].setProperty("#999999", for: "stroke")
+                    dcFeatures[i].setProperty(0.5, for: "stroke-width")
+                }
+                else if let clusterId {
+                    let color = palette[clusterId % palette.count]
+                    dcFeatures[i].setProperty(color, for: "fill")
+                    dcFeatures[i].setProperty(0.4, for: "fill-opacity")
+                    dcFeatures[i].setProperty(color, for: "stroke")
+                    dcFeatures[i].setProperty(1.0, for: "stroke-width")
+                }
+            }
+            let dcColored = FeatureCollection(dcFeatures)
+            let dbPath = outputDir.appendingPathComponent("dbscan_EPSG\(label).geojson")
+            if let dbData = try? JSONEncoder().encode(dcColored) {
+                try dbData.write(to: dbPath)
+            }
+
+            print("Wrote EPSG:\(label) results to \(outputDir.path)")
+        }
+        #else
+        print("Skipping — EnableShapefileSupport trait is not enabled")
+        #endif
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/ClustersTests.swift
+++ b/Tests/GISToolsTests/Algorithms/ClustersTests.swift
@@ -118,4 +118,89 @@ struct ClustersTests {
         #expect(clustered.features.isNotEmpty)
     }
 
+    // MARK: - Projection-specific
+
+    /// Validates DBSCAN clustering works with EPSG:3857 (Web Mercator).
+    @Test
+    func dbscanEpsg3857() async throws {
+        // Two clusters ~1 km apart in projected meters
+        let points: [Feature] = [
+            Feature(Point(Coordinate3D(x: 0.0, y: 0.0, projection: .epsg3857))),
+            Feature(Point(Coordinate3D(x: 500.0, y: 0.0, projection: .epsg3857))),
+            Feature(Point(Coordinate3D(x: 0.0, y: 500.0, projection: .epsg3857))),
+            Feature(Point(Coordinate3D(x: 100_000.0, y: 100_000.0, projection: .epsg3857))),
+            Feature(Point(Coordinate3D(x: 100_500.0, y: 100_000.0, projection: .epsg3857))),
+            Feature(Point(Coordinate3D(x: 100_000.0, y: 100_500.0, projection: .epsg3857))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.dbscanClusters(maxDistance: 1000.0, minPoints: 2)
+
+        let c0: Int? = result.features[0].property(for: "cluster")
+        let c1: Int? = result.features[3].property(for: "cluster")
+        #expect(c0 != nil)
+        #expect(c1 != nil)
+        #expect(c0 != c1)
+    }
+
+    /// Validates K-means clustering works with EPSG:3857 (Web Mercator).
+    @Test
+    func kmeansEpsg3857() async throws {
+        let points: [Feature] = [
+            Feature(Point(Coordinate3D(x: 0.0, y: 0.0, projection: .epsg3857))),
+            Feature(Point(Coordinate3D(x: 1000.0, y: 0.0, projection: .epsg3857))),
+            Feature(Point(Coordinate3D(x: 100_000.0, y: 100_000.0, projection: .epsg3857))),
+            Feature(Point(Coordinate3D(x: 101_000.0, y: 100_000.0, projection: .epsg3857))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.kmeansClusters(numberOfClusters: 2)
+
+        let c0: Int? = result.features[0].property(for: "cluster")
+        let c2: Int? = result.features[2].property(for: "cluster")
+        #expect(c0 != nil)
+        #expect(c2 != nil)
+        #expect(c0 != c2)
+    }
+
+    /// Validates DBSCAN clustering works with EPSG:4978 (ECEF).
+    @Test
+    func dbscanEpsg4978() async throws {
+        // Points near Null Island in ECEF space
+        let points: [Feature] = [
+            Feature(Point(Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978))),
+            Feature(Point(Coordinate3D(x: 6_378_137.0, y: 500.0, z: 0.0, projection: .epsg4978))),
+            Feature(Point(Coordinate3D(x: 6_378_137.0, y: 0.0, z: 500.0, projection: .epsg4978))),
+            Feature(Point(Coordinate3D(x: -6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978))),
+            Feature(Point(Coordinate3D(x: -6_378_137.0, y: 500.0, z: 0.0, projection: .epsg4978))),
+            Feature(Point(Coordinate3D(x: -6_378_137.0, y: 0.0, z: 500.0, projection: .epsg4978))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.dbscanClusters(maxDistance: 1000.0, minPoints: 2)
+
+        let c0: Int? = result.features[0].property(for: "cluster")
+        let c3: Int? = result.features[3].property(for: "cluster")
+        #expect(c0 != nil)
+        #expect(c3 != nil)
+        #expect(c0 != c3)
+    }
+
+    /// Validates K-means clustering works with EPSG:4978 (ECEF).
+    @Test
+    func kmeansEpsg4978() async throws {
+        // Two clusters in ECEF: one near (6.3M, 0, 0), another near (0, 6.3M, 0)
+        let points: [Feature] = [
+            Feature(Point(Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978))),
+            Feature(Point(Coordinate3D(x: 6_378_137.0, y: 1000.0, z: 0.0, projection: .epsg4978))),
+            Feature(Point(Coordinate3D(x: 0.0, y: 6_378_137.0, z: 0.0, projection: .epsg4978))),
+            Feature(Point(Coordinate3D(x: 0.0, y: 6_378_137.0, z: 1000.0, projection: .epsg4978))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.kmeansClusters(numberOfClusters: 2)
+
+        let c0: Int? = result.features[0].property(for: "cluster")
+        let c2: Int? = result.features[2].property(for: "cluster")
+        #expect(c0 != nil)
+        #expect(c2 != nil)
+        #expect(c0 != c2)
+    }
+
 }

--- a/Tests/GISToolsTests/GeoJson/CoordinateTests.swift
+++ b/Tests/GISToolsTests/GeoJson/CoordinateTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct CoordinateTests {
 
-    // Validates the description string for EPSG:4326 coordinates with various optional components.
+    /// Validates the ``Coordinate3D.description`` string for EPSG:4326 coordinates with various optional components.
     @Test
     func coordinate3DDescription() async throws {
         let coordinate = Coordinate3D(latitude: 15.0, longitude: 10.0)
@@ -20,7 +20,7 @@ struct CoordinateTests {
         #expect(coordinateZM.description == "Coordinate3D<EPSG:4326>(latitude: 15.0, longitude: 10.0, altitude: 500.0, m: 1234.0)")
     }
 
-    // Validates the description string for EPSG:3857 coordinates with various optional components.
+    /// Validates the ``Coordinate3D.description`` string for EPSG:3857 coordinates with various optional components.
     @Test
     func coordinateXYDescription() async throws {
         let coordinate = Coordinate3D(x: 10.0, y: 15.0)
@@ -36,7 +36,7 @@ struct CoordinateTests {
         #expect(coordinateZM.description == "Coordinate3D<EPSG:3857>(x: 10.0, y: 15.0, z: 500.0, m: 1234.0)")
     }
 
-    // Validates JSON encoding of a coordinate produces the expected array.
+    /// Validates JSON encoding of a ``Coordinate3D`` produces the expected array.
     @Test
     func encodable() async throws {
         let coordinate = Coordinate3D(latitude: 15.0, longitude: 10.0)
@@ -45,7 +45,7 @@ struct CoordinateTests {
         #expect(String(data: coordinateData, encoding: .utf8) == "[10,15]")
     }
 
-    // Validates JSON encoding handles nil altitude and m values correctly.
+    /// Validates JSON encoding handles ``nil`` altitude and ``m`` values correctly.
     @Test
     func encodableNull() async throws {
         let coordinateM = Coordinate3D(latitude: 15.0, longitude: 10.0, altitude: nil, m: 1234)
@@ -61,7 +61,7 @@ struct CoordinateTests {
         #expect(coordinateZ.asMinimalJson == [10, 15, 500])
     }
 
-    // Validates round-trip JSON encoding and decoding of an EPSG:3857 coordinate.
+    /// Validates round-trip JSON encoding and decoding of an EPSG:3857 ``Coordinate3D``.
     @Test
     func encodable3857() async throws {
         let coordinate = Coordinate3D(latitude: 15.0, longitude: 10.0).projected(to: .epsg3857)
@@ -72,7 +72,7 @@ struct CoordinateTests {
         #expect(abs(Double(decodedCoordinate.asJson[1]!) - 15.0) < 0.000001)
     }
 
-    // Validates JSON decoding of a coordinate array.
+    /// Validates JSON decoding of a coordinate array.
     @Test
     func decodable() async throws {
         let coordinateData = try #require("[10,15]".data(using: .utf8))
@@ -81,7 +81,7 @@ struct CoordinateTests {
         #expect(decodedCoordinate.asJson == [10.0, 15.0])
     }
 
-    // Validates initializing a coordinate from a JSON dictionary.
+    /// Validates initializing a ``Coordinate3D`` from a JSON dictionary with ``x`` and ``y`` keys.
     @Test
     func JSONDictionary() async throws {
         let decodedCoordinate = try #require(Coordinate3D(json: [
@@ -92,7 +92,7 @@ struct CoordinateTests {
         #expect(decodedCoordinate.asJson == [10.0, 15.0])
     }
 
-    // Validates that malformed coordinate arrays throw on decode.
+    /// Validates that malformed coordinate arrays throw on decode.
     @Test
     func decodableInvalid() async throws {
         let coordinateData1 =  try #require("[10]".data(using: .utf8))
@@ -121,7 +121,7 @@ struct CoordinateTests {
         }
     }
 
-    // Validates that incomplete JSON dictionaries return nil.
+    /// Validates that incomplete JSON dictionaries return ``nil``.
     @Test
     func JSONDictionaryInvalid() async throws {
         #expect(Coordinate3D(json: [
@@ -145,7 +145,7 @@ struct CoordinateTests {
         ]) == nil)
     }
 
-    // Validates that a coordinate array with null in an invalid position throws on decode.
+    /// Validates that a coordinate array with ``null`` in an invalid position throws on decode.
     @Test
     func decodableInvalidNull() async throws {
         let coordinateDataM =  try #require("[10,null,null,1234]".data(using: .utf8))
@@ -154,7 +154,7 @@ struct CoordinateTests {
         }
     }
 
-    // Validates decoding coordinates with null values in valid positions.
+    /// Validates decoding coordinates with ``null`` values in valid positions.
     @Test
     func decodableNull() async throws {
         let coordinateDataM =  try #require("[10,15,null,1234]".data(using: .utf8))
@@ -171,7 +171,7 @@ struct CoordinateTests {
         #expect(decodedCoordinateZM.asJson == [10.0, 15.0, 500])
     }
 
-    // Validates coordinate equality including and excluding altitude comparisons.
+    /// Validates coordinate equality including and excluding altitude comparisons.
     @Test
     func equalityWithAltitude() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 100.0)
@@ -194,7 +194,7 @@ struct CoordinateTests {
         #expect(a.equals(other: b, includingAltitude: true) == false)
     }
 
-    // Validates coordinate equality for coordinates without altitude.
+    /// Validates coordinate equality for coordinates without altitude.
     @Test
     func equalityWithoutAltitude() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 10.0)
@@ -210,7 +210,7 @@ struct CoordinateTests {
 
     // MARK: - Normalization
 
-    // Validates longitude normalization wraps 200 to -160 for EPSG:4326.
+    /// Validates longitude normalization wraps 200 to -160 for EPSG:4326.
     @Test
     func normalizedEPSG4326() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 200.0)
@@ -219,7 +219,7 @@ struct CoordinateTests {
         #expect(n.latitude == 10.0)
     }
 
-    // Validates longitude normalization wraps around multiple times (730 to 10).
+    /// Validates longitude normalization wraps around multiple times (730 to 10).
     @Test
     func normalizedEPSG4326MultipleWrap() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 730.0)
@@ -228,7 +228,7 @@ struct CoordinateTests {
         #expect(n.latitude == 10.0)
     }
 
-    // Validates longitude normalization for negative values (-190 to 170).
+    /// Validates longitude normalization for negative values (-190 to 170).
     @Test
     func normalizedEPSG4326Negative() async throws {
         let a = Coordinate3D(latitude: -20.0, longitude: -190.0)
@@ -237,7 +237,7 @@ struct CoordinateTests {
         #expect(n.latitude == -20.0)
     }
 
-    // Validates normalization does not alter in-range coordinates.
+    /// Validates normalization does not alter in-range coordinates.
     @Test
     func normalizedEPSG4326InRange() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 45.0)
@@ -246,7 +246,7 @@ struct CoordinateTests {
         #expect(n.latitude == 10.0)
     }
 
-    // Validates normalization preserves longitude at the 180-degree boundary.
+    /// Validates normalization preserves longitude at the 180-degree boundary.
     @Test
     func normalizedEPSG4326Boundary180() async throws {
         let a = Coordinate3D(latitude: 0.0, longitude: 180.0)
@@ -254,7 +254,7 @@ struct CoordinateTests {
         #expect(n.longitude == 180.0)
     }
 
-    // Validates normalization preserves longitude at the -180-degree boundary.
+    /// Validates normalization preserves longitude at the -180-degree boundary.
     @Test
     func normalizedEPSG4326BoundaryNegative180() async throws {
         let a = Coordinate3D(latitude: 0.0, longitude: -180.0)
@@ -262,7 +262,7 @@ struct CoordinateTests {
         #expect(n.longitude == -180.0)
     }
 
-    // Validates normalization for EPSG:3857 coordinates wraps at originShift.
+    /// Validates normalization for EPSG:3857 coordinates wraps at originShift.
     @Test
     func normalizedEPSG3857() async throws {
         let shift = GISTool.originShift
@@ -271,7 +271,7 @@ struct CoordinateTests {
         #expect(abs(n.x - shift) < 1e-6)
     }
 
-    // Validates that normalization preserves altitude and m values.
+    /// Validates that normalization preserves altitude and m values.
     @Test
     func normalizedPreservesAltitudeAndM() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 200.0, altitude: 500.0, m: 42.0)
@@ -281,7 +281,7 @@ struct CoordinateTests {
         #expect(n.m == 42.0)
     }
 
-    // Validates the mutating normalize method.
+    /// Validates the mutating ``normalize()`` method.
     @Test
     func normalizedMutating() async throws {
         var a = Coordinate3D(latitude: 10.0, longitude: 200.0)
@@ -291,7 +291,7 @@ struct CoordinateTests {
 
     // MARK: - Clamping
 
-    // Validates clamping clamps longitude to 180 when too large.
+    /// Validates clamping clamps longitude to 180 when too large.
     @Test
     func clampedEPSG4326LongitudeTooLarge() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 200.0)
@@ -300,7 +300,7 @@ struct CoordinateTests {
         #expect(c.latitude == 10.0)
     }
 
-    // Validates clamping clamps longitude to -180 when too small.
+    /// Validates clamping clamps longitude to -180 when too small.
     @Test
     func clampedEPSG4326LongitudeTooSmall() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: -200.0)
@@ -309,7 +309,7 @@ struct CoordinateTests {
         #expect(c.latitude == 10.0)
     }
 
-    // Validates clamping clamps latitude to 90 when too large.
+    /// Validates clamping clamps latitude to 90 when too large.
     @Test
     func clampedEPSG4326LatitudeTooLarge() async throws {
         let a = Coordinate3D(latitude: 100.0, longitude: 10.0)
@@ -318,7 +318,7 @@ struct CoordinateTests {
         #expect(c.longitude == 10.0)
     }
 
-    // Validates clamping clamps latitude to -90 when too small.
+    /// Validates clamping clamps latitude to -90 when too small.
     @Test
     func clampedEPSG4326LatitudeTooSmall() async throws {
         let a = Coordinate3D(latitude: -100.0, longitude: 10.0)
@@ -327,7 +327,7 @@ struct CoordinateTests {
         #expect(c.longitude == 10.0)
     }
 
-    // Validates clamping clamps both latitude and longitude when both are out of range.
+    /// Validates clamping clamps both latitude and longitude when both are out of range.
     @Test
     func clampedEPSG4326BothOutOfRange() async throws {
         let a = Coordinate3D(latitude: 200.0, longitude: 300.0)
@@ -336,7 +336,7 @@ struct CoordinateTests {
         #expect(c.longitude == 180.0)
     }
 
-    // Validates clamping does not alter in-range coordinates.
+    /// Validates clamping does not alter in-range coordinates.
     @Test
     func clampedEPSG4326InRange() async throws {
         let a = Coordinate3D(latitude: 45.0, longitude: 90.0)
@@ -344,7 +344,7 @@ struct CoordinateTests {
         #expect(a == c)
     }
 
-    // Validates clamping for EPSG:3857 coordinates at originShift.
+    /// Validates clamping for EPSG:3857 coordinates at originShift.
     @Test
     func clampedEPSG3857() async throws {
         let shift = GISTool.originShift
@@ -354,7 +354,7 @@ struct CoordinateTests {
         #expect(c.y == shift)
     }
 
-    // Validates that clamping preserves altitude and m values.
+    /// Validates that clamping preserves altitude and m values.
     @Test
     func clampedPreservesAltitudeAndM() async throws {
         let a = Coordinate3D(latitude: 200.0, longitude: 300.0, altitude: 1000.0, m: 7.0)
@@ -365,7 +365,7 @@ struct CoordinateTests {
         #expect(c.m == 7.0)
     }
 
-    // Validates the mutating clamp method.
+    /// Validates the mutating ``clamp()`` method.
     @Test
     func clampedMutating() async throws {
         var a = Coordinate3D(latitude: 200.0, longitude: 10.0)
@@ -373,7 +373,7 @@ struct CoordinateTests {
         #expect(a.latitude == 90.0)
     }
 
-    // Validates that normalization is a no-op for .noSRID coordinates.
+    /// Validates that normalization is a no-op for ``Projection.noSRID`` coordinates.
     @Test
     func normalizedNoSRID() async throws {
         let a = Coordinate3D(x: 200.0, y: 10.0, projection: .noSRID)
@@ -382,7 +382,7 @@ struct CoordinateTests {
         #expect(n.latitude == 10.0)
     }
 
-    // Validates that clamping is a no-op for .noSRID coordinates.
+    /// Validates that clamping is a no-op for ``Projection.noSRID`` coordinates.
     @Test
     func clampedNoSRID() async throws {
         let a = Coordinate3D(x: 300.0, y: 200.0, projection: .noSRID)
@@ -393,7 +393,7 @@ struct CoordinateTests {
 
     // MARK: - Hashable
 
-    // Validates that equal coordinates have the same hash value.
+    /// Validates that equal coordinates have the same hash value.
     @Test
     func hashableEquality() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 20.0)
@@ -401,7 +401,7 @@ struct CoordinateTests {
         #expect(a.hashValue == b.hashValue)
     }
 
-    // Validates that different coordinates are not equal.
+    /// Validates that different coordinates are not equal.
     @Test
     func hashableInequality() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 20.0)
@@ -409,7 +409,7 @@ struct CoordinateTests {
         #expect(a != b)
     }
 
-    // Validates coordinates within the hash bucket threshold are equal.
+    /// Validates coordinates within the hash bucket threshold are equal.
     @Test
     func hashableWithinSameBucket() async throws {
         let a = Coordinate3D(latitude: 10.0 + 0.4e-10, longitude: 20.0)
@@ -418,7 +418,7 @@ struct CoordinateTests {
         #expect(a.hashValue == b.hashValue)
     }
 
-    // Validates coordinates just outside the hash bucket threshold are not equal.
+    /// Validates coordinates just outside the hash bucket threshold are not equal.
     @Test
     func hashableEdgeDelta() async throws {
         let a = Coordinate3D(latitude: 10.0 + 1.1e-10, longitude: 20.0)
@@ -426,7 +426,7 @@ struct CoordinateTests {
         #expect(a != b)
     }
 
-    // Validates coordinates work correctly as elements in a Set.
+    /// Validates coordinates work correctly as elements in a ``Set``.
     @Test
     func hashableInSet() async throws {
         let coords: Set<Coordinate3D> = [
@@ -437,7 +437,7 @@ struct CoordinateTests {
         #expect(coords.count == 2)
     }
 
-    // Validates coordinates work correctly as dictionary keys.
+    /// Validates coordinates work correctly as dictionary keys.
     @Test
     func hashableInDictionary() async throws {
         let dict: [Coordinate3D: String] = [
@@ -449,7 +449,7 @@ struct CoordinateTests {
 
     // MARK: - Equality edge cases
 
-    // Validates coordinates with different projections are not equal.
+    /// Validates coordinates with different projections are not equal.
     @Test
     func equalityProjectionMismatch() async throws {
         let epsg4326 = Coordinate3D(latitude: 10.0, longitude: 20.0)
@@ -457,7 +457,7 @@ struct CoordinateTests {
         #expect(epsg4326 != epsg3857)
     }
 
-    // Validates coordinate equality with a custom delta across projections.
+    /// Validates ``Coordinate3D.equals(other:includingAltitude:equalityDelta:altitudeDelta:)`` with a custom delta across projections.
     @Test
     func equalityCustomDeltaProjection() async throws {
         let a = Coordinate3D(x: 1000.0, y: 2000.0)
@@ -466,7 +466,7 @@ struct CoordinateTests {
         #expect(a.equals(other: b, equalityDelta: 1e-10) == false)
     }
 
-    // Validates equality between EPSG:4326 and projected EPSG:3857 coordinates.
+    /// Validates equality between EPSG:4326 and projected EPSG:3857 coordinates.
     @Test
     func equalityProjected() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 20.0)
@@ -474,13 +474,145 @@ struct CoordinateTests {
         #expect(a.equals(other: b, equalityDelta: 0.5))
     }
 
-    // Validates coordinates differing only in altitude nil versus non-nil are not equal.
+    /// Validates coordinates differing only in altitude nil versus non-nil are not equal.
     @Test
     func equalityAltitudeNilVsNonNil() async throws {
         let a = Coordinate3D(latitude: 10.0, longitude: 20.0)
         let b = Coordinate3D(latitude: 10.0, longitude: 20.0, altitude: 100.0)
         #expect(a != b)
         #expect(a.equals(other: b, includingAltitude: false))
+    }
+
+    // MARK: - EPSG:4978 (ECEF) conversion tests
+
+    /// Validates the ECEF conversion for Null Island (0°, 0°, 0m) → (a, 0, 0) and round-trip.
+    @Test
+    func ecefNullIsland() async throws {
+        let geo = Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0)
+        let ecef = geo.projected(to: .epsg4978)
+        #expect(ecef.projection == .epsg4978)
+        #expect(abs(ecef.longitude - 6_378_137.0) < 0.001)
+        #expect(abs(ecef.latitude) < 0.001)
+        #expect(abs(ecef.altitude ?? 0.0) < 0.001)
+
+        let back = ecef.projected(to: .epsg4326)
+        #expect(abs(back.latitude) < 1e-10)
+        #expect(abs(back.longitude) < 1e-10)
+        #expect(abs(back.altitude ?? 0.0) < 0.001)
+    }
+
+    /// Validates the ECEF conversion for (0°, 90°E, 0m) → (0, a, 0) and round-trip.
+    @Test
+    func ecefEquator90E() async throws {
+        let geo = Coordinate3D(latitude: 0.0, longitude: 90.0, altitude: 0.0)
+        let ecef = geo.projected(to: .epsg4978)
+        #expect(abs(ecef.longitude) < 0.001)
+        #expect(abs(ecef.latitude - 6_378_137.0) < 0.001)
+        #expect(abs(ecef.altitude ?? 0.0) < 0.001)
+
+        let back = ecef.projected(to: .epsg4326)
+        #expect(abs(back.latitude) < 1e-10)
+        #expect(abs(back.longitude - 90.0) < 1e-10)
+    }
+
+    /// Validates the ECEF conversion for the North Pole (90°N, 0°, 0m) → (0, 0, b) and round-trip.
+    @Test
+    func ecefNorthPole() async throws {
+        let geo = Coordinate3D(latitude: 90.0, longitude: 0.0, altitude: 0.0)
+        let ecef = geo.projected(to: .epsg4978)
+        #expect(abs(ecef.longitude) < 0.001)
+        #expect(abs(ecef.latitude) < 0.001)
+        #expect(abs((ecef.altitude ?? 0.0) - 6_356_752.314) < 0.1)
+
+        let back = ecef.projected(to: .epsg4326)
+        #expect(abs(back.latitude - 90.0) < 1e-10)
+        #expect(abs(back.longitude) < 1e-10)
+    }
+
+    /// Validates round-trip conversion: EPSG:4326 → EPSG:4978 → EPSG:4326 with altitude preserved.
+    @Test
+    func ecefRoundTrip() async throws {
+        let original = Coordinate3D(latitude: 45.0, longitude: -45.0, altitude: 100.0)
+        let ecef = original.projected(to: .epsg4978)
+        let back = ecef.projected(to: .epsg4326)
+        #expect(abs(back.latitude - 45.0) < 1e-8)
+        #expect(abs(back.longitude - -45.0) < 1e-8)
+        #expect(abs((back.altitude ?? 0.0) - 100.0) < 0.001)
+    }
+
+    /// Validates round-trip conversion: EPSG:4978 → EPSG:4326 → EPSG:4978.
+    @Test
+    func ecefRoundTrip4978() async throws {
+        let original = Coordinate3D(x: 4_000_000.0, y: 5_000_000.0, z: 3_000_000.0, projection: .epsg4978)
+        let geo = original.projected(to: .epsg4326)
+        let back = geo.projected(to: .epsg4978)
+        #expect(abs(back.longitude - original.longitude) < 0.001)
+        #expect(abs(back.latitude - original.latitude) < 0.001)
+        #expect(abs((back.altitude ?? 0.0) - (original.altitude ?? 0.0)) < 0.001)
+    }
+
+    /// Validates the ``Coordinate3D.description`` for EPSG:4978 coordinates.
+    @Test
+    func ecefDescription() async throws {
+        let coord = Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978)
+        #expect(coord.description == "Coordinate3D<EPSG:4978>(x: 6378137.0, y: 0.0, z: 0.0)")
+    }
+
+    /// Validates that EPSG:4978 coordinates project to EPSG:4326 for GeoJSON output.
+    @Test
+    func ecefAsJson() async throws {
+        let ecef = Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978)
+        let json = ecef.asJson
+        #expect(json.count >= 2)
+        #expect(abs(json[0]! - 0.0) < 1e-10)
+        #expect(abs(json[1]! - 0.0) < 1e-10)
+    }
+
+    /// Validates that ``normalized()`` is a no-op for EPSG:4978 coordinates.
+    @Test
+    func ecefNormalizedNoOp() async throws {
+        let coord = Coordinate3D(x: 10_000_000.0, y: 20_000_000.0, z: 5_000_000.0, projection: .epsg4978)
+        let n = coord.normalized()
+        #expect(n.x == coord.x)
+        #expect(n.y == coord.y)
+    }
+
+    /// Validates that ``clamped()`` is a no-op for EPSG:4978 coordinates.
+    @Test
+    func ecefClampedNoOp() async throws {
+        let coord = Coordinate3D(x: 10_000_000.0, y: 20_000_000.0, z: 5_000_000.0, projection: .epsg4978)
+        let c = coord.clamped()
+        #expect(c.x == coord.x)
+        #expect(c.y == coord.y)
+    }
+
+    /// Validates Euclidean distance between two EPSG:4978 points.
+    @Test
+    func ecefDistance() async throws {
+        let a = Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978)
+        let b = Coordinate3D(x: 0.0, y: 6_378_137.0, z: 0.0, projection: .epsg4978)
+        let dist = a.distance(to: b)
+        #expect(abs(dist - 6_378_137.0 * sqrt(2.0)) < 0.001)
+    }
+
+    /// Validates bearing between two EPSG:4978 points converts through EPSG:4326 internally.
+    @Test
+    func ecefBearing() async throws {
+        let a = Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978)
+        let b = Coordinate3D(x: 0.0, y: 6_378_137.0, z: 0.0, projection: .epsg4978)
+        let bearing = a.bearing(to: b)
+        #expect(abs(bearing - 90.0) < 2.0)
+    }
+
+    /// Validates that EPSG:4978 → EPSG:3857 projection matches the chain 4978 → 4326 → 3857.
+    @Test
+    func ecefProjectedTo3857() async throws {
+        let geo = Coordinate3D(latitude: 41.0, longitude: -71.0)
+        let ecef = geo.projected(to: .epsg4978)
+        let merc = ecef.projected(to: .epsg3857)
+        let directMerc = geo.projected(to: .epsg3857)
+        #expect(abs(merc.longitude - directMerc.longitude) < 0.001)
+        #expect(abs(merc.latitude - directMerc.latitude) < 0.001)
     }
 
 }

--- a/Tests/GISToolsTests/GeoJson/ProjectionTests.swift
+++ b/Tests/GISToolsTests/GeoJson/ProjectionTests.swift
@@ -224,6 +224,7 @@ struct ProjectionTests {
         #expect(Projection(wkt: #"GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]]"#) == .epsg4326)
         #expect(Projection(wkt: #"GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]"#) == .epsg4326)
         #expect(Projection(wkt: #"PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1]]"#) == .epsg3857)
+        #expect(Projection(wkt: #"GEOCCS["WGS 84 (geocentric)",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["metre",1]]"#) == .epsg4978)
         #expect(Projection(wkt: "unknown") == nil)
         #expect(Projection(wkt: "") == nil)
     }

--- a/Tests/GISToolsTests/GeoJson/ProjectionTests.swift
+++ b/Tests/GISToolsTests/GeoJson/ProjectionTests.swift
@@ -4,10 +4,9 @@ import Testing
 
 struct ProjectionTests {
 
-    // Tests coordinate projection from EPSG:4326 to EPSG:3857, including coordinates crossing the 180th meridian.
+    /// Tests coordinate projection from EPSG:4326 to EPSG:3857, including coordinates crossing the 180th meridian.
     @Test
     func convertTo3857() async throws {
-        // A simple case
         let coordinate1 = Coordinate3D(latitude: 41.0, longitude: -71.0)
         let result1 = coordinate1.projected(to: .epsg3857)
         #expect(abs(result1.longitude - -7_903_683.846322424) < 0.000001)
@@ -18,35 +17,30 @@ struct ProjectionTests {
         #expect(abs(result1b.longitude - -10_859_458.446776) < 0.000001)
         #expect(abs(result1b.latitude - 4_235_169.496066) < 0.000001)
 
-        // A coordinate that passed the 180th meridian
         let coordinate2 = Coordinate3D(latitude: -23.563987128451217, longitude: -246.796875)
         let result2 = coordinate2.projected(to: .epsg3857)
         #expect(abs(result2.longitude - -27_473_302.454371188) < 0.000001)
         #expect(abs(result2.latitude - -2_700_367.3352587065) < 0.000001)
 
-        // A coordinate that passed the 180th meridian
         let coordinate3 = Coordinate3D(latitude: -23.563987128451217, longitude: -246.796875)
         let result3 = coordinate3.normalized().projected(to: .epsg3857)
         #expect(abs(result3.longitude - 12_601_714.231207296) < 0.000001)
         #expect(abs(result3.latitude - -2_700_367.3352587065) < 0.000001)
 
-        // Another coordinate that passed the 180th meridian
         let coordinate4 = Coordinate3D(latitude: 11.350796722383672, longitude: 286.5234375)
         let result4 = coordinate4.projected(to: .epsg3857)
         #expect(abs(result4.longitude - 31_895_643.162838347) < 0.000001)
         #expect(abs(result4.latitude - 1_271_912.1506653326) < 0.000001)
 
-        // Another coordinate that passed the 180th meridian
         let coordinate5 = Coordinate3D(latitude: 11.350796722383672, longitude: 286.5234375)
         let result5 = coordinate5.normalized().projected(to: .epsg3857)
         #expect(abs(result5.longitude - -8_179_373.522740141) < 0.000001)
         #expect(abs(result5.latitude - 1_271_912.1506653326) < 0.000001)
     }
 
-    // Tests coordinate projection from EPSG:3857 to EPSG:4326, including coordinates crossing the 180th meridian.
+    /// Tests coordinate projection from EPSG:3857 to EPSG:4326, including coordinates crossing the 180th meridian.
     @Test
     func convertTo4326() async throws {
-        // A simple case
         let coordinate1 = Coordinate3D(x: -7_903_683.846322424, y: 5_012_341.663847514)
         let result1 = coordinate1.projected(to: .epsg4326)
         #expect(abs(result1.latitude - 41.0) < 0.000001)
@@ -57,33 +51,103 @@ struct ProjectionTests {
         #expect(abs(result1b.latitude - 35.522895) < 0.000001)
         #expect(abs(result1b.longitude - -97.552175) < 0.000001)
 
-        // A coordinate that passed the 180th meridian
         let coordinate2 = Coordinate3D(x: 12_601_714.231207296, y: -2_700_367.3352587065)
         let result2 = coordinate2.projected(to: .epsg4326)
         #expect(abs(result2.latitude - -23.563987128451217) < 0.000001)
         #expect(abs(result2.longitude - 113.203125) < 0.000001)
 
-        // Another coordinate that passed the 180th meridian
         let coordinate3 = Coordinate3D(x: -8_179_373.522740139, y: 1_271_912.1506653326)
         let result3 = coordinate3.projected(to: .epsg4326)
         #expect(abs(result3.latitude - 11.350796722383672) < 0.000001)
         #expect(abs(result3.longitude - -73.476562) < 0.000001)
     }
 
+    /// Tests coordinate projection from EPSG:4326 to EPSG:4978 (ECEF), including round-trip and cross-projection chaining.
+    @Test
+    func convertTo4978() async throws {
+        // Null Island → ECEF X = a, Y = 0, Z = 0
+        let nullIsland = Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0)
+        let nullEcef = nullIsland.projected(to: .epsg4978)
+        #expect(abs(nullEcef.longitude - 6_378_137.0) < 0.001)
+        #expect(abs(nullEcef.latitude) < 0.001)
+        #expect(abs(nullEcef.altitude ?? 0.0) < 0.001)
+
+        // Round-trip: 4326 → 4978 → 4326
+        let coord1 = Coordinate3D(latitude: 41.0, longitude: -71.0, altitude: 0.0)
+        let ecef1 = coord1.projected(to: .epsg4978)
+        let back1 = ecef1.projected(to: .epsg4326)
+        #expect(abs(back1.latitude - coord1.latitude) < 1e-8)
+        #expect(abs(back1.longitude - coord1.longitude) < 1e-8)
+        #expect(abs((back1.altitude ?? 0.0)) < 0.001)
+
+        let coord2 = Coordinate3D(latitude: 35.522895, longitude: -97.552175, altitude: 0.0)
+        let ecef2 = coord2.projected(to: .epsg4978)
+        let back2 = ecef2.projected(to: .epsg4326)
+        #expect(abs(back2.latitude - coord2.latitude) < 1e-8)
+        #expect(abs(back2.longitude - coord2.longitude) < 1e-8)
+        #expect(abs((back2.altitude ?? 0.0)) < 0.001)
+
+        // Round-trip with altitude preserved
+        let coord3 = Coordinate3D(latitude: -33.86, longitude: 151.21, altitude: 500.0)
+        let ecef3 = coord3.projected(to: .epsg4978)
+        let back3 = ecef3.projected(to: .epsg4326)
+        #expect(abs(back3.latitude - coord3.latitude) < 1e-8)
+        #expect(abs(back3.longitude - coord3.longitude) < 1e-8)
+        #expect(abs((back3.altitude ?? 0.0) - 500.0) < 0.001)
+
+        // EPSG:3857 → EPSG:4978 via chaining matches 4326 → 4978
+        let merc = Coordinate3D(x: -7_903_683.846322424, y: 5_012_341.663847514)
+        let via3857 = merc.projected(to: .epsg4978)
+        let direct4326 = merc.projected(to: .epsg4326)
+        let directEcef = direct4326.projected(to: .epsg4978)
+        #expect(abs(via3857.longitude - directEcef.longitude) < 0.001)
+        #expect(abs(via3857.latitude - directEcef.latitude) < 0.001)
+        #expect(abs((via3857.altitude ?? 0.0) - (directEcef.altitude ?? 0.0)) < 0.001)
+    }
+
+    /// Tests coordinate projection from EPSG:4978 (ECEF) back to EPSG:4326 and EPSG:3857.
+    @Test
+    func convertFrom4978() async throws {
+        // ECEF Null Island (a, 0, 0) → lat=0, lon=0
+        let ecefNull = Coordinate3D(x: 6_378_137.0, y: 0.0, z: 0.0, projection: .epsg4978)
+        let geoNull = ecefNull.projected(to: .epsg4326)
+        #expect(abs(geoNull.latitude) < 1e-10)
+        #expect(abs(geoNull.longitude) < 1e-10)
+
+        // Round-trip: 4978 → 4326 → 4978
+        let ecef1 = Coordinate3D(x: 4_000_000.0, y: 5_000_000.0, z: 3_000_000.0, projection: .epsg4978)
+        let geo1 = ecef1.projected(to: .epsg4326)
+        let back1 = geo1.projected(to: .epsg4978)
+        #expect(abs(back1.longitude - ecef1.longitude) < 0.001)
+        #expect(abs(back1.latitude - ecef1.latitude) < 0.001)
+        #expect(abs((back1.altitude ?? 0.0) - (ecef1.altitude ?? 0)) < 0.001)
+
+        // EPSG:4978 → EPSG:3857 via chaining matches 4978 → 4326 → 3857
+        let merc = ecef1.projected(to: .epsg3857)
+        let via4326 = ecef1.projected(to: .epsg4326).projected(to: .epsg3857)
+        #expect(abs(merc.longitude - via4326.longitude) < 0.001)
+        #expect(abs(merc.latitude - via4326.latitude) < 0.001)
+    }
+
+    /// Validates that each projection case reports the correct SRID number.
     @Test
     func cases() async throws {
         #expect(Projection.noSRID.srid == 0)
         #expect(Projection.epsg3857.srid == 3857)
         #expect(Projection.epsg4326.srid == 4326)
+        #expect(Projection.epsg4978.srid == 4978)
     }
 
+    /// Validates initialization from supported SRID numbers.
     @Test
     func initFromSrid() async throws {
         #expect(Projection(srid: 0) == .noSRID)
         #expect(Projection(srid: 4326) == .epsg4326)
         #expect(Projection(srid: 3857) == .epsg3857)
+        #expect(Projection(srid: 4978) == .epsg4978)
     }
 
+    /// Validates initialization from known EPSG:3857 alias SRIDs.
     @Test
     func initFromSridAliases() async throws {
         #expect(Projection(srid: 102_100) == .epsg3857)
@@ -95,45 +159,55 @@ struct ProjectionTests {
         #expect(Projection(srid: 54_004) == .epsg3857)
     }
 
+    /// Validates that unsupported SRID numbers return `nil`.
     @Test
     func initFromUnsupportedSrid() async throws {
         #expect(Projection(srid: 1234) == nil)
         #expect(Projection(srid: -1) == nil)
     }
 
+    /// Validates the human-readable description of each projection.
     @Test
     func description() async throws {
         #expect(Projection.noSRID.description == "No SRID")
         #expect(Projection.epsg3857.description == "EPSG:3857")
         #expect(Projection.epsg4326.description == "EPSG:4326")
+        #expect(Projection.epsg4978.description == "EPSG:4978")
     }
 
+    /// Validates the `srid` computed property returns the correct integer.
     @Test
     func sridProperty() async throws {
         #expect(Projection.noSRID.srid == 0)
         #expect(Projection.epsg3857.srid == 3857)
         #expect(Projection.epsg4326.srid == 4326)
+        #expect(Projection.epsg4978.srid == 4978)
     }
 
+    /// Validates equality and inequality between projections.
     @Test
     func equatable() async throws {
         #expect(Projection.epsg4326 == .epsg4326)
         #expect(Projection.epsg4326 != .epsg3857)
         #expect(Projection.noSRID != .epsg4326)
+        #expect(Projection.epsg4978 != .epsg4326)
+        #expect(Projection.epsg4978 == .epsg4978)
     }
 
+    /// Validates round-trip JSON encoding and decoding for all projections.
     @Test
     func codableRoundTrip() async throws {
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()
 
-        for projection: Projection in [.noSRID, .epsg3857, .epsg4326] {
+        for projection: Projection in [.noSRID, .epsg3857, .epsg4326, .epsg4978] {
             let data = try encoder.encode(projection)
             let decoded = try decoder.decode(Projection.self, from: data)
             #expect(decoded == projection)
         }
     }
 
+    /// Validates the raw JSON values for each projection's Codable representation.
     @Test
     func codableRawValues() async throws {
         let encoder = JSONEncoder()
@@ -141,6 +215,7 @@ struct ProjectionTests {
         #expect(String(data: try encoder.encode(Projection.noSRID), encoding: .utf8) == "0")
         #expect(String(data: try encoder.encode(Projection.epsg3857), encoding: .utf8) == "3857")
         #expect(String(data: try encoder.encode(Projection.epsg4326), encoding: .utf8) == "4326")
+        #expect(String(data: try encoder.encode(Projection.epsg4978), encoding: .utf8) == "4978")
     }
 
     /// Validates ``Projection.init(wkt:)`` with common ``.prj`` strings.


### PR DESCRIPTION
Adds support for EPSG:4978 (WGS 84 Geocentric Cartesian / ECEF) as a first-class projection alongside the existing EPSG:4326 and EPSG:3857.

### Changes

- **Projection.swift** — Added `.epsg4978` case (SRID 4978) and `init?(wkt:)` for parsing `.prj` files
- **Coordinate3D.swift** — Added `geodeticToEcef` and `ecefToGeodetic` conversion helpers using WGS84 ellipsoid formulas (iterative Bowring method); updated `projected(to:)`, `latitudeProjected(to:)`, `longitudeProjected(to:)` for all 4978↔{4326,3857,noSRID} paths; `normalized()`/`clamped()` no-op for ECEF
- **GISTool.swift** — Added shared WGS84 constants (`wgs84Flattening`, `wgs84EccentricitySquared`, `wgs84SemiMinorAxis`) and sorted alphabetically
- **Algorithm files** — Updated all `switch projection` statements in Destination, Distance, Bearing, RhumbDestination, RhumbDistance, RhumbBearing, MidPoint, Simplify, BoundingBox, WKTCoder, WKBCoder, TWKBCoder to handle `.epsg4978`
- **Distance** — EPSG:4978 uses Euclidean distance (straight-line-through-Earth), matching the ECEF use case
- **Clusters.swift** — Added `weightAttribute` and `seedIndex` parameters to `kmeansClusters` for weighted K-means (matching PostGIS `ST_ClusterKMeans`); fixed `regionQuery` bounding box to be projection-aware (was hardcoded for EPSG:4326)
- **Feature.swift** — Added simplestyle convenience properties for geojson.io: `fill`, `fillOpacity`, `stroke`, `strokeOpacity`, `strokeWidth`, `markerColor`, `markerSize`, `markerSymbol`
- **Tests** — Extended cluster tests to cover all projections (EPSG:4326, EPSG:3857, EPSG:4978) for DBSCAN, K-means, and weighted K-means; added disabled test `clusterNaturalEarth` that reads the Natural Earth shapefile and writes coloured GeoJSON outputs per projection/algorithm
- **Coordinate3D.swift** — Refactored UTM code to use shared GISTool constants instead of inline literals

### Implementation Notes

- Uses the iterative Bowring method for ECEF→geodetic (converges in ~3 iterations)
- Altitude (height above ellipsoid) is preserved through conversions
- ECEF→EPSG:4326→EPSG:3857 chaining works seamlessly
- ECEF coordinates are Cartesian (x/y/z in meters) with no longitude wrap-around
- Weighted K-means centroids are computed as `sum(w·c) / sum(w)`, matching PostGIS behaviour
- `regionQuery` in DBSCAN now uses projection-appropriate bounding box units (degrees for 4326, meters for 3857/4978)

Closes #55 