### PR TITLE
Port turf/polygon-tangents

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | point-to-line-distance      | `let distance = lineString.distanceFrom(coordinate: Coordinate3D(…))`                                                                 |     | [Source][99] / [Tests][100]  |
 | pole-of-inaccessibility     | `let pole = polygon.poleOfInaccessibility()`                                                                                           |     | [Source][101] / [Tests][152] |
 | polygon-smooth              | `let smoothed = polygon.smooth(iterations: 3)`                                                                                         |     | [Source][148] / [Tests][149] |
+| polygon-tangents            | `let tangents = polygon.tangentPoints(to: point)`                                                                                      |     | [Source][195] / [Tests][196] |
 | polygon-to-line             | `var lineStrings = polygon.lineStrings`                                                                                               |     | [Source][129]                |
 | random                      | `BoundingBox.randomPoints(count: 10)`                                                                                                 |     | [Source][179] / [Tests][180] |
 | reverse                     | `let lineStringReversed = lineString.reversed`                                                                                        |     | [Source][102] / [Tests][103] |
@@ -1213,6 +1214,8 @@ Thomas Rasch, Outdooractive
 [192]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/FlipTests.swift "FlipTests"
 [193]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/GeoJson/BoundingBox.swift "BoundingBox"
 [194]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift "BoundingBoxTests"
