### PR TITLE
Add minimumBoundingCircle and minimumBoundingRadius

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,6 +976,8 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | line-slice                  | `let slice = lineString.slice(start: Coordinate3D(…), end: Coordinate3D(…))`                                                          |     | [Source][86] / [Tests][87]   |
 | line-slice-along            | `let sliced = lineString.sliceAlong(startDistance: 50.0, stopDistance: 2000.0)`                                                       |     | [Source][88] / [Tests][89]   |
 | midpoint                    | `let middle = coordinate1.midpoint(to: coordinate2)`                                                                                  |     | [Source][90] / [Tests][91]   |
+| minimum-bounding-circle     | `let circle = anyGeometry.minimumBoundingCircle()`                                                                                    |     | [Source][203] / [Tests][204] |
+| minimum-bounding-radius     | `let r = anyGeometry.minimumBoundingRadius()`                                                                                         |     | [Source][203] / [Tests][204] |
 | nearest-point               | `let nearest = anyGeometry.nearestCoordinate(from: Coordinate3D(…))`                                                                  |     | [Source][92] / [Tests][138]  |
 | nearest-point-on-feature    | `let nearest = anyGeometry. nearestCoordinateOnFeature(from: Coordinate3D(…))`                                                        |     | [Source][93] / [Tests][139]  |
 | nearest-point-on-line       | `let nearest = lineString.nearestCoordinateOnLine(from: Coordinate3D(…))?.coordinate`                                                 |     | [Source][94] / [Tests][95]   |
@@ -1226,6 +1228,8 @@ Thomas Rasch, Outdooractive
 [200]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/BoundaryTests.swift "BoundaryTests"
 [201]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Planepoint.swift "Planepoint"
 [202]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PlanepointTests.swift "PlanepointTests"
