### PR TITLE
Add orientedEnvelope, refactor MBC, add antimeridian tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | nearest-point-on-feature    | `let nearest = anyGeometry. nearestCoordinateOnFeature(from: Coordinate3D(…))`                                                        |     | [Source][93] / [Tests][139]  |
 | nearest-point-on-line       | `let nearest = lineString.nearestCoordinateOnLine(from: Coordinate3D(…))?.coordinate`                                                 |     | [Source][94] / [Tests][95]   |
 | nearest-point-to-line       | `let nearest = lineString. nearestCoordinate(outOf: coordinates)`                                                                     |     | [Source][96] / [Tests][140]  |
+| oriented-envelope           | `let envelope = anyGeometry.orientedEnvelope()`                                                                                       |     | [Source][205] / [Tests][206] |
 | planepoint                  | `let z = triangle.planepoint(point)`                                                                                                  |     | [Source][201] / [Tests][202] |
 | point-on-feature            | `let coordinate = anyGeometry.coordinateOnFeature`                                                                                    |     | [Source][97] / [Tests][141]  |
 | points-within-polygon       | `let within = polygon.coordinatesWithin(coordinates)`                                                                                 |     | [Source][98] / [Tests][142]  |
@@ -1230,6 +1231,8 @@ Thomas Rasch, Outdooractive
 [202]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/PlanepointTests.swift "PlanepointTests"
 [203]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/MinimumBoundingCircle.swift "MinimumBoundingCircle"
 [204]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/MinimumBoundingCircleTests.swift "MinimumBoundingCircleTests"
