### PR TITLE
Port turf/square

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | rhumb-distance              | `let distance = coordinate1.rhumbDistance(from: coordinate2)`                                                                         |     | [Source][108] / [Tests][109] |
 | sample                      | `let sampled = featureCollection.sample(size: 10)`                                                                                    |     | [Source][181] / [Tests][182] |
 | sector                      | `let sector = coordinate.sector(radius: 5000.0, bearing1: 0.0, bearing2: 90.0)`                                                       |     | [Source][189] / [Tests][190] |
+| square                      | `let squared = boundingBox.squared()`                                                                                                 |     | [Source][193] / [Tests][194] |
 | simplify                    | `let simplified = lineString. simplified(tolerance: 5.0, highQuality: false)`                                                         |     | [Source][110] / [Tests][111] |
 | snap-to-grid                | `anyGeometry.snappedToGrid(tolerance: 0.5)`                                                                                           |     | [Source][175] / [Tests][176] |
 | tile-cover                  | `let tileCover = anyGeometry.tileCover(atZoom: 14)`                                                                                   |     | [Source][112] / [Tests][113] |
@@ -1210,6 +1211,8 @@ Thomas Rasch, Outdooractive
 [190]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/SectorTests.swift "SectorTests"
 [191]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Flip.swift "Flip"
 [192]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/FlipTests.swift "FlipTests"
+[193]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/GeoJson/BoundingBox.swift "BoundingBox"
+[194]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift "BoundingBoxTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -435,6 +435,44 @@ extension BoundingBox {
         return size.width * size.height
     }
 
+    /// Returns a square bounding box that fully contains the receiver.
+    ///
+    /// The shorter dimension is extended equally on both sides to match the longer
+    /// dimension, producing a square bounding box. Works in the native units of the
+    /// coordinate system (degrees for EPSG:4326, meters for EPSG:3857/4978).
+    ///
+    /// - Returns: A square ``BoundingBox`` that contains the receiver
+    public func squared() -> BoundingBox {
+        let w = northEast.longitude - southWest.longitude
+        let h = northEast.latitude - southWest.latitude
+        let maxSide = max(w, h)
+
+        if w >= h {
+            let pad = (w - h) / 2.0
+            return BoundingBox(
+                southWest: Coordinate3D(
+                    x: southWest.longitude,
+                    y: southWest.latitude - pad,
+                    projection: projection),
+                northEast: Coordinate3D(
+                    x: northEast.longitude,
+                    y: northEast.latitude + pad,
+                    projection: projection))
+        }
+        else {
+            let pad = (h - w) / 2.0
+            return BoundingBox(
+                southWest: Coordinate3D(
+                    x: southWest.longitude - pad,
+                    y: southWest.latitude,
+                    projection: projection),
+                northEast: Coordinate3D(
+                    x: northEast.longitude + pad,
+                    y: northEast.latitude,
+                    projection: projection))
+        }
+    }
+
     /// The size of the bounding box (width, height) in meters (approximation).
     public var size: (width: Double, height: Double) {
         switch projection {

--- a/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
+++ b/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
@@ -765,4 +765,49 @@ struct BoundingBoxTests {
         #expect(bbox.position(of: point).contains(.center))
     }
 
+    // MARK: - Squared
+
+    // Validates squared() on a bbox that is wider than tall.
+    @Test
+    func squaredWide() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 30.0))
+        let square = bbox.squared()
+        #expect(abs(square.northEast.latitude - square.southWest.latitude)
+            == abs(square.northEast.longitude - square.southWest.longitude))
+        #expect(square.southWest.latitude == -10.0)
+        #expect(square.northEast.latitude == 20.0)
+        #expect(square.southWest.longitude == 0.0)
+        #expect(square.northEast.longitude == 30.0)
+    }
+
+    // Validates squared() on a bbox that is taller than wide.
+    @Test
+    func squaredTall() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 10.0))
+        let square = bbox.squared()
+        #expect(abs(square.northEast.latitude - square.southWest.latitude)
+            == abs(square.northEast.longitude - square.southWest.longitude))
+        #expect(square.southWest.latitude == 0.0)
+        #expect(square.northEast.latitude == 30.0)
+        #expect(square.southWest.longitude == -10.0)
+        #expect(square.northEast.longitude == 20.0)
+    }
+
+    // Validates squared() on a square bbox returns itself (no change).
+    @Test
+    func squaredAlreadySquare() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0))
+        let square = bbox.squared()
+        #expect(square.southWest.latitude == 0.0)
+        #expect(square.southWest.longitude == 0.0)
+        #expect(square.northEast.latitude == 20.0)
+        #expect(square.northEast.longitude == 20.0)
+    }
+
 }


### PR DESCRIPTION
Closes #139

Ports @turf/square — extends the shorter dimension of a bounding box to match the longer one, producing a square.

```swift
let bbox = BoundingBox(
    southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
    northEast: Coordinate3D(latitude: 10.0, longitude: 30.0))
let square = bbox.squared()
// square → (latitude: -10.0 ... 20.0, longitude: 0.0 ... 30.0)
```

Works in native units (degrees for EPSG:4326, meters for EPSG:3857/4978).