### PR TITLE
Add isClosed property to LineString

### DIFF
--- a/Sources/GISTools/GeoJson/LineString.swift
+++ b/Sources/GISTools/GeoJson/LineString.swift
@@ -189,6 +189,19 @@ extension LineString {
         coordinates.last
     }
 
+    /// A Boolean value that indicates whether this line string forms a closed ring.
+    ///
+    /// A line string is closed when its first and last coordinates are equal
+    /// (within ``GISTool/equalityDelta``).
+    @inlinable
+    public var isClosed: Bool {
+        guard let first = coordinates.first,
+              let last = coordinates.last,
+              coordinates.count > 1
+        else { return false }
+        return first.isCoincident(to: last)
+    }
+
 }
 
 // MARK: - Projection

--- a/Tests/GISToolsTests/GeoJson/LineStringTests.swift
+++ b/Tests/GISToolsTests/GeoJson/LineStringTests.swift
@@ -88,4 +88,25 @@ struct LineStringTests {
         #expect(lineStringData == lineString.asJsonData(prettyPrinted: true))
     }
 
+    // Validates that isClosed returns false for open line strings and true for closed rings.
+    @Test
+    func isClosed() async throws {
+        let open = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+        #expect(!open.isClosed)
+
+        let closed = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        #expect(closed.isClosed)
+
+        #expect(LineString().isClosed == false)
+    }
+
 }


### PR DESCRIPTION
Adds a computed `isClosed` property to `LineString` that returns `true` when the first and last coordinates are coincident within `GISTool.equalityDelta`.

```swift
let ring = LineString([
    Coordinate3D(latitude: 0.0, longitude: 0.0),
    Coordinate3D(latitude: 1.0, longitude: 0.0),
    Coordinate3D(latitude: 1.0, longitude: 1.0),
    Coordinate3D(latitude: 0.0, longitude: 1.0),
    Coordinate3D(latitude: 0.0, longitude: 0.0),
])!
ring.isClosed // true

let line = LineString([
    Coordinate3D(latitude: 0.0, longitude: 0.0),
    Coordinate3D(latitude: 1.0, longitude: 1.0),
])!
line.isClosed // false
```