### PR TITLE
Port turf/planepoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,6 +980,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | nearest-point-on-feature    | `let nearest = anyGeometry. nearestCoordinateOnFeature(from: Coordinate3D(…))`                                                        |     | [Source][93] / [Tests][139]  |
 | nearest-point-on-line       | `let nearest = lineString.nearestCoordinateOnLine(from: Coordinate3D(…))?.coordinate`                                                 |     | [Source][94] / [Tests][95]   |
 | nearest-point-to-line       | `let nearest = lineString. nearestCoordinate(outOf: coordinates)`                                                                     |     | [Source][96] / [Tests][140]  |
+| planepoint                  | `let z = triangle.planepoint(point)`                                                                                                  |     | [Source][201] / [Tests][202] |
 | point-on-feature            | `let coordinate = anyGeometry.coordinateOnFeature`                                                                                    |     | [Source][97] / [Tests][141]  |
 | points-within-polygon       | `let within = polygon.coordinatesWithin(coordinates)`                                                                                 |     | [Source][98] / [Tests][142]  |
 | point-to-line-distance      | `let distance = lineString.distanceFrom(coordinate: Coordinate3D(…))`                                                                 |     | [Source][99] / [Tests][100]  |
@@ -1000,6 +1001,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | snap-to-grid                | `anyGeometry.snappedToGrid(tolerance: 0.5)`                                                                                           |     | [Source][175] / [Tests][176] |
 | tile-cover                  | `let tileCover = anyGeometry.tileCover(atZoom: 14)`                                                                                   |     | [Source][112] / [Tests][113] |
 | tin                         | `anyGeometry.tin()`                                                                                                                  |     | [Source][163] / [Tests][164] |
+| tin-to-point-cloud          | `let cloud = tin.tinToPointCloud()`                                                                                                  |     | [Source][201] / [Tests][202] |
 | transform-coordinates       | `let transformed = anyGeometry.transformCoordinates({ $0 })`                                                                          |     | [Source][114] / [Tests][115] |
 | transform-rotate            | `let transformed = anyGeometry. transformedRotate(angle: 25.0, pivot: Coordinate3D(…))`                                               |     | [Source][116] / [Tests][117] |
 | transform-scale             | `let transformed = anyGeometry. transformedScale(factor: 2.5, anchor: .center)`                                                       |     | [Source][118] / [Tests][119] |
@@ -1222,6 +1224,8 @@ Thomas Rasch, Outdooractive
 [198]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PolygonizeTests.swift "PolygonizeTests"
 [199]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Boundary.swift "Boundary"
 [200]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/BoundaryTests.swift "BoundaryTests"