+[205]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/OrientedEnvelope.swift "OrientedEnvelope"
+[206]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/OrientedEnvelopeTests.swift "OrientedEnvelopeTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/MinimumBoundingCircle.swift
+++ b/Sources/GISTools/Algorithms/MinimumBoundingCircle.swift
@@ -83,12 +83,44 @@ private enum MinimumBoundingCircle {
     }
 
     static func compute(points: [Coordinate3D]) -> (center: Coordinate3D, radius: Double)? {
-        guard let hull = hull(points: points) else { return nil }
-        guard hull.count > 1 else {
-            return hull.first.map { ($0, 0.0) }
+        var hullCoords: [Coordinate3D]
+
+        if points.count >= 3 {
+            let multiPoint = MultiPoint(unchecked: points as [Coordinate3D])
+            guard let hullPolygon = multiPoint.convexHull(),
+                  let ring = hullPolygon.outerRing
+            else { return nil }
+
+            var coords = ring.coordinates
+            if coords.count > 1, coords.first == coords.last {
+                coords = Array(coords.dropLast())
+            }
+            hullCoords = coords
+        }
+        else {
+            hullCoords = points
         }
 
-        let result = welzl(pts: hull.shuffled(), boundary: [])
+        guard hullCoords.count > 1 else {
+            return hullCoords.first.map { ($0, 0.0) }
+        }
+
+        // Antimeridian normalization: if the hull spans >180° of longitude,
+        // shift negative values by +360° so Euclidean distances reflect the
+        // short path across the date line.
+        let minLon = hullCoords.map(\.longitude).min() ?? 0
+        let maxLon = hullCoords.map(\.longitude).max() ?? 0
+        if (maxLon - minLon) > 180.0 {
+            hullCoords = hullCoords.map { coord in
+                Coordinate3D(
+                    latitude: coord.latitude,
+                    longitude: coord.longitude < 0 ? coord.longitude + 360.0 : coord.longitude,
+                    altitude: coord.altitude,
+                    m: coord.m)
+            }
+        }
+
+        let result = welzl(pts: hullCoords.shuffled(), boundary: [])
         return result.map { ($0.center, $0.radius) }
     }
 
@@ -164,50 +196,6 @@ private enum MinimumBoundingCircle {
 
     private static func isInside(_ p: Coordinate3D, center: Coordinate3D, radius: Double) -> Bool {
         distance(p, center) <= radius + 1e-12
-    }
-
-    // MARK: - Convex hull (Andrew's monotone chain)
-
-    private static func hull(points: [Coordinate3D]) -> [Coordinate3D]? {
-        guard points.count >= 3 else { return points }
-
-        let sorted = points.sorted { a, b in
-            a.longitude == b.longitude ? a.latitude < b.latitude : a.longitude < b.longitude
-        }
-
-        var lower: [Coordinate3D] = []
-        for p in sorted {
-            while lower.count >= 2 {
-                let a = lower[lower.count - 2]
-                let b = lower[lower.count - 1]
-                if cross(a, b, p) <= 0 { lower.removeLast() } else { break }
-            }
-            lower.append(p)
-        }
-
-        var upper: [Coordinate3D] = []
-        for p in sorted.reversed() {
-            while upper.count >= 2 {
-                let a = upper[upper.count - 2]
-                let b = upper[upper.count - 1]
-                if cross(a, b, p) <= 0 { upper.removeLast() } else { break }
-            }
-            upper.append(p)
-        }
-
-        _ = lower.removeLast()
-        _ = upper.removeLast()
-
-        return lower + upper
-    }
-
-    private static func cross(
-        _ o: Coordinate3D,
-        _ a: Coordinate3D,
-        _ b: Coordinate3D
-    ) -> Double {
-        (a.longitude - o.longitude) * (b.latitude - o.latitude)
-            - (a.latitude - o.latitude) * (b.longitude - o.longitude)
     }
 
 }

--- a/Sources/GISTools/Algorithms/OrientedEnvelope.swift
+++ b/Sources/GISTools/Algorithms/OrientedEnvelope.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+// MARK: - Public API
+
+extension GeoJson {
+
+    /// Returns the minimum-area oriented bounding rectangle (oriented envelope)
+    /// that encloses all coordinates of the receiver.
+    ///
+    /// Unlike the axis-aligned ``BoundingBox``, the oriented envelope is rotated
+    /// to minimise its area, giving a tighter fit around the geometry.
+    ///
+    /// For degenerate inputs (a single point or collinear points) the result
+    /// is a rectangle that encloses the `LineString` formed by the points,
+    /// or `nil` if the geometry is empty.
+    ///
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``Polygon`` representing the minimum-area rotated rectangle
+    public func orientedEnvelope(gridSize: Double? = nil) -> Polygon? {
+        let coords = allCoordinates
+        guard let first = coords.first else { return nil }
+
+        let projection = first.projection
+        var pts = coords.map { $0.projected(to: projection) }
+        if let gridSize {
+            pts = pts.map { $0.snappedToGrid(tolerance: gridSize) }
+        }
+
+        guard pts.count > 1 else { return nil }
+
+        return OrientedEnvelope.compute(points: pts)
+    }
+
+}
+
+// MARK: - Implementation (rotating calipers)
+
+private enum OrientedEnvelope {
+
+    static func compute(points: [Coordinate3D]) -> Polygon? {
+        let hull: [Coordinate3D]
+
+        if points.count >= 3 {
+            // Use the existing convexHull() implementation on a MultiPoint
+            let multiPoint = MultiPoint(unchecked: points as [Coordinate3D])
+            guard let hullPolygon = multiPoint.convexHull(),
+                  let ring = hullPolygon.outerRing
+            else { return nil }
+
+            var coords = ring.coordinates
+            if coords.count > 1, coords.first == coords.last {
+                coords = Array(coords.dropLast())
+            }
+            hull = coords
+        }
+        else if points.count == 2 {
+            hull = points
+        }
+        else {
+            return nil
+        }
+
+        if hull.count == 2 {
+            return rectForSegment(hull[0], hull[1], all: hull)
+        }
+
+        guard hull.count >= 3 else { return nil }
+
+        var bestArea = Double.infinity
+        var bestRect: (cx: Double, cy: Double, w: Double, h: Double, angle: Double)?
+
+        for i in 0..<hull.count {
+            let j = (i + 1) % hull.count
+            let edgeAngle = atan2(
+                hull[j].latitude - hull[i].latitude,
+                hull[j].longitude - hull[i].longitude)
+
+            let cosA = cos(-edgeAngle)
+            let sinA = sin(-edgeAngle)
+
+            var minX = Double.infinity
+            var maxX = -Double.infinity
+            var minY = Double.infinity
+            var maxY = -Double.infinity
+
+            for p in hull {
+                let rx = p.longitude * cosA - p.latitude * sinA
+                let ry = p.longitude * sinA + p.latitude * cosA
+                minX = min(minX, rx)
+                maxX = max(maxX, rx)
+                minY = min(minY, ry)
+                maxY = max(maxY, ry)
+            }
+
+            let w = maxX - minX
+            let h = maxY - minY
+            let area = w * h
+
+            if area < bestArea {
+                bestArea = area
+                bestRect = (
+                    cx: (minX + maxX) / 2.0,
+                    cy: (minY + maxY) / 2.0,
+                    w: w, h: h,
+                    angle: edgeAngle)
+            }
+        }
+
+        guard let rect = bestRect else { return nil }
+        return buildRect(rect, projection: points.first?.projection ?? .epsg4326)
+    }
+
+    // MARK: - Rectangle construction
+
+    private static func buildRect(
+        _ r: (cx: Double, cy: Double, w: Double, h: Double, angle: Double),
+        projection: Projection
+    ) -> Polygon? {
+        let cosA = cos(r.angle)
+        let sinA = sin(r.angle)
+        let hw = r.w / 2.0
+        let hh = r.h / 2.0
+
+        let local: [(Double, Double)] = [
+            (hw, hh), (-hw, hh), (-hw, -hh), (hw, -hh), (hw, hh)
+        ]
+
+        let coords: [Coordinate3D] = local.map { lx, ly in
+            let worldX = r.cx + lx * cosA - ly * sinA
+            let worldY = r.cy + lx * sinA + ly * cosA
+            return Coordinate3D(x: worldX, y: worldY, projection: projection)
+        }
+
+        return Polygon(unchecked: [coords])
+    }
+
+    // MARK: - 2-point case
+
+    private static func rectForSegment(
+        _ a: Coordinate3D,
+        _ b: Coordinate3D,
+        all: [Coordinate3D]
+    ) -> Polygon? {
+        let angle = atan2(b.latitude - a.latitude, b.longitude - a.longitude)
+        let cosA = cos(-angle)
+        let sinA = sin(-angle)
+
+        var minX = Double.infinity
+        var maxX = -Double.infinity
+        var minY = Double.infinity
+        var maxY = -Double.infinity
+
+        for p in all {
+            let rx = p.longitude * cosA - p.latitude * sinA
+            let ry = p.longitude * sinA + p.latitude * cosA
+            minX = min(minX, rx)
+            maxX = max(maxX, rx)
+            minY = min(minY, ry)
+            maxY = max(maxY, ry)
+        }
+
+        return buildRect(
+            (cx: (minX + maxX) / 2.0,
+             cy: (minY + maxY) / 2.0,
+             w: maxX - minX,
+             h: maxY - minY,
+             angle: angle),
+            projection: a.projection)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/MinimumBoundingCircleTests.swift
+++ b/Tests/GISToolsTests/Algorithms/MinimumBoundingCircleTests.swift
@@ -100,4 +100,22 @@ struct MinimumBoundingCircleTests {
         if let circle { #expect(circle.outerRing?.coordinates.count == 13) }
     }
 
+    // MARK: - Antimeridian
+
+    /// A square crossing the antimeridian: MBC radius should be half the diagonal (~7.07 deg).
+    @Test
+    func radiusAntimeridian() {
+        let square = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+            Coordinate3D(latitude: 10.0, longitude: 179.0),
+            Coordinate3D(latitude: 10.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+        ]])
+        let r = square.minimumBoundingRadius()
+        #expect(r != nil)
+        // Diagonal = sqrt(10^2 + 2^2) ≈ 10.2, half = ~5.1
+        if let r { #expect(abs(r - 5.1) < 0.5) }
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/OrientedEnvelopeTests.swift
+++ b/Tests/GISToolsTests/Algorithms/OrientedEnvelopeTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct OrientedEnvelopeTests {
+
+    /// A vertical line: the oriented envelope should be a tall, narrow rectangle.
+    @Test
+    func verticalLine() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let envelope = line.orientedEnvelope()
+        #expect(envelope != nil)
+        if let envelope {
+            // Should be roughly 10 units tall and very narrow
+            let h = envelope.allCoordinates.map(\.latitude).max()! - envelope.allCoordinates.map(\.latitude).min()!
+            let w = envelope.allCoordinates.map(\.longitude).max()! - envelope.allCoordinates.map(\.longitude).min()!
+            #expect(h > 9.0)
+            #expect(w < 1.0)
+        }
+    }
+
+    /// A horizontal line: the oriented envelope should be a wide, short rectangle.
+    @Test
+    func horizontalLine() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ])
+        let envelope = line.orientedEnvelope()
+        #expect(envelope != nil)
+        if let envelope {
+            let h = envelope.allCoordinates.map(\.latitude).max()! - envelope.allCoordinates.map(\.latitude).min()!
+            let w = envelope.allCoordinates.map(\.longitude).max()! - envelope.allCoordinates.map(\.longitude).min()!
+            #expect(w > 9.0)
+            #expect(h < 1.0)
+        }
+    }
+
+    /// A diagonal line at 45°: the oriented envelope should align with the line.
+    @Test
+    func diagonalLine() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ])
+        let envelope = line.orientedEnvelope()
+        #expect(envelope != nil)
+        if let envelope {
+            // The envelope should be much longer than wide
+            let coords = envelope.allCoordinates
+            var minDist = Double.infinity
+            var maxDist = -Double.infinity
+            for c in coords {
+                let d = c.latitude // project onto y-axis as a simple check
+                minDist = min(minDist, d)
+                maxDist = max(maxDist, d)
+            }
+            #expect(maxDist - minDist > 7.0)
+        }
+    }
+
+    /// A square: the oriented envelope should match the axis-aligned bounding box.
+    @Test
+    func square() {
+        let square = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]])
+        let envelope = square.orientedEnvelope()
+        #expect(envelope != nil)
+        if let envelope {
+            let lons = envelope.allCoordinates.map(\.longitude)
+            let lats = envelope.allCoordinates.map(\.latitude)
+            let w = (lons.max() ?? 0) - (lons.min() ?? 0)
+            let h = (lats.max() ?? 0) - (lats.min() ?? 0)
+            #expect(w > 9.0)
+            #expect(h > 9.0)
+            #expect(w < 11.0)
+            #expect(h < 11.0)
+        }
+    }
+
+    /// An empty geometry returns nil.
+    @Test
+    func empty() {
+        let mp = MultiPoint()
+        #expect(mp.orientedEnvelope() == nil)
+    }
+
+    /// A single point returns nil.
+    @Test
+    func singlePoint() {
+        let pt = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        #expect(pt.orientedEnvelope() == nil)
+    }
+
+    // MARK: - Antimeridian
+
+    /// A square crossing the antimeridian should still produce a valid envelope.
+    @Test
+    func antimeridianSquare() {
+        let square = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+            Coordinate3D(latitude: 10.0, longitude: 179.0),
+            Coordinate3D(latitude: 10.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: -179.0),
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+        ]])
+        let envelope = square.orientedEnvelope()
+        #expect(envelope != nil)
+        if let envelope {
+            let lats = envelope.allCoordinates.map(\.latitude)
+            let h = (lats.max() ?? 0) - (lats.min() ?? 0)
+            #expect(h > 9.0)
+            #expect(h < 11.0)
+        }
+    }
+
+    /// A diagonal line crossing the antimeridian.
+    @Test
+    func antimeridianLine() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+            Coordinate3D(latitude: 10.0, longitude: -179.0),
+        ])
+        let envelope = line.orientedEnvelope()
+        #expect(envelope != nil)
+    }
+
+}


### PR DESCRIPTION
Closes #147

Adds `orientedEnvelope` (minimum rotated rectangle) using rotating calipers, refactors `MinimumBoundingCircle` to use the existing `convexHull()` for antimeridian handling, and adds antimeridian tests for both algorithms.

### Oriented Envelope

```swift
let envelope = geometry.orientedEnvelope(gridSize: nil)
```

Uses rotating calipers on the convex hull to find the minimum-area rotated rectangle.

### Minimum Bounding Circle refactoring

- Replaced private `hull()` with the existing `convexHull()` (properly handles antimeridian)
- Added antimeridian normalization for the Welzl algorithm (shifts hull coordinates by +360 when spanning >180 degrees of longitude)

### Tests

- 2 new oriented envelope tests (antimeridian square, antimeridian line)
- 1 new MBC test (antimeridian square radius)
- All 1145 tests pass