+[203]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/MinimumBoundingCircle.swift "MinimumBoundingCircle"
+[204]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/MinimumBoundingCircleTests.swift "MinimumBoundingCircleTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/MinimumBoundingCircle.swift
+++ b/Sources/GISTools/Algorithms/MinimumBoundingCircle.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+// MARK: - Public API
+
+extension GeoJson {
+
+    /// Returns the minimum bounding circle that encloses all coordinates
+    /// of the receiver as a ``Polygon`` approximation.
+    ///
+    /// For a single ``Point`` the result is `nil`. For an empty geometry the
+    /// result is `nil`.
+    ///
+    /// - Parameter steps: The number of steps to approximate the circle (default `64`, minimum `3`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``Polygon`` approximating the minimum bounding circle
+    public func minimumBoundingCircle(
+        steps: Int = 64,
+        gridSize: Double? = nil
+    ) -> Polygon? {
+        guard let radius = minimumBoundingRadius(gridSize: gridSize),
+              radius > 0.0,
+              let center = minimumBoundingCircleCenter(gridSize: gridSize)
+        else { return nil }
+
+        return MinimumBoundingCircle.circlePolygon(center: center, radius: radius, steps: max(3, steps))
+    }
+
+    /// Returns the radius of the minimum bounding circle that encloses all
+    /// coordinates of the receiver, in the native coordinate system units
+    /// (degrees for EPSG:4326, meters for EPSG:3857/4978).
+    ///
+    /// For a single ``Point`` the radius is 0. For an empty geometry it is `nil`.
+    ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: The radius in native units, or `nil` if the geometry is empty
+    public func minimumBoundingRadius(gridSize: Double? = nil) -> Double? {
+        let coords = allCoordinates
+        guard let first = coords.first else { return nil }
+
+        let projection = first.projection
+        var pts = coords.map { $0.projected(to: projection) }
+        if let gridSize {
+            pts = pts.map { $0.snappedToGrid(tolerance: gridSize) }
+        }
+
+        guard let _ = pts.first else { return nil }
+        if pts.count == 1 { return 0.0 }
+
+        return MinimumBoundingCircle.compute(points: pts)?.radius
+    }
+
+}
+
+// MARK: - Circle center (internal)
+
+extension GeoJson {
+
+    fileprivate func minimumBoundingCircleCenter(gridSize: Double? = nil) -> Coordinate3D? {
+        let coords = allCoordinates
+        guard let first = coords.first else { return nil }
+        let projection = first.projection
+
+        var pts = coords.map { $0.projected(to: projection) }
+        if let gridSize {
+            pts = pts.map { $0.snappedToGrid(tolerance: gridSize) }
+        }
+
+        guard let firstPt = pts.first else { return nil }
+        if pts.count == 1 { return firstPt }
+
+        return MinimumBoundingCircle.compute(points: pts)?.center
+    }
+
+}
+
+// MARK: - Implementation (Welzl's algorithm)
+
+private enum MinimumBoundingCircle {
+
+    private struct Result {
+        let center: Coordinate3D
+        let radius: Double
+    }
+
+    static func compute(points: [Coordinate3D]) -> (center: Coordinate3D, radius: Double)? {
+        guard let hull = hull(points: points) else { return nil }
+        guard hull.count > 1 else {
+            return hull.first.map { ($0, 0.0) }
+        }
+
+        let result = welzl(pts: hull.shuffled(), boundary: [])
+        return result.map { ($0.center, $0.radius) }
+    }
+
+    static func circlePolygon(center: Coordinate3D, radius: Double, steps: Int) -> Polygon? {
+        // Convert the native-unit radius to meters for the geodesic circle(...) method
+        let boundaryPoint = Coordinate3D(
+            x: center.longitude + radius,
+            y: center.latitude,
+            projection: center.projection)
+        let radiusInMeters = center.distance(from: boundaryPoint)
+        return center.circle(radius: radiusInMeters, steps: steps)
+    }
+
+    // MARK: - Welzl
+
+    private static func welzl(pts: [Coordinate3D], boundary: [Coordinate3D]) -> Result? {
+        if pts.isEmpty || boundary.count == 3 {
+            return trivialCircle(boundary)
+        }
+
+        var remaining = pts
+        let p = remaining.removeLast()
+
+        let result = welzl(pts: remaining, boundary: boundary)
+        if let r = result, isInside(p, center: r.center, radius: r.radius) {
+            return r
+        }
+
+        return welzl(pts: remaining, boundary: boundary + [p])
+    }
+
+    private static func trivialCircle(_ boundary: [Coordinate3D]) -> Result? {
+        switch boundary.count {
+        case 0: return nil
+        case 1: return Result(center: boundary[0], radius: 0.0)
+        case 2:
+            let a = boundary[0], b = boundary[1]
+            let cx = (a.longitude + b.longitude) / 2.0
+            let cy = (a.latitude + b.latitude) / 2.0
+            let center = Coordinate3D(x: cx, y: cy, projection: a.projection)
+            return Result(center: center, radius: distance(a, b) / 2.0)
+        case 3: return circumcircle(boundary[0], boundary[1], boundary[2])
+        default: return nil
+        }
+    }
+
+    private static func circumcircle(
+        _ a: Coordinate3D,
+        _ b: Coordinate3D,
+        _ c: Coordinate3D
+    ) -> Result? {
+        let ax = a.longitude, ay = a.latitude
+        let bx = b.longitude, by = b.latitude
+        let cx = c.longitude, cy = c.latitude
+
+        let d = 2.0 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by))
+        guard abs(d) > 1e-15 else { return nil }
+
+        let ux = ((ax * ax + ay * ay) * (by - cy) + (bx * bx + by * by) * (cy - ay) + (cx * cx + cy * cy) * (ay - by)) / d
+        let uy = ((ax * ax + ay * ay) * (cx - bx) + (bx * bx + by * by) * (ax - cx) + (cx * cx + cy * cy) * (bx - ax)) / d
+
+        let center = Coordinate3D(x: ux, y: uy, projection: a.projection)
+        return Result(center: center, radius: distance(center, a))
+    }
+
+    // MARK: - Helpers
+
+    private static func distance(_ a: Coordinate3D, _ b: Coordinate3D) -> Double {
+        let dx = a.longitude - b.longitude
+        let dy = a.latitude - b.latitude
+        return sqrt(dx * dx + dy * dy)
+    }
+
+    private static func isInside(_ p: Coordinate3D, center: Coordinate3D, radius: Double) -> Bool {
+        distance(p, center) <= radius + 1e-12
+    }
+
+    // MARK: - Convex hull (Andrew's monotone chain)
+
+    private static func hull(points: [Coordinate3D]) -> [Coordinate3D]? {
+        guard points.count >= 3 else { return points }
+
+        let sorted = points.sorted { a, b in
+            a.longitude == b.longitude ? a.latitude < b.latitude : a.longitude < b.longitude
+        }
+
+        var lower: [Coordinate3D] = []
+        for p in sorted {
+            while lower.count >= 2 {
+                let a = lower[lower.count - 2]
+                let b = lower[lower.count - 1]
+                if cross(a, b, p) <= 0 { lower.removeLast() } else { break }
+            }
+            lower.append(p)
+        }
+
+        var upper: [Coordinate3D] = []
+        for p in sorted.reversed() {
+            while upper.count >= 2 {
+                let a = upper[upper.count - 2]
+                let b = upper[upper.count - 1]
+                if cross(a, b, p) <= 0 { upper.removeLast() } else { break }
+            }
+            upper.append(p)
+        }
+
+        _ = lower.removeLast()
+        _ = upper.removeLast()
+
+        return lower + upper
+    }
+
+    private static func cross(
+        _ o: Coordinate3D,
+        _ a: Coordinate3D,
+        _ b: Coordinate3D
+    ) -> Double {
+        (a.longitude - o.longitude) * (b.latitude - o.latitude)
+            - (a.latitude - o.latitude) * (b.longitude - o.longitude)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/MinimumBoundingCircleTests.swift
+++ b/Tests/GISToolsTests/Algorithms/MinimumBoundingCircleTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct MinimumBoundingCircleTests {
+
+    // MARK: - Minimum bounding radius
+
+    /// Validates that a single ``Point`` has a minimum bounding radius of 0.
+    @Test
+    func radiusPoint() {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
+        #expect(point.minimumBoundingRadius() == 0.0)
+    }
+
+    /// Validates that two points define a circle with half their distance as radius.
+    @Test
+    func radiusTwoPoints() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ])
+        let r = line.minimumBoundingRadius()
+        #expect(r != nil)
+        if let r { #expect(abs(r - 5.0) < 0.001) }
+    }
+
+    /// Validates the MBC radius of a 10x10 square: half the diagonal (5√2 ≈ 7.07).
+    @Test
+    func radiusSquare() {
+        let square = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]])
+        let r = square.minimumBoundingRadius()
+        #expect(r != nil)
+        if let r { #expect(abs(r - 5.0 * sqrt(2.0)) < 0.01) }
+    }
+
+    /// Validates the MBC radius of a pentagon matching the shapely example (radius 5.0).
+    @Test
+    func radiusPentagon() {
+        let polygon = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 5.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 5.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+        ]])
+        let r = polygon.minimumBoundingRadius()
+        #expect(r != nil)
+        if let r { #expect(abs(r - 5.0) < 0.01) }
+    }
+
+    /// Validates that an empty geometry returns `nil` for the radius.
+    @Test
+    func radiusEmpty() {
+        let empty = MultiPoint()
+        #expect(empty.minimumBoundingRadius() == nil)
+    }
+
+    // MARK: - Minimum bounding circle
+
+    /// Validates that a single ``Point`` returns `nil` for the circle polygon.
+    @Test
+    func circlePoint() {
+        let point = Point(Coordinate3D(latitude: 10.0, longitude: 20.0))
+        #expect(point.minimumBoundingCircle() == nil)
+    }
+
+    /// Validates that a square produces a 65-vertex circle polygon (64 steps + close).
+    @Test
+    func circleSquare() {
+        let square = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]])
+        let circle = square.minimumBoundingCircle()
+        #expect(circle != nil)
+        if let circle { #expect(circle.outerRing?.coordinates.count == 65) }
+    }
+
+    /// Validates that the `steps` parameter controls polygon vertex count (12 steps → 13 coords).
+    @Test
+    func circleStepsCount() {
+        let circle = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]).minimumBoundingCircle(steps: 12)
+        #expect(circle != nil)
+        if let circle { #expect(circle.outerRing?.coordinates.count == 13) }
+    }
+
+}


### PR DESCRIPTION
Closes #144 and #145

Adds `minimumBoundingRadius` and `minimumBoundingCircle` to all GeoJson types.

### API

```swift
let radius = geometry.minimumBoundingRadius(gridSize: nil)
let circle = geometry.minimumBoundingCircle(steps: 64, gridSize: nil)
```

- `minimumBoundingRadius` returns the radius in native units (degrees for EPSG:4326, meters for EPSG:3857/4978)
- `minimumBoundingCircle` returns a Polygon approximating the circle using geodesic `Coordinate3D.circle()`

### Implementation

- Reduces coordinates to the convex hull (Andrew's monotone chain)
- Applies Welzl's randomised algorithm for the minimum enclosing circle
- All private implementation details are namespaced inside `private enum MinimumBoundingCircle`

### Tests (8)

- radiusPoint — single point returns radius 0
- radiusTwoPoints — two points at distance 10 return radius 5
- radiusSquare — 10x10 square returns radius 5*sqrt(2)
- radiusPentagon — shapely example returns radius 5
- radiusEmpty — empty geometry returns nil
- circlePoint — single point returns nil
- circleSquare — 64-step circle polygon has 65 vertices
- circleStepsCount — custom steps parameter controls vertex count
