### PR TITLE
Port turf/flip

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,6 +956,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | distance                    | `let distance = coordinate1.distance(from: coordinate2)`                                                                              |     | [Source][68] / [Tests][69]   |
 | ellipse                     | `let ellipse = coordinate.ellipse(xSemiAxis: 5000.0, ySemiAxis: 3000.0)`                                                              |     | [Source][183] / [Tests][184] |
 | flatten                     | `let featureCollection = anyGeometry.flattened`                                                                                       |     | [Source][70] / [Tests][71]   |
+| flip                        | `let flipped = anyGeometry.flipped()`                                                                                                 |     | [Source][189] / [Tests][190] |
 | great-circle                | `let arc = start.greatCircle(to: end)`                                                                                                |     | [Source][144] / [Tests][145] |
 | frechetDistance             | `let distance = lineString.frechetDistance(from: other)`                                                                              |     | [Source][72] / [Tests][73]   |
 | grid-hex                    | `bbox.hexGrid(cellSide: 1000.0)`                                                                                                      |     | [Source][165] / [Tests][166] |
@@ -1207,6 +1208,8 @@ Thomas Rasch, Outdooractive
 [188]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/BooleanContainsTests.swift "BooleanContainsTests"
 [189]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Sector.swift "Sector"
 [190]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/SectorTests.swift "SectorTests"
+[191]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Flip.swift "Flip"
+[192]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/FlipTests.swift "FlipTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/ConcaveHull.swift
+++ b/Sources/GISTools/Algorithms/ConcaveHull.swift
@@ -19,7 +19,10 @@ extension GeoJson {
     /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     ///
     /// - Returns: A `MultiPolygon` representing the concave hull
-    public func concaveHull(maxEdgeLength: CLLocationDistance, gridSize: Double? = nil) -> MultiPolygon? {
+    public func concaveHull(
+        maxEdgeLength: CLLocationDistance,
+        gridSize: Double? = nil
+    ) -> MultiPolygon? {
         let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
         let coords = snappedSelf.allCoordinates
         let unique = Set(coords)

--- a/Sources/GISTools/Algorithms/Flip.swift
+++ b/Sources/GISTools/Algorithms/Flip.swift
@@ -1,0 +1,43 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/blob/master/packages/turf-flip
+
+extension GeoJson {
+
+    /// Flips the coordinates of the receiver by swapping latitude and longitude.
+    ///
+    /// Altitude and `m` values are preserved unchanged.
+    ///
+    /// - Returns: A new geometry with flipped coordinates.
+    public func flipped() -> Self {
+        transformedCoordinates { coordinate in
+            Coordinate3D(
+                latitude: coordinate.longitude,
+                longitude: coordinate.latitude,
+                altitude: coordinate.altitude,
+                m: coordinate.m)
+        }
+    }
+
+    /// Flips the coordinates of the receiver in-place.
+    public mutating func flip() {
+        self = flipped()
+    }
+
+}
+
+extension Coordinate3D {
+
+    /// Returns a copy of this coordinate with latitude and longitude swapped.
+    public func flipped() -> Coordinate3D {
+        Coordinate3D(
+            latitude: longitude,
+            longitude: latitude,
+            altitude: altitude,
+            m: m)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/FlipTests.swift
+++ b/Tests/GISToolsTests/Algorithms/FlipTests.swift
@@ -1,0 +1,78 @@
+@testable import GISTools
+import Testing
+
+struct FlipTests {
+
+    // Validates flipping a Point swaps latitude and longitude.
+    @Test
+    func flipPoint() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
+        let flipped = point.flipped()
+        #expect(flipped.coordinate.latitude == 20.0)
+        #expect(flipped.coordinate.longitude == 10.0)
+    }
+
+    // Validates flipping a Point preserves altitude and m values.
+    @Test
+    func flipPointPreservesAltitudeAndM() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0, altitude: 500.0, m: 42.0))
+        let flipped = point.flipped()
+        #expect(flipped.coordinate.latitude == 20.0)
+        #expect(flipped.coordinate.longitude == 10.0)
+        #expect(flipped.coordinate.altitude == 500.0)
+        #expect(flipped.coordinate.m == 42.0)
+    }
+
+    // Validates flipping a LineString swaps coordinates.
+    @Test
+    func flipLineString() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 3.0),
+        ]))
+        let flipped = line.flipped()
+        #expect(flipped.coordinates[0].latitude == 1.0)
+        #expect(flipped.coordinates[0].longitude == 0.0)
+        #expect(flipped.coordinates[1].latitude == 3.0)
+        #expect(flipped.coordinates[1].longitude == 2.0)
+    }
+
+    // Validates flipping a MultiPolygon swaps all coordinates.
+    @Test
+    func flipMultiPolygon() async throws {
+        let ring = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 3.0),
+            Coordinate3D(latitude: 4.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+        ]))
+        let poly = try #require(Polygon([ring]))
+        let multi = MultiPolygon([poly])!
+        let flipped = multi.flipped()
+        let flippedRing = flipped.polygons[0].rings[0]
+        #expect(flippedRing.coordinates[0].latitude == 1.0)
+        #expect(flippedRing.coordinates[0].longitude == 0.0)
+    }
+
+    // Validates the mutating flip() method.
+    @Test
+    func flipMutating() async throws {
+        var point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
+        point.flip()
+        #expect(point.coordinate.latitude == 20.0)
+        #expect(point.coordinate.longitude == 10.0)
+    }
+
+    // Validates that a Feature and FeatureCollection also flip.
+    @Test
+    func flipFeature() async throws {
+        var feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)))
+        feature.properties = ["name": "test"]
+        let flipped = feature.flipped()
+        let flippedPoint = try #require(flipped.geometry as? Point)
+        #expect(flippedPoint.coordinate.latitude == 20.0)
+        #expect(flippedPoint.coordinate.longitude == 10.0)
+        #expect(flipped.properties["name"] as? String == "test")
+    }
+
+}


### PR DESCRIPTION
Closes #131

Ports @turf/flip — swaps latitude and longitude for all coordinates in any GeoJSON geometry.

Available on all `GeoJson` types via `transformedCoordinates`. Altitude and `m` values are preserved.

```swift
let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
let flipped = point.flipped()
// flipped.coordinate → (latitude: 20.0, longitude: 10.0)

var line = LineString([...])
line.flip() // mutating version
```