+[195]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PolygonTangents.swift "PolygonTangents"
+[196]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PolygonTangentsTests.swift "PolygonTangentsTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/PolygonTangents.swift
+++ b/Sources/GISTools/Algorithms/PolygonTangents.swift
@@ -1,0 +1,144 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-polygon-tangents
+
+extension Polygon {
+
+    /// Finds the two tangent points of this polygon from an external point.
+    ///
+    /// The result is a ``MultiPoint`` containing the two points on the polygon's
+    /// boundary where lines from the given point are tangent to the polygon.
+    /// Returns `nil` if the point is inside the polygon or if the polygon has
+    /// no outer ring.
+    ///
+    /// - Parameter point: An external point
+    /// - Returns: A ``MultiPoint`` with the two tangent points, or `nil`
+    public func tangentPoints(to point: Coordinate3D) -> MultiPoint? {
+        guard let ring = outerRing else { return nil }
+        let coords = ring.coordinates
+
+        guard coords.count >= 3 else { return nil }
+
+        // Project both to the same coordinate system
+        let point = point.projected(to: projection)
+        let projectedCoords = coords.map { $0.projected(to: projection) }
+
+        // Skip the closing coordinate (last == first)
+        var vertices = Array(projectedCoords.dropLast())
+        guard vertices.count >= 3 else { return nil }
+
+        // Determine whether to shift longitudes for antimeridian handling.
+        // Case 1: the polygon itself spans the date line (max-min > 180°).
+        // Case 2: the polygon is compact but the point is on the far side
+        //         (raw longitude difference from polygon centroid > 180°),
+        //         so the shortest tangent crosses the date line.
+        let minLon = vertices.map(\.longitude).min() ?? 0
+        let maxLon = vertices.map(\.longitude).max() ?? 0
+        let centroidLon = (minLon + maxLon) / 2.0
+        let spansAntimeridian = (maxLon - minLon) > 180.0
+        let pointOnFarSide = abs(point.longitude - centroidLon) > 180.0
+
+        let shiftedPoint: Coordinate3D
+        var shiftedVertices = vertices
+        var shouldUnshift = false
+
+        if spansAntimeridian {
+            shouldUnshift = true
+            shiftedPoint = Coordinate3D(
+                latitude: point.latitude,
+                longitude: point.longitude < 0 ? point.longitude + 360.0 : point.longitude,
+                altitude: point.altitude,
+                m: point.m)
+            shiftedVertices = vertices.map { coord in
+                let newLon = coord.longitude < 0 ? coord.longitude + 360.0 : coord.longitude
+                return Coordinate3D(latitude: coord.latitude, longitude: newLon, altitude: coord.altitude, m: coord.m)
+            }
+        }
+        else if pointOnFarSide {
+            // Shift the point so it approaches the polygon across the date line
+            shouldUnshift = true
+            let shift = point.longitude < centroidLon ? 360.0 : -360.0
+            shiftedPoint = Coordinate3D(
+                latitude: point.latitude,
+                longitude: point.longitude + shift,
+                altitude: point.altitude,
+                m: point.m)
+            shiftedVertices = vertices
+        }
+        else {
+            shiftedPoint = point
+        }
+
+        guard !isInside(shiftedPoint, vertices: shiftedVertices) else { return nil }
+
+        guard let rightIdx = findTangent(vertices: shiftedVertices, point: shiftedPoint, direction: 1),
+              let leftIdx = findTangent(vertices: shiftedVertices, point: shiftedPoint, direction: -1)
+        else { return nil }
+
+        // Unshift tangents back to original longitude range
+        func unshift(_ coord: Coordinate3D) -> Coordinate3D {
+            guard shouldUnshift, abs(coord.longitude) > 180.0 else { return coord }
+            return Coordinate3D(latitude: coord.latitude, longitude: coord.longitude - 360.0,
+                                altitude: coord.altitude, m: coord.m)
+        }
+        return MultiPoint([unshift(shiftedVertices[rightIdx]), unshift(shiftedVertices[leftIdx])])
+    }
+
+}
+
+// MARK: - Helpers
+
+extension Polygon {
+
+    /// Checks if `point` is inside the convex polygon defined by `vertices`.
+    private func isInside(_ point: Coordinate3D, vertices: [Coordinate3D]) -> Bool {
+        guard vertices.count >= 3 else { return false }
+        let sign = crossProduct(vertices[0], vertices[1], point) > 0.0
+        for i in 1..<vertices.count {
+            let j = (i + 1) % vertices.count
+            let s = crossProduct(vertices[i], vertices[j], point)
+            if s == 0.0 { continue }
+            if (s > 0.0) != sign { return false }
+        }
+        return true
+    }
+
+    /// Cross product of vectors (a→b) × (a→p).
+    /// Positive = counter-clockwise turn, negative = clockwise.
+    private func crossProduct(_ a: Coordinate3D, _ b: Coordinate3D, _ p: Coordinate3D) -> Double {
+        (b.longitude - a.longitude) * (p.latitude - a.latitude)
+            - (b.latitude - a.latitude) * (p.longitude - a.longitude)
+    }
+
+    /// Linear scan for a tangent vertex in the given direction.
+    /// Direction 1 = right tangent (point is left of both adjacent edges).
+    /// Direction -1 = left tangent (point is right of both adjacent edges).
+    private func findTangent(
+        vertices: [Coordinate3D],
+        point: Coordinate3D,
+        direction: Int
+    ) -> Int? {
+        let n = vertices.count
+        guard n >= 2 else { return nil }
+
+        let dir = Double(direction)
+
+        for i in 0..<n {
+            let prev = (i - 1 + n) % n
+            let next = (i + 1) % n
+
+            let cpPrev = dir * crossProduct(point, vertices[i], vertices[prev])
+            let cpNext = dir * crossProduct(point, vertices[i], vertices[next])
+
+            if cpPrev >= 0 && cpNext >= 0 {
+                return i
+            }
+        }
+
+        return nil
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/PolygonTangentsTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PolygonTangentsTests.swift
@@ -1,0 +1,163 @@
+@testable import GISTools
+import Testing
+
+struct PolygonTangentsTests {
+
+    /// Tests a square polygon with an external point to the right.
+    /// Both tangents should touch the right edge (longitude ≈ 5).
+    @Test
+    func squareRight() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let point = Coordinate3D(latitude: 2.5, longitude: 10.0)
+        let tangentPoints = try #require(polygon.tangentPoints(to: point))
+
+        #expect(tangentPoints.coordinates.count == 2)
+        for coord in tangentPoints.coordinates {
+            #expect(abs(coord.longitude - 5.0) < 0.001)
+        }
+    }
+
+    /// Tests a square polygon with an external point above.
+    /// Both tangents should touch the top edge (latitude ≈ 5).
+    @Test
+    func squareAbove() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let point = Coordinate3D(latitude: 10.0, longitude: 2.5)
+        let tangentPoints = try #require(polygon.tangentPoints(to: point))
+
+        #expect(tangentPoints.coordinates.count == 2)
+        for coord in tangentPoints.coordinates {
+            #expect(abs(coord.latitude - 5.0) < 0.001)
+        }
+    }
+
+    /// Returns nil when the point is inside the polygon.
+    @Test
+    func insideReturnsNil() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let point = Coordinate3D(latitude: 2.5, longitude: 2.5)
+        #expect(polygon.tangentPoints(to: point) == nil)
+    }
+
+    /// Tests a convex pentagon with an external point to the upper-right.
+    @Test
+    func pentagon() async throws {
+        let pentagon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 4.0, longitude: 2.0),
+                Coordinate3D(latitude: 5.0, longitude: 6.0),
+                Coordinate3D(latitude: 1.0, longitude: 8.0),
+                Coordinate3D(latitude: -3.0, longitude: 4.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let point = Coordinate3D(latitude: -5.0, longitude: 15.0)
+        let tangentPoints = try #require(pentagon.tangentPoints(to: point))
+
+        #expect(tangentPoints.coordinates.count == 2)
+        // Both tangents should be on the right side
+        for coord in tangentPoints.coordinates {
+            #expect(coord.longitude > 0.0)
+        }
+    }
+
+    /// Tests a polygon that crosses the antimeridian (~180° longitude).
+    /// The polygon spans from lon=179 to lon=-179 near the equator,
+    /// and the external point is at lon=-170.
+    @Test
+    func antimeridian() async throws {
+        let polygon = Polygon(unchecked: [
+            [
+                Coordinate3D(latitude: 0.0, longitude: 179.0),
+                Coordinate3D(latitude: 5.0, longitude: 179.0),
+                Coordinate3D(latitude: 5.0, longitude: -179.0),
+                Coordinate3D(latitude: 0.0, longitude: -179.0),
+                Coordinate3D(latitude: 0.0, longitude: 179.0),
+            ],
+        ])
+        let point = Coordinate3D(latitude: 2.5, longitude: -170.0)
+        let tangentPoints = try #require(polygon.tangentPoints(to: point))
+
+        #expect(tangentPoints.coordinates.count == 2)
+        for coord in tangentPoints.coordinates {
+            #expect(abs(coord.longitude - -179.0) < 1.0)
+        }
+    }
+
+    /// Tests a polygon crossing the date line (South Pacific) with the external
+    /// point on the opposite side (east of the date line).
+    /// The polygon spans lon=175 to -175 across the date line near Fiji,
+    /// and the point is at lon=-140 (east of the date line).
+    @Test
+    func antimeridianPointOnOtherSide() async throws {
+        let polygon = Polygon(unchecked: [
+            [
+                Coordinate3D(latitude: -15.0, longitude: 175.0),
+                Coordinate3D(latitude: -15.0, longitude: -175.0),
+                Coordinate3D(latitude: -20.0, longitude: -175.0),
+                Coordinate3D(latitude: -20.0, longitude: 175.0),
+                Coordinate3D(latitude: -15.0, longitude: 175.0),
+            ],
+        ])
+        let point = Coordinate3D(latitude: -17.5, longitude: -140.0)
+        let tangentPoints = try #require(polygon.tangentPoints(to: point))
+
+        #expect(tangentPoints.coordinates.count == 2)
+        for coord in tangentPoints.coordinates {
+            #expect(abs(coord.longitude - -175.0) < 1.0)
+        }
+    }
+
+    /// Tests a polygon entirely east of the date line (near Guam) with the
+    /// external point west of the date line. The shortest tangents cross the
+    /// date line; the algorithm must shift the point's longitude so the
+    /// Cartesian cross product reflects the short route.
+    @Test
+    func polygonEastPointWest() async throws {
+        // Small square near Guam: ~144°E–145°E, ~13°N–14°N
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 13.0, longitude: 144.0),
+                Coordinate3D(latitude: 14.0, longitude: 144.0),
+                Coordinate3D(latitude: 14.0, longitude: 145.0),
+                Coordinate3D(latitude: 13.0, longitude: 145.0),
+                Coordinate3D(latitude: 13.0, longitude: 144.0),
+            ],
+        ]))
+        // Point west of the date line, in the central Pacific
+        let point = Coordinate3D(latitude: 13.5, longitude: -170.0)
+        let tangentPoints = try #require(polygon.tangentPoints(to: point))
+
+        #expect(tangentPoints.coordinates.count == 2)
+        // Both tangents should be on the side facing the shifted point (lon ≈ 145)
+        for coord in tangentPoints.coordinates {
+            #expect(abs(coord.longitude - 145.0) < 1.0)
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #137

Ports [@turf/polygon-tangents](https://github.com/Turfjs/turf/tree/master/packages/turf-polygon-tangents) — finds the two tangent points on a convex polygon from an external point.

```swift
let polygon = Polygon([...])!
let point = Coordinate3D(latitude: 2.5, longitude: 10.0)
let tangents = polygon.tangentPoints(to: point)
// tangents → MultiPoint with the two tangent vertices
```

### Implementation

- Linear scan with cross-product orientation checks (O(n))
- Antimeridian handling for polygons spanning the date line
- Detects when a compact polygon is on one side of the date line and the external point on the other, shifting the point by ±360° so the cross product reflects the short route

### Tests (7)

- squareRight — external point to the right of a square
- squareAbove — external point above a square
- insideReturnsNil — point inside the polygon
- pentagon — convex pentagon with external point
- antimeridian — polygon crossing the date line (179 to -179)
- antimeridianPointOnOtherSide — polygon crossing the date line near Fiji, point on opposite side
- polygonEastPointWest — polygon near Guam (144°E), point west of date line (-170°), tangents cross the date line