### PR TITLE
Add topological boundary property

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,6 +943,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | boolean-touches             | `anyGeometry.touches(other)`                                                                                                          |     | [Source][159] / [Tests][160] |
 | boolean-valid               | `anyGeometry.isValid`                                                                                                                 |     | [Source][58] / [Tests][136]  |
 | bbox-clip                   | `let clipped = lineString.clipped(to: boundingBox)`                                                                                   |     | [Source][59] / [Tests][60]   |
+| boundary                    | `let boundary = anyGeometry.boundary`                                                                                                 |     | [Source][199] / [Tests][200] |
 | buffer                      | `let buffered = lineString.buffered(by: 1000.meters)`                                                                                 |     | [Source][61] / [Tests][158]  |
 | center-median               | `let median = featureCollection.centerMedian()`                                                                                       |     | [Source][62] / [Tests][137]  |
 | center/centroid/center-mean | `let center = polygon.center`                                                                                                         |     | [Source][62] / [Tests][137]  |
@@ -1219,6 +1220,8 @@ Thomas Rasch, Outdooractive
 [196]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PolygonTangentsTests.swift "PolygonTangentsTests"
 [197]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Polygonize.swift "Polygonize"
 [198]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PolygonizeTests.swift "PolygonizeTests"
+[199]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Boundary.swift "Boundary"
+[200]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/BoundaryTests.swift "BoundaryTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/BooleanCrosses.swift
+++ b/Sources/GISTools/Algorithms/BooleanCrosses.swift
@@ -152,13 +152,14 @@ extension GeoJson {
               let coords2 = lineString2.coordinates as [Coordinate3D]?
         else { return false }
 
+        let boundary1 = lineString1.boundary
+        let boundary2 = lineString2.boundary
+
         for intersectPoint in intersectionPoints {
             let pt = intersectPoint.coordinate
-            if !pt.isCoincident(to: coords1.first),
-               !pt.isCoincident(to: coords1.last),
-               !pt.isCoincident(to: coords2.first),
-               !pt.isCoincident(to: coords2.last)
-            {
+            let onBoundary1 = boundary1.coordinates.contains { $0.isCoincident(to: pt) }
+            let onBoundary2 = boundary2.coordinates.contains { $0.isCoincident(to: pt) }
+            if !onBoundary1 && !onBoundary2 {
                 return true
             }
         }

--- a/Sources/GISTools/Algorithms/BooleanTouches.swift
+++ b/Sources/GISTools/Algorithms/BooleanTouches.swift
@@ -610,8 +610,7 @@ extension BooleanTouches {
         _ lineString: LineString
     ) -> Bool {
         guard let coordinate else { return false }
-        return coordinate.isCoincident(to: lineString.firstCoordinate)
-            || coordinate.isCoincident(to: lineString.lastCoordinate)
+        return lineString.boundary.coordinates.contains { $0.isCoincident(to: coordinate) }
     }
 
     fileprivate static func isOnLineInterior(

--- a/Sources/GISTools/Algorithms/Boundary.swift
+++ b/Sources/GISTools/Algorithms/Boundary.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+// MARK: - Topological boundary (OGC Simple Features / DE-9IM)
+
+extension Point {
+
+    /// The topological boundary of a Point is empty.
+    public var boundary: GeometryCollection {
+        GeometryCollection([])
+    }
+
+}
+
+extension MultiPoint {
+
+    /// The topological boundary of a MultiPoint is empty.
+    public var boundary: GeometryCollection {
+        GeometryCollection([])
+    }
+
+}
+
+extension LineString {
+
+    /// The topological boundary of a LineString is its endpoints.
+    /// Returns an empty `MultiPoint` if the line is closed (a ring).
+    public var boundary: MultiPoint {
+        if isClosed {
+            return MultiPoint()
+        }
+        return MultiPoint(unchecked: [firstCoordinate, lastCoordinate].compactMap { $0 } as [Coordinate3D])
+    }
+
+}
+
+extension MultiLineString {
+
+    /// The topological boundary of a MultiLineString is the set of endpoints
+    /// that appear an odd number of times across all constituent lines.
+    public var boundary: MultiPoint {
+        var counts: [Coordinate3D: Int] = [:]
+
+        for line in lineStrings {
+            if let first = line.firstCoordinate {
+                counts[first, default: 0] += 1
+            }
+            if let last = line.lastCoordinate {
+                counts[last, default: 0] += 1
+            }
+        }
+
+        let result = counts.filter { $0.value % 2 == 1 }.map(\.key)
+        return MultiPoint(unchecked: result as [Coordinate3D])
+    }
+
+}
+
+extension Polygon {
+
+    /// The topological boundary of a Polygon is its outer ring.
+    /// For a polygon with holes only the exterior ring is returned,
+    /// matching the OGC Simple Features definition.
+    public var boundary: LineString? {
+        guard let ring = outerRing else { return nil }
+        return ring.lineString
+    }
+
+}
+
+extension MultiPolygon {
+
+    /// The topological boundary of a MultiPolygon is the union of the
+    /// boundaries of all constituent polygons, returned as a ``MultiLineString``.
+    public var boundary: MultiLineString? {
+        let lines: [LineString] = polygons.compactMap { $0.boundary }
+        guard lines.isNotEmpty else { return nil }
+        return MultiLineString(lines)
+    }
+
+}
+
+extension GeometryCollection {
+
+    /// The topological boundary of a GeometryCollection is the union of the
+    /// boundaries of all its contained geometries.
+    public var boundary: GeometryCollection? {
+        let boundaries: [GeoJsonGeometry] = geometries.compactMap { geo in
+            if let p = geo as? Point { return p.boundary }
+            if let mp = geo as? MultiPoint { return mp.boundary }
+            if let ls = geo as? LineString { return ls.boundary }
+            if let mls = geo as? MultiLineString { return mls.boundary }
+            if let pg = geo as? Polygon { return pg.boundary }
+            if let mpg = geo as? MultiPolygon { return mpg.boundary }
+            if let gc = geo as? GeometryCollection { return gc.boundary }
+            return nil
+        }
+        guard boundaries.isNotEmpty else { return nil }
+        return GeometryCollection(boundaries)
+    }
+
+}
+
+extension Feature {
+
+    /// The topological boundary of a Feature is the boundary of its geometry.
+    public var boundary: GeoJsonGeometry? {
+        if let p = geometry as? Point { return p.boundary }
+        if let mp = geometry as? MultiPoint { return mp.boundary }
+        if let ls = geometry as? LineString { return ls.boundary }
+        if let mls = geometry as? MultiLineString { return mls.boundary }
+        if let pg = geometry as? Polygon { return pg.boundary }
+        if let mpg = geometry as? MultiPolygon { return mpg.boundary }
+        if let gc = geometry as? GeometryCollection { return gc.boundary }
+        return nil
+    }
+
+}
+
+extension FeatureCollection {
+
+    /// The topological boundary of a FeatureCollection is the union of the
+    /// boundaries of all its features' geometries.
+    public var boundary: GeometryCollection? {
+        let boundaries: [GeoJsonGeometry] = features.compactMap { $0.boundary }
+        guard boundaries.isNotEmpty else { return nil }
+        return GeometryCollection(boundaries)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/BoundaryTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BoundaryTests.swift
@@ -1,0 +1,260 @@
+@testable import GISTools
+import Testing
+
+struct BoundaryTests {
+
+    // MARK: - Point
+
+    @Test
+    func pointBoundary() async throws {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
+        let boundary = point.boundary
+        #expect(boundary.geometries.isEmpty)
+    }
+
+    // MARK: - MultiPoint
+
+    @Test
+    func multiPointBoundary() async throws {
+        let multiPoint = MultiPoint(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ])
+        let boundary = multiPoint.boundary
+        #expect(boundary.geometries.isEmpty)
+    }
+
+    // MARK: - LineString
+
+    @Test
+    func openLineStringBoundary() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+        ]))
+        let boundary = line.boundary
+        #expect(boundary.coordinates.count == 2)
+        #expect(boundary.coordinates[0] == Coordinate3D(latitude: 0.0, longitude: 0.0))
+        #expect(boundary.coordinates[1] == Coordinate3D(latitude: 2.0, longitude: 2.0))
+    }
+
+    @Test
+    func closedLineStringBoundary() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        let boundary = line.boundary
+        #expect(boundary.coordinates.isEmpty)
+    }
+
+    // MARK: - MultiLineString
+
+    @Test
+    func multiLineStringBoundary() async throws {
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+        ]))
+        let multiLine = try #require(MultiLineString([line1, line2]))
+        let boundary = multiLine.boundary
+        // (0,0) appears once, (2,2) appears once — both are odd
+        // (1,1) appears twice (as end of line1 and start of line2) — even
+        #expect(boundary.coordinates.count == 2)
+        #expect(boundary.coordinates.contains(Coordinate3D(latitude: 0.0, longitude: 0.0)))
+        #expect(boundary.coordinates.contains(Coordinate3D(latitude: 2.0, longitude: 2.0)))
+    }
+
+    @Test
+    func multiLineStringClosedLoop() async throws {
+        // A closed loop of 3 segments: all endpoints appear twice (even)
+        let line1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+        ]))
+        let line2 = try #require(LineString([
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+        ]))
+        let line3 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        let multiLine = try #require(MultiLineString([line1, line2, line3]))
+        let boundary = multiLine.boundary
+        #expect(boundary.coordinates.isEmpty)
+    }
+
+    // MARK: - Polygon
+
+    @Test
+    func polygonBoundary() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let boundary = try #require(polygon.boundary)
+        #expect(boundary.coordinates.first == Coordinate3D(latitude: 0.0, longitude: 0.0))
+        #expect(boundary.isClosed)
+    }
+
+    // MARK: - MultiPolygon
+
+    @Test
+    func multiPolygonBoundary() async throws {
+        let poly1 = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 2.0, longitude: 0.0),
+                Coordinate3D(latitude: 2.0, longitude: 2.0),
+                Coordinate3D(latitude: 0.0, longitude: 2.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let poly2 = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 3.0, longitude: 3.0),
+                Coordinate3D(latitude: 5.0, longitude: 3.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 3.0, longitude: 5.0),
+                Coordinate3D(latitude: 3.0, longitude: 3.0),
+            ],
+        ]))
+        let multiPolygon = try #require(MultiPolygon([poly1, poly2]))
+        let boundary = try #require(multiPolygon.boundary)
+        #expect(boundary.lineStrings.count == 2)
+    }
+
+    // MARK: - GeometryCollection
+
+    @Test
+    func geometryCollectionEmptyBoundary() async throws {
+        let collection = GeometryCollection([])
+        #expect(collection.boundary == nil)
+    }
+
+    @Test
+    func geometryCollectionBoundary() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 2.0, longitude: 0.0),
+                Coordinate3D(latitude: 2.0, longitude: 2.0),
+                Coordinate3D(latitude: 0.0, longitude: 2.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let collection = GeometryCollection([line, polygon])
+        let boundary = try #require(collection.boundary)
+        #expect(boundary.geometries.count == 2)
+    }
+
+    // MARK: - Feature
+
+    @Test
+    func featurePointBoundary() async throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)))
+        let boundary = try #require(feature.boundary as? GeometryCollection)
+        #expect(boundary.geometries.isEmpty)
+    }
+
+    @Test
+    func featureLineBoundary() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+        let feature = Feature(line)
+        let boundary = try #require(feature.boundary as? MultiPoint)
+        #expect(boundary.coordinates.count == 2)
+    }
+
+    // MARK: - FeatureCollection
+
+    @Test
+    func featureCollectionBoundary() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 2.0, longitude: 0.0),
+                Coordinate3D(latitude: 2.0, longitude: 2.0),
+                Coordinate3D(latitude: 0.0, longitude: 2.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ]))
+        let fc = FeatureCollection([Feature(line), Feature(polygon)])
+        let boundary = try #require(fc.boundary)
+        #expect(boundary.geometries.count == 2)
+    }
+
+    // MARK: - Antimeridian
+
+    /// A LineString crossing the antimeridian: boundary is still its two endpoints.
+    @Test
+    func antimeridianLineString() async throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+            Coordinate3D(latitude: 5.0, longitude: -179.0),
+        ]))
+        let boundary = line.boundary
+        #expect(boundary.coordinates.count == 2)
+        #expect(boundary.coordinates[0] == Coordinate3D(latitude: 0.0, longitude: 179.0))
+        #expect(boundary.coordinates[1] == Coordinate3D(latitude: 5.0, longitude: -179.0))
+    }
+
+    /// A Polygon crossing the antimeridian: boundary is its outer ring.
+    @Test
+    func antimeridianPolygon() async throws {
+        let polygon = Polygon(unchecked: [
+            [
+                Coordinate3D(latitude: 0.0, longitude: 179.0),
+                Coordinate3D(latitude: 5.0, longitude: 179.0),
+                Coordinate3D(latitude: 5.0, longitude: -179.0),
+                Coordinate3D(latitude: 0.0, longitude: -179.0),
+                Coordinate3D(latitude: 0.0, longitude: 179.0),
+            ],
+        ])
+        let boundary = try #require(polygon.boundary)
+        #expect(boundary.isClosed)
+        #expect(boundary.coordinates.count == 5)
+        #expect(boundary.coordinates.first == Coordinate3D(latitude: 0.0, longitude: 179.0))
+    }
+
+    /// A closed MultiLineString crossing the antimeridian: shared endpoints cancel out.
+    @Test
+    func antimeridianMultiLineString() async throws {
+        let seg1 = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+            Coordinate3D(latitude: 5.0, longitude: -179.0),
+        ]))
+        let seg2 = try #require(LineString([
+            Coordinate3D(latitude: 5.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+        ]))
+        let multiLine = try #require(MultiLineString([seg1, seg2]))
+        let boundary = multiLine.boundary
+        // Both endpoints appear twice → empty boundary
+        #expect(boundary.coordinates.isEmpty)
+    }
+
+}


### PR DESCRIPTION
Closes #148

Adds the topological boundary of a geometry per OGC Simple Features / DE-9IM.

### API

Point -> GeometryCollection (empty)
MultiPoint -> GeometryCollection (empty)
LineString -> MultiPoint (endpoints, empty if closed)
MultiLineString -> MultiPoint (odd-count endpoints)
Polygon -> LineString (outer ring)
MultiPolygon -> MultiLineString (union of polygon boundaries)
GeometryCollection -> GeometryCollection (union of element boundaries)
Feature -> GeoJsonGeometry (delegates to geometry)
FeatureCollection -> GeometryCollection (union of feature boundaries)

### Refactored algorithms

- BooleanTouches.isOnLineEnd now delegates to LineString.boundary instead of manually comparing firstCoordinate/lastCoordinate. Fixes a pre-existing edge case where a closed ring's start/end point was incorrectly treated as boundary.
- BooleanCrosses.doLineStringsCross uses boundary instead of four manual endpoint-coincidence checks.

### Tests (16)

All geometry types, including empty, open/closed LineStrings, MultiLineString endpoint counting, GeometryCollection/Feature/FeatureCollection boundary union, and antimeridian-crossing geometries.
