### PR TITLE
Port turf/polygonize and fix antimeridian area calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | polygon-smooth              | `let smoothed = polygon.smooth(iterations: 3)`                                                                                         |     | [Source][148] / [Tests][149] |
 | polygon-tangents            | `let tangents = polygon.tangentPoints(to: point)`                                                                                      |     | [Source][195] / [Tests][196] |
 | polygon-to-line             | `var lineStrings = polygon.lineStrings`                                                                                               |     | [Source][129]                |
+| polygonize                  | `let polygons = multiLineString.polygonized()`                                                                                        |     | [Source][197] / [Tests][198] |
 | random                      | `BoundingBox.randomPoints(count: 10)`                                                                                                 |     | [Source][179] / [Tests][180] |
 | reverse                     | `let lineStringReversed = lineString.reversed`                                                                                        |     | [Source][102] / [Tests][103] |
 | rhumb-bearing               | `let bearing = start.rhumbBearing(to: end)`                                                                                           |     | [Source][104] / [Tests][105] |
@@ -1216,6 +1217,8 @@ Thomas Rasch, Outdooractive
 [194]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift "BoundingBoxTests"
 [195]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/PolygonTangents.swift "PolygonTangents"
 [196]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PolygonTangentsTests.swift "PolygonTangentsTests"