+[201]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Planepoint.swift "Planepoint"
+[202]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PlanepointTests.swift "PlanepointTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Planepoint.swift
+++ b/Sources/GISTools/Algorithms/Planepoint.swift
@@ -1,0 +1,123 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-planepoint
+
+extension Polygon {
+
+    /// Interpolates the z-value at a point on a triangular polygon.
+    ///
+    /// The polygon must be a triangle (3 vertices) with z-values (altitudes) assigned
+    /// to each vertex. The result is the interpolated z-value at the given point using
+    /// barycentric coordinates.
+    ///
+    /// - Parameter point: The query coordinate
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: The interpolated z-value, or `nil` if the point is outside the triangle
+    ///   or the polygon is not a triangle
+    public func planepoint(
+        _ point: Coordinate3D,
+        gridSize: Double? = nil
+    ) -> CLLocationDistance? {
+        guard let ring = outerRing else { return nil }
+        let coords = ring.coordinates
+
+        // A triangle has 3 unique vertices. The ring may have 4 coordinates
+        // if the last one closes the ring (same as first).
+        var pts = coords
+        if pts.count == 4, pts.first == pts.last {
+            pts = Array(pts.dropLast())
+        }
+        guard pts.count == 3 else { return nil }
+
+        let snappedPoint: Coordinate3D
+        let snappedCoords: [Coordinate3D]
+        if let gridSize {
+            snappedPoint = point.snappedToGrid(tolerance: gridSize)
+            snappedCoords = pts.map { $0.snappedToGrid(tolerance: gridSize) }
+        } else {
+            snappedPoint = point
+            snappedCoords = pts
+        }
+
+        let p = snappedPoint.projected(to: projection)
+        let a = snappedCoords[0].projected(to: projection)
+        let b = snappedCoords[1].projected(to: projection)
+        let c = snappedCoords[2].projected(to: projection)
+
+        // Normalise antimeridian crossing: if the triangle spans >180° of
+        // longitude, shift negative values by +360° so the Cartesian cross
+        // product reflects the short path across the date line.
+        let lons = [a.longitude, b.longitude, c.longitude, p.longitude]
+        let minLon = lons.min() ?? 0
+        let maxLon = lons.max() ?? 0
+        let shift = (maxLon - minLon) > 180.0 ? 360.0 : 0.0
+
+        func norm(_ coord: Coordinate3D) -> Coordinate3D {
+            guard shift > 0, coord.longitude < 0 else { return coord }
+            return Coordinate3D(
+                latitude: coord.latitude,
+                longitude: coord.longitude + shift,
+                altitude: coord.altitude, m: coord.m)
+        }
+
+        let na = norm(a)
+        let nb = norm(b)
+        let nc = norm(c)
+        let np = norm(p)
+
+        // Barycentric coordinates using area ratios (cross products)
+        let denom = (nb.longitude - na.longitude) * (nc.latitude - na.latitude)
+            - (nc.longitude - na.longitude) * (nb.latitude - na.latitude)
+        guard abs(denom) > 1e-15 else { return nil }
+
+        let vb = ((np.longitude - na.longitude) * (nc.latitude - na.latitude)
+            - (nc.longitude - na.longitude) * (np.latitude - na.latitude)) / denom
+        let vc = ((nb.longitude - na.longitude) * (np.latitude - na.latitude)
+            - (np.longitude - na.longitude) * (nb.latitude - na.latitude)) / denom
+        let va = 1.0 - vb - vc
+
+        guard va >= 0.0, vb >= 0.0, vc >= 0.0 else { return nil }
+
+        let za = a.altitude ?? 0.0
+        let zb = b.altitude ?? 0.0
+        let zc = c.altitude ?? 0.0
+
+        return va * za + vb * zb + vc * zc
+    }
+
+}
+
+extension FeatureCollection {
+
+    /// Converts a TIN (triangulated irregular network) into a point cloud by
+    /// placing a point at the centroid of each triangle and interpolating its
+    /// altitude from the triangle vertices.
+    ///
+    /// Each feature in the collection must contain a triangular ``Polygon``
+    /// with z-values (altitudes) on its vertices. The result is a
+    /// ``FeatureCollection`` of ``Point`` features, one per input triangle,
+    /// with the interpolated altitude set on the coordinate.
+    ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``FeatureCollection`` of point features with interpolated altitudes
+    public func tinToPointCloud(gridSize: Double? = nil) -> FeatureCollection {
+        let points: [Feature] = features.compactMap { feature in
+            guard let polygon = feature.geometry as? Polygon,
+                  let centroid = polygon.centroid,
+                  let z = polygon.planepoint(centroid.coordinate, gridSize: gridSize)
+            else { return nil }
+
+            var pointFeature = Feature(Point(Coordinate3D(
+                latitude: centroid.coordinate.latitude,
+                longitude: centroid.coordinate.longitude,
+                altitude: z)))
+            pointFeature.properties = feature.properties
+            return pointFeature
+        }
+        return FeatureCollection(points)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/PlanepointTests.swift
+++ b/Tests/GISToolsTests/Algorithms/PlanepointTests.swift
@@ -1,0 +1,135 @@
+@testable import GISTools
+import Testing
+
+struct PlanepointTests {
+
+    /// Interpolates the z-value at the centroid of a flat triangle.
+    @Test
+    func flatTriangleCentroid() async throws {
+        let triangle = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 10.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0, altitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 10.0),
+            ],
+        ]))
+        let point = Coordinate3D(latitude: 3.0, longitude: 5.0)
+        let z = try #require(triangle.planepoint(point))
+        #expect(abs(z - 10.0) < 0.001)
+    }
+
+    /// Interpolates the z-value at a vertex returns that vertex's z-value.
+    @Test
+    func vertexZ() async throws {
+        let triangle = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 200.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0, altitude: 300.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            ],
+        ]))
+        let z = try #require(triangle.planepoint(Coordinate3D(latitude: 0.0, longitude: 0.0)))
+        #expect(abs(z - 100.0) < 0.001)
+    }
+
+    /// Interpolates along an edge: halfway between (0,0,z=0) and (10,10,z=100)
+    /// at (5,5) should give z=50.
+    @Test
+    func edgeMidpoint() async throws {
+        let triangle = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 100.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0, altitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0),
+            ],
+        ]))
+        let point = Coordinate3D(latitude: 5.0, longitude: 5.0)
+        let z = try #require(triangle.planepoint(point))
+        #expect(abs(z - 50.0) < 1.0)
+    }
+
+    /// Returns nil for a point outside the triangle.
+    @Test
+    func outsideTriangle() async throws {
+        let triangle = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0, altitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0),
+            ],
+        ]))
+        let point = Coordinate3D(latitude: 50.0, longitude: 50.0)
+        #expect(triangle.planepoint(point) == nil)
+    }
+
+    /// Returns nil for a non-triangular polygon.
+    @Test
+    func notATriangle() async throws {
+        let polygon = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0, altitude: 10.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0, altitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0),
+            ],
+        ]))
+        #expect(polygon.planepoint(Coordinate3D(latitude: 5.0, longitude: 5.0)) == nil)
+    }
+
+    // MARK: - Antimeridian
+
+    /// A triangle crossing the date line: vertices at lon=179 and lon=-179.
+    /// The query point is between them (lon=180, the short way across).
+    @Test
+    func antimeridianTriangle() async throws {
+        let triangle = Polygon(unchecked: [
+            [
+                Coordinate3D(latitude: 0.0, longitude: 179.0, altitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: -179.0, altitude: 100.0),
+                Coordinate3D(latitude: 0.0, longitude: -179.0, altitude: 50.0),
+                Coordinate3D(latitude: 0.0, longitude: 179.0, altitude: 0.0),
+            ],
+        ])
+        // Point near the centre of the triangle
+        let point = Coordinate3D(latitude: 2.5, longitude: 180.0)
+        let z = try #require(triangle.planepoint(point))
+        #expect(z > 20.0)
+        #expect(z < 80.0)
+    }
+
+    // MARK: - TIN to point cloud
+
+    @Test
+    func tinToPointCloud() async throws {
+        let triangle1 = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0, altitude: 100.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0, altitude: 50.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 0.0),
+            ],
+        ]))
+        let triangle2 = try #require(Polygon([
+            [
+                Coordinate3D(latitude: 10.0, longitude: 0.0, altitude: 100.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 200.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0, altitude: 50.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0, altitude: 100.0),
+            ],
+        ]))
+        let fc = FeatureCollection([Feature(triangle1), Feature(triangle2)])
+        let cloud = fc.tinToPointCloud()
+        #expect(cloud.features.count == 2)
+        for feature in cloud.features {
+            let point = try #require(feature.geometry as? Point)
+            #expect(point.coordinate.altitude != nil)
+            #expect(point.coordinate.altitude! > 0.0)
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #136

Ports @turf/planepoint — interpolates the z-value (altitude) at a point on a triangular polygon using barycentric coordinates.

### API

```swift
let z = triangle.planepoint(queryPoint)
```

Also adds a convenience extension on FeatureCollection for converting a TIN to a point cloud:

```swift
let cloud = tin.tinToPointCloud()
```

Each triangle's centroid gets a Point with the interpolated altitude from planepoint, preserving the triangle's properties.

### Features

- Barycentric interpolation using area ratios (cross products)
- Antimeridian handling: normalises longitudes when the triangle spans >180 degrees
- gridSize parameter for coordinate snapping
- tinToPointCloud extension for post-processing TIN output

### Tests (7)

- flatTriangleCentroid — z-value at the centroid of a flat (constant-z) triangle
- vertexZ — z-value at a vertex returns that vertex's z-value
- edgeMidpoint — linear interpolation along a triangle edge
- outsideTriangle — point outside returns nil
- notATriangle — non-triangular polygon returns nil
- antimeridianTriangle — triangle crossing the date line with query point between the split
- tinToPointCloud — two triangles converted to two points with positive altitudes