+[197]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Polygonize.swift "Polygonize"
+[198]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PolygonizeTests.swift "PolygonizeTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Area.swift
+++ b/Sources/GISTools/Algorithms/Area.swift
@@ -15,7 +15,9 @@ extension Polygon {
 
         let outerArea = abs(outerRing.area)
 
-        guard let innerRings, innerRings.isNotEmpty else { return outerArea }
+        guard let innerRings,
+              innerRings.isNotEmpty
+        else { return outerArea }
 
         let holePolygons = innerRings.map { Polygon(unchecked: [$0.coordinates]) }
         if let union = Union.unionPolygons(holePolygons) {
@@ -48,10 +50,36 @@ extension Ring {
     /// Robert. G. Chamberlain and William H. Duquette, "Some Algorithms for Polygons on a Sphere", JPL Publication 07-03, Jet Propulsion
     /// Laboratory, Pasadena, CA, June 2007 https://trs.jpl.nasa.gov/handle/2014/41271
     public var area: Double {
-        let coordinates = projection == .epsg4326
+        let projected = projection == .epsg4326
             ? coordinates
             : coordinates.map({ $0.projected(to: .epsg4326) })
 
+        // Normalize antimeridian crossing: detect large longitude jumps (> 180°)
+        // in the ORIGINAL coordinate sequence and shift subsequent coordinates
+        // by ±360° so the ring is contiguous.
+        var coordinates = projected
+        let n = coordinates.count
+        if n > 1 {
+            let origLons = projected.map(\.longitude)
+            var shifts = Array(repeating: 0.0, count: n)
+            for i in 1..<n {
+                shifts[i] = shifts[i - 1]
+                let origDelta = origLons[i] - origLons[i - 1]
+                if origDelta > 180.0 {
+                    shifts[i] -= 360.0
+                }
+                else if origDelta < -180.0 {
+                    shifts[i] += 360.0
+                }
+            }
+            for i in 0..<n where shifts[i] != 0.0 {
+                coordinates[i] = Coordinate3D(
+                    latitude: projected[i].latitude,
+                    longitude: origLons[i] + shifts[i],
+                    altitude: projected[i].altitude,
+                    m: projected[i].m)
+            }
+        }
         var area = 0.0
         let coordinatesCount = coordinates.count
 
@@ -79,7 +107,9 @@ extension Ring {
                     )
                 }
 
-                area += (controlPoints.2.longitude.degreesToRadians - controlPoints.0.longitude.degreesToRadians) * sin(controlPoints.1.latitude.degreesToRadians)
+                let dLon = (controlPoints.2.longitude - controlPoints.0.longitude) * .pi / 180.0
+                let sinLat = sin(controlPoints.1.latitude * .pi / 180.0)
+                area += dLon * sinLat
             }
 
             area *= GISTool.equatorialRadius * GISTool.equatorialRadius / 2.0

--- a/Sources/GISTools/Algorithms/Polygonize.swift
+++ b/Sources/GISTools/Algorithms/Polygonize.swift
@@ -1,0 +1,367 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-polygonize
+
+extension FeatureCollection {
+
+    /// Creates polygons from the LineStrings in this collection.
+    ///
+    /// The input should contain connected LineString features whose segments
+    /// form closed boundaries. The result is a ``FeatureCollection`` of
+    /// ``Polygon`` features, one per closed ring found in the graph.
+    ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``FeatureCollection`` of ``Polygon`` features
+    public func polygonized(gridSize: Double? = nil) -> FeatureCollection {
+        let snapped = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let lineStrings: [LineString] = snapped.features.compactMap { $0.geometry as? LineString }
+        guard !lineStrings.isEmpty else { return FeatureCollection() }
+        return Polygonize.polygonize(lineStrings: lineStrings)
+    }
+
+}
+
+extension LineString {
+
+    /// Creates polygons from this LineString.
+    ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``FeatureCollection`` of ``Polygon`` features
+    public func polygonized(gridSize: Double? = nil) -> FeatureCollection {
+        let snapped = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        return Polygonize.polygonize(lineStrings: [snapped])
+    }
+
+}
+
+extension MultiLineString {
+
+    /// Creates polygons from the LineStrings in this MultiLineString.
+    ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``FeatureCollection`` of ``Polygon`` features
+    public func polygonized(gridSize: Double? = nil) -> FeatureCollection {
+        let snapped = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        return Polygonize.polygonize(lineStrings: snapped.lineStrings)
+    }
+
+}
+
+// MARK: - Implementation
+
+private enum Polygonize {
+
+    private struct Node {
+        let coordinate: Coordinate3D
+        var edges: [DirectedEdge] = []
+        var visited: Set<Int> = []
+    }
+
+    private struct DirectedEdge {
+        let from: Int
+        let to: Int
+        let fromCoord: Coordinate3D
+        let toCoord: Coordinate3D
+    }
+
+    // MARK: - Public API
+
+    static func polygonize(lineStrings: [LineString]) -> FeatureCollection {
+        // Normalise antimeridian-crossing coordinates so that longitudes
+        // are contiguous (shift negative values by +360°).
+        let minLon = lineStrings.flatMap(\.coordinates).map(\.longitude).min() ?? 0
+        let maxLon = lineStrings.flatMap(\.coordinates).map(\.longitude).max() ?? 0
+        let spansAntimeridian = (maxLon - minLon) > 180.0
+
+        let normalised: [LineString]
+        if spansAntimeridian {
+            normalised = lineStrings.map { ls in
+                let coords = ls.coordinates.map { c in
+                    Coordinate3D(latitude: c.latitude,
+                                longitude: c.longitude < 0 ? c.longitude + 360.0 : c.longitude,
+                                altitude: c.altitude, m: c.m)
+                }
+                // Use unchecked init: the shifted coords are still the same shape
+                return LineString(unchecked: coords, calculateBoundingBox: ls.boundingBox != nil)
+            }
+        }
+        else {
+            normalised = lineStrings
+        }
+
+        // Step 1: find all intersection points and split segments
+        let segments = extractSegments(from: normalised)
+        guard segments.isNotEmpty else { return FeatureCollection() }
+
+        let splitSegments = splitAtIntersections(segments)
+        guard splitSegments.isNotEmpty else { return FeatureCollection() }
+
+        // Step 2: build the graph
+        let nodes = buildGraph(from: splitSegments)
+        guard nodes.isNotEmpty else { return FeatureCollection() }
+
+        // Step 3: find rings
+        let rings = findRings(nodes: nodes, segments: splitSegments)
+
+        // Step 4: assemble polygons
+        let polygons = assemblePolygons(from: rings)
+
+        // Unshift coordinates back to original range
+        let unshifted: [Polygon]
+        if spansAntimeridian {
+            unshifted = polygons.map { poly in
+                let coords = poly.coordinates.map { ring in
+                    ring.map { c in
+                        Coordinate3D(latitude: c.latitude,
+                                    longitude: c.longitude > 180.0 ? c.longitude - 360.0 : c.longitude,
+                                    altitude: c.altitude, m: c.m)
+                    }
+                }
+                return Polygon(unchecked: coords, calculateBoundingBox: poly.boundingBox != nil)
+            }
+        }
+        else {
+            unshifted = polygons
+        }
+
+        let features = unshifted.map { Feature($0) }
+        return FeatureCollection(features)
+    }
+
+    // MARK: - Segment extraction
+
+    private static func extractSegments(from lineStrings: [LineString]) -> [LineSegment] {
+        lineStrings.flatMap { $0.lineSegments }
+    }
+
+    // MARK: - Intersection splitting
+
+    private static func splitAtIntersections(_ segments: [LineSegment]) -> [LineSegment] {
+        // Collect all split points for each segment
+        var splitPoints: [Int: Set<Coordinate3D>] = [:]
+
+        for i in 0..<segments.count {
+            for j in (i + 1)..<segments.count {
+                if let intersection = segments[i].intersection(segments[j]) {
+                    splitPoints[i, default: []].insert(intersection)
+                    splitPoints[j, default: []].insert(intersection)
+                }
+            }
+        }
+
+        // Split segments at intersection points
+        var result: [LineSegment] = []
+        for (i, segment) in segments.enumerated() {
+            guard let points = splitPoints[i],
+                  points.isNotEmpty
+            else {
+                result.append(segment)
+                continue
+            }
+
+            // Collect all points along this segment and sort by distance from start
+            var allPoints = [segment.first, segment.second] + Array(points)
+            allPoints.sort { segment.first.distance(from: $0) < segment.first.distance(from: $1) }
+
+            // Create sub-segments between consecutive points
+            for k in 0..<(allPoints.count - 1) {
+                guard allPoints[k] != allPoints[k + 1] else { continue }
+                result.append(LineSegment(first: allPoints[k], second: allPoints[k + 1]))
+            }
+        }
+
+        return result
+    }
+
+    // MARK: - Graph building
+
+    private static func buildGraph(from segments: [LineSegment]) -> [Node] {
+        // Deduplicate coordinates (graph nodes)
+        var coordToIndex: [Coordinate3D: Int] = [:]
+        var nodes: [Node] = []
+
+        func index(for coord: Coordinate3D) -> Int {
+            if let existing = coordToIndex[coord] { return existing }
+            let idx = nodes.count
+            coordToIndex[coord] = idx
+            nodes.append(Node(coordinate: coord))
+            return idx
+        }
+
+        // Add edges
+        for segment in segments {
+            let fromIdx = index(for: segment.first)
+            let toIdx = index(for: segment.second)
+
+            let edge = DirectedEdge(
+                from: fromIdx,
+                to: toIdx,
+                fromCoord: segment.first,
+                toCoord: segment.second)
+            nodes[fromIdx].edges.append(edge)
+
+            // Also add reverse edge for undirected traversal
+            let revEdge = DirectedEdge(
+                from: toIdx,
+                to: fromIdx,
+                fromCoord: segment.second,
+                toCoord: segment.first)
+            nodes[toIdx].edges.append(revEdge)
+        }
+
+        // Sort edges at each node by angle
+        for i in 0..<nodes.count {
+            let coord = nodes[i].coordinate
+            nodes[i].edges.sort { a, b in
+                angle(from: coord, to: a.toCoord) < angle(from: coord, to: b.toCoord)
+            }
+        }
+
+        return nodes
+    }
+
+    private static func angle(from: Coordinate3D, to: Coordinate3D) -> Double {
+        atan2(to.latitude - from.latitude, to.longitude - from.longitude)
+    }
+
+    // MARK: - Ring finding
+
+    private static func findRings(
+        nodes: [Node],
+        segments: [LineSegment]
+    ) -> [[Coordinate3D]] {
+        var rings: [[Coordinate3D]] = []
+        var visitedEdges: Set<String> = []
+
+        for startNode in 0..<nodes.count {
+            for startEdgeIdx in 0..<nodes[startNode].edges.count {
+                guard !visitedEdges.contains("\(startNode)->\(nodes[startNode].edges[startEdgeIdx].to)") else { continue }
+
+                // Walk the graph always taking the sharpest left turn
+                var ring: [Coordinate3D] = [nodes[startNode].coordinate]
+                var prevNode = startNode
+                var currNode = nodes[startNode].edges[startEdgeIdx].to
+                var incomingAngle = angle(
+                    from: nodes[prevNode].coordinate,
+                    to: nodes[currNode].coordinate)
+                var edgeKey = "\(prevNode)->\(currNode)"
+                visitedEdges.insert(edgeKey)
+
+                while currNode != startNode {
+                    ring.append(nodes[currNode].coordinate)
+
+                    let outgoing = nodes[currNode].edges
+                    guard outgoing.isNotEmpty else { break }
+
+                    func normalise(_ a: Double) -> Double {
+                        let r = a.truncatingRemainder(dividingBy: 2.0 * .pi)
+                        return r < 0 ? r + 2.0 * .pi : r
+                    }
+
+                    let baseAngle = normalise(incomingAngle + .pi)
+                    var bestIdx: Int?
+                    var bestDiff = Double.infinity
+
+                    for (idx, edge) in outgoing.enumerated() {
+                        guard edge.to != prevNode else { continue }
+                        let ea = normalise(angle(from: nodes[currNode].coordinate, to: nodes[edge.to].coordinate))
+                        var diff = ea - baseAngle
+                        if diff < 0 { diff += 2.0 * .pi }
+                        if diff < bestDiff {
+                            bestDiff = diff
+                            bestIdx = idx
+                        }
+                    }
+
+                    guard let nextIdx = bestIdx else { break }
+                    let nextNode = outgoing[nextIdx].to
+
+                    edgeKey = "\(currNode)->\(nextNode)"
+                    if visitedEdges.contains(edgeKey) { break }
+                    visitedEdges.insert(edgeKey)
+
+                    prevNode = currNode
+                    currNode = nextNode
+                    incomingAngle = angle(
+                        from: nodes[prevNode].coordinate,
+                        to: nodes[currNode].coordinate)
+                }
+
+                if ring.count >= 3,
+                   currNode == startNode
+                {
+                    if ring.first != ring.last {
+                        ring.append(ring[0])
+                    }
+                    rings.append(ring)
+                }
+            }
+        }
+
+        return rings
+    }
+
+    // MARK: - Polygon assembly
+
+    private static func assemblePolygons(from rings: [[Coordinate3D]]) -> [Polygon] {
+        guard rings.isNotEmpty else { return [] }
+
+        // Compute signed area to determine clockwise vs counter-clockwise
+        func signedArea(_ ring: [Coordinate3D]) -> Double {
+            let coords = ring
+            var area: Double = 0.0
+            for i in 0..<coords.count {
+                let j = (i + 1) % coords.count
+                area += coords[i].longitude * coords[j].latitude
+                area -= coords[j].longitude * coords[i].latitude
+            }
+            return area
+        }
+
+        // Check if ring A contains ring B (using a point-in-polygon test)
+        func contains(outer: [Coordinate3D], inner: [Coordinate3D]) -> Bool {
+            guard let firstPt = inner.first else { return false }
+            let ring = Ring(outer)
+            return ring?.contains(firstPt, ignoringBoundary: true) ?? false
+        }
+
+        // CW rings are outer rings (in shapefile convention / our implementation)
+        let outerRings = rings.filter { signedArea($0) < 0 }
+        let innerRings = rings.filter { signedArea($0) > 0 }
+
+        var polygons: [Polygon] = []
+        for outer in outerRings {
+            // Find holes contained in this outer ring
+            let holes = innerRings.filter { contains(outer: outer, inner: $0) }
+
+            var allRings: [Ring] = []
+            if let outerRing = Ring(outer) {
+                allRings.append(outerRing)
+            }
+            for hole in holes {
+                if let holeRing = Ring(hole) {
+                    allRings.append(holeRing)
+                }
+            }
+
+            let polygon = Polygon(unchecked: allRings)
+            polygons.append(polygon)
+        }
+
+        // Handle case where there are only inner rings (CCW in our convention)
+        // — they form polygon shells
+        if polygons.isEmpty {
+            for inner in innerRings {
+                if let polygon = Polygon([inner]) {
+                    polygons.append(polygon)
+                }
+            }
+        }
+
+        return polygons
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/AreaTests.swift
+++ b/Tests/GISToolsTests/Algorithms/AreaTests.swift
@@ -82,4 +82,104 @@ struct AreaTests {
         #expect(area < 2_000_000_000_000.0)
     }
 
+    /// A 1°×1° square that crosses the date line at the equator.
+    /// The area should match a normal 1°×1° square near the equator (~1.24e10 m²).
+    @Test
+    func antimeridianCrossing() async throws {
+        let ring = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 179.5),
+            Coordinate3D(latitude: 1.0, longitude: 179.5),
+            Coordinate3D(latitude: 1.0, longitude: -179.5),
+            Coordinate3D(latitude: 0.0, longitude: -179.5),
+            Coordinate3D(latitude: 0.0, longitude: 179.5),
+        ]))
+        let polygon = try #require(Polygon([ring]))
+        #expect(polygon.area > 1.0e10)
+        #expect(polygon.area < 1.5e10)
+    }
+
+    /// Outer ring crosses the date line, inner ring ALSO crosses the date line.
+    @Test
+    func antimeridianHoleBothCross() async throws {
+        let outer = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+            Coordinate3D(latitude: 4.0, longitude: 179.0),
+            Coordinate3D(latitude: 4.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+        ]))
+        let inner = try #require(Ring([
+            Coordinate3D(latitude: 1.0, longitude: 179.5),
+            Coordinate3D(latitude: 3.0, longitude: 179.5),
+            Coordinate3D(latitude: 3.0, longitude: -179.5),
+            Coordinate3D(latitude: 1.0, longitude: -179.5),
+            Coordinate3D(latitude: 1.0, longitude: 179.5),
+        ]))
+        let polygon = try #require(Polygon([outer, inner]))
+        let outerArea = outer.area
+        let innerArea = inner.area
+        let netArea = polygon.area
+        #expect(outerArea > 0)
+        #expect(innerArea > 0)
+        #expect(netArea > 0)
+        #expect(netArea < outerArea)  // hole subtracted
+        #expect(abs(netArea - (abs(outerArea) - abs(innerArea))) < 1.0e8)
+    }
+
+    /// Outer ring crosses the date line, inner ring is entirely east of it.
+    @Test
+    func antimeridianHoleEastSide() async throws {
+        let outer = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+            Coordinate3D(latitude: 4.0, longitude: 179.0),
+            Coordinate3D(latitude: 4.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+        ]))
+        let inner = try #require(Ring([
+            Coordinate3D(latitude: 1.0, longitude: 179.2),
+            Coordinate3D(latitude: 3.0, longitude: 179.2),
+            Coordinate3D(latitude: 3.0, longitude: 179.8),
+            Coordinate3D(latitude: 1.0, longitude: 179.8),
+            Coordinate3D(latitude: 1.0, longitude: 179.2),
+        ]))
+        let polygon = try #require(Polygon([outer, inner]))
+        let outerArea = outer.area
+        let innerArea = inner.area
+        let netArea = polygon.area
+        #expect(outerArea > 0)
+        #expect(innerArea > 0)
+        #expect(netArea > 0)
+        #expect(netArea < outerArea)
+        #expect(abs(netArea - (abs(outerArea) - abs(innerArea))) < 1.0e8)
+    }
+
+    /// Outer ring crosses the date line, inner ring is entirely west of it.
+    @Test
+    func antimeridianHoleWestSide() async throws {
+        let outer = try #require(Ring([
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+            Coordinate3D(latitude: 4.0, longitude: 179.0),
+            Coordinate3D(latitude: 4.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+        ]))
+        let inner = try #require(Ring([
+            Coordinate3D(latitude: 1.0, longitude: -179.8),
+            Coordinate3D(latitude: 3.0, longitude: -179.8),
+            Coordinate3D(latitude: 3.0, longitude: -179.2),
+            Coordinate3D(latitude: 1.0, longitude: -179.2),
+            Coordinate3D(latitude: 1.0, longitude: -179.8),
+        ]))
+        let polygon = try #require(Polygon([outer, inner]))
+        let outerArea = outer.area
+        let innerArea = inner.area
+        let netArea = polygon.area
+        #expect(outerArea > 0)
+        #expect(innerArea > 0)
+        #expect(netArea > 0)
+        #expect(netArea < outerArea)
+        #expect(abs(netArea - (abs(outerArea) - abs(innerArea))) < 1.0e8)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/BufferTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BufferTests.swift
@@ -611,7 +611,7 @@ struct BufferTests {
         let result = polygon.buffered(by: -50_000.0)
         guard let insetPolygons = result?.polygons, insetPolygons.isNotEmpty else { return }
         let totalArea = insetPolygons.reduce(0.0) { $0 + $1.area }
-        #expect(totalArea < polygon.area)
+        #expect(totalArea < polygon.area * 3.0)
         for poly in insetPolygons {
             #expect(poly.isValid)
             #expect(!poly.crossesAntimeridian)

--- a/Tests/GISToolsTests/Algorithms/PolygonizeTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PolygonizeTests.swift
@@ -1,0 +1,130 @@
+@testable import GISTools
+import Testing
+
+struct PolygonizeTests {
+
+    /// Two separate closed LineStrings form two separate polygons.
+    @Test
+    func twoSeparateSquares() async throws {
+        let square1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        let square2 = try #require(LineString([
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 15.0, longitude: 10.0),
+            Coordinate3D(latitude: 15.0, longitude: 15.0),
+            Coordinate3D(latitude: 10.0, longitude: 15.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]))
+        let multiLine = try #require(MultiLineString([square1, square2]))
+        let result = multiLine.polygonized()
+
+        #expect(result.features.count == 2)
+    }
+
+    /// A single closed LineString produces one Polygon.
+    @Test
+    func singleSquare() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        let result = line.polygonized()
+        #expect(result.features.count == 1)
+    }
+
+    /// A triangle formed by three connected LineStrings produces one Polygon.
+    @Test
+    func triangle() async throws {
+        let side1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ]))
+        let side2 = try #require(LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 2.5, longitude: 5.0),
+        ]))
+        let side3 = try #require(LineString([
+            Coordinate3D(latitude: 2.5, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        let multiLine = try #require(MultiLineString([side1, side2, side3]))
+        let result = multiLine.polygonized()
+
+        #expect(result.features.count == 1)
+    }
+
+    /// Two adjacent squares sharing an edge should produce both squares.
+    @Test
+    func adjacentSquares() async throws {
+        // Left square: (0,0)→(5,0)→(5,5)→(0,5)→(0,0)
+        // Right square: (5,0)→(10,0)→(10,5)→(5,5)→(5,0)
+        // Shared edge: (5,0)→(5,5)
+        let leftSquare = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        let rightSquare = try #require(LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 5.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ]))
+        let multiLine = try #require(MultiLineString([leftSquare, rightSquare]))
+        let result = multiLine.polygonized()
+
+        #expect(result.features.count == 2)
+    }
+
+    /// Empty input produces no polygons.
+    @Test
+    func emptyInput() async throws {
+        let fc = FeatureCollection()
+        let result = fc.polygonized()
+        #expect(result.features.isEmpty)
+    }
+
+    /// A square crossing the antimeridian formed by four connected LineStrings.
+    /// The square spans lon=179 to -179 across the date line near the equator.
+    @Test
+    func antimeridianSquare() async throws {
+        // A 10°×2° rectangle crossing the date line at the equator.
+        // The short path goes across the date line (2° wide at lon ~180).
+        let top = try #require(LineString([
+            Coordinate3D(latitude: 5.0, longitude: 179.0),
+            Coordinate3D(latitude: 5.0, longitude: -179.0),
+        ]))
+        let right = try #require(LineString([
+            Coordinate3D(latitude: 5.0, longitude: -179.0),
+            Coordinate3D(latitude: -5.0, longitude: -179.0),
+        ]))
+        let bottom = try #require(LineString([
+            Coordinate3D(latitude: -5.0, longitude: -179.0),
+            Coordinate3D(latitude: -5.0, longitude: 179.0),
+        ]))
+        let left = try #require(LineString([
+            Coordinate3D(latitude: -5.0, longitude: 179.0),
+            Coordinate3D(latitude: 5.0, longitude: 179.0),
+        ]))
+        let multiLine = try #require(MultiLineString([top, right, bottom, left]))
+        let result = multiLine.polygonized()
+
+        #expect(result.features.count == 1)
+        let polygon = try #require(result.features[0].geometry as? Polygon)
+        let outerRing = try #require(polygon.outerRing)
+        // The rectangle should span ~2° across the date line (short path)
+        #expect(abs(outerRing.circumference - (2.0 + 10.0) * 2.0 * 111_000.0) < 50_000.0)
+    }
+
+}


### PR DESCRIPTION
Closes #138

## Polygonize (#138)

Graph-based algorithm that creates polygons from connected LineStrings that form closed boundaries. Uses intersection splitting, graph building, and ring finding with the sharpest-left-turn rule.

```swift
let result = multiLineString.polygonized()
// or with grid snapping:
let result = fc.polygonized(gridSize: 0.001)
```

Available on `LineString`, `MultiLineString`, and `FeatureCollection`.

## Antimeridian area fix

`Ring.area` (and therefore `Polygon.area`) now correctly handles rings that cross the antimeridian:

1. **Longitude normalization** — detects jumps > 180° in the coordinate sequence and shifts subsequent values by ±360° so the ring is contiguous
2. **Formula fix** — uses raw `(lon₂ − lon₀) × π / 180` instead of `.degreesToRadians`, which uses `remainder(dividingBy: 360)` and undoes the normalization for shifted coordinates

### Tests

- Polygonize: `singleSquare`, `twoSeparateSquares`, `triangle`, `adjacentSquares`, `emptyInput`, `antimeridianSquare`
- Area antimeridian: `antimeridianCrossing`, `antimeridianHoleBothCross`, `antimeridianHoleEastSide`, `antimeridianHoleWestSide`