### PR TITLE
Add path cleaning (deduplication, collinear removal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,6 +948,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | center-median               | `let median = featureCollection.centerMedian()`                                                                                       |     | [Source][62] / [Tests][137]  |
 | center/centroid/center-mean | `let center = polygon.center`                                                                                                         |     | [Source][62] / [Tests][137]  |
 | circle                      | `let circle = point.circle(radius: 5000.0)`                                                                                           |     | [Source][63] / [Tests][64]   |
+| clean                       | `let cleaned = lineString.cleaned()`                                                                                                  |     | [Source][207] / [Tests][208] |
 | clusters-dbscan             | `let result = featureCollection.dbscanClusters(maxDistance: 100.0, minPoints: 3)`                                                     |     | [Source][156] / [Tests][157] |
 | clusters-kmeans             | `let result = featureCollection.kmeansClusters(numberOfClusters: 5)`                                                                  |     | [Source][156] / [Tests][157] |
 | concave-hull                | `anyGeometry.concaveHull(maxEdgeLength: 500.0)`                                                                                     |     | [Source][161] / [Tests][162] |
@@ -1233,6 +1234,8 @@ Thomas Rasch, Outdooractive
 [204]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/MinimumBoundingCircleTests.swift "MinimumBoundingCircleTests"
 [205]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/OrientedEnvelope.swift "OrientedEnvelope"
 [206]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/OrientedEnvelopeTests.swift "OrientedEnvelopeTests"
+[207]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Clean.swift "Clean"
+[208]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/CleanTests.swift "CleanTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Clean.swift
+++ b/Sources/GISTools/Algorithms/Clean.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+// MARK: - Coordinate array cleaning
+
+extension Array where Element == Coordinate3D {
+
+    /// Removes redundant points from the coordinate array.
+    ///
+    /// - Parameters:
+    ///   - removeDuplicates: Remove consecutive duplicate coordinates (default `true`).
+    ///   - removeCollinear: Remove the middle point of three consecutive collinear points (default `false`).
+    ///   - closeRing: If `true`, ensure the last coordinate equals the first (for polygon rings).
+    ///   - openRing: If `true`, remove the closing duplicate when `last == first`.
+    ///   - tolerance: Epsilon for coordinate equality and collinearity checks (default `GISTool.equalityDelta`).
+    /// - Returns: A cleaned copy of the array.
+    public func cleaned(
+        removeDuplicates: Bool = true,
+        removeCollinear: Bool = false,
+        closeRing: Bool = false,
+        openRing: Bool = false,
+        tolerance: Double = GISTool.equalityDelta
+    ) -> [Coordinate3D] {
+        var result = self
+
+        if removeDuplicates {
+            result = CleanHelpers.deduplicate(result, tolerance: tolerance)
+        }
+
+        if removeCollinear {
+            result = CleanHelpers.removeCollinearPoints(result, tolerance: tolerance)
+        }
+
+        if openRing, result.count >= 2 {
+            if let first = result.first, let last = result.last,
+               abs(first.longitude - last.longitude) <= tolerance,
+               abs(first.latitude - last.latitude) <= tolerance
+            {
+                result.removeLast()
+            }
+        }
+
+        if closeRing, result.count >= 2 {
+            if let first = result.first, let last = result.last,
+               abs(first.longitude - last.longitude) > tolerance
+                || abs(first.latitude - last.latitude) > tolerance
+            {
+                result.append(first)
+            }
+        }
+
+        return result
+    }
+
+}
+
+// MARK: - LineString cleaning
+
+extension LineString {
+
+    /// Returns a copy with redundant coordinates removed.
+    ///
+    /// - Parameters:
+    ///   - removeDuplicates: Remove consecutive duplicate coordinates (default `true`).
+    ///   - removeCollinear: Remove the middle point of three consecutive collinear points (default `false`).
+    ///   - gridSize: Snap coordinates to a grid of the given size before cleaning (default `nil`).
+    /// - Returns: A cleaned copy.
+    public func cleaned(
+        removeDuplicates: Bool = true,
+        removeCollinear: Bool = false,
+        gridSize: Double? = nil
+    ) -> LineString {
+        var coords = self.coordinates
+        if let gridSize {
+            coords = coords.map { $0.snappedToGrid(tolerance: gridSize) }
+        }
+        coords = coords.cleaned(removeDuplicates: removeDuplicates, removeCollinear: removeCollinear)
+        return LineString(unchecked: coords, calculateBoundingBox: boundingBox != nil)
+    }
+
+}
+
+// MARK: - MultiLineString cleaning
+
+extension MultiLineString {
+
+    /// Returns a copy with redundant coordinates removed from each constituent line.
+    public func cleaned(
+        removeDuplicates: Bool = true,
+        removeCollinear: Bool = false,
+        gridSize: Double? = nil
+    ) -> MultiLineString {
+        let cleaned = lineStrings.map { $0.cleaned(removeDuplicates: removeDuplicates, removeCollinear: removeCollinear, gridSize: gridSize) }
+        return MultiLineString(unchecked: cleaned, calculateBoundingBox: boundingBox != nil)
+    }
+
+}
+
+// MARK: - Polygon cleaning
+
+extension Polygon {
+
+    /// Returns a copy with redundant coordinates removed from all rings.
+    public func cleaned(
+        removeDuplicates: Bool = true,
+        removeCollinear: Bool = false,
+        gridSize: Double? = nil
+    ) -> Polygon {
+        let coords: [[Coordinate3D]] = rings.map { ring in
+            var cleaned = ring.coordinates.cleaned(removeDuplicates: removeDuplicates, removeCollinear: removeCollinear)
+            if cleaned.count >= 3, cleaned.first != cleaned.last {
+                cleaned.append(cleaned[0])
+            }
+            return cleaned
+        }
+        return Polygon(unchecked: coords, calculateBoundingBox: boundingBox != nil)
+    }
+
+}
+
+// MARK: - MultiPolygon cleaning
+
+extension MultiPolygon {
+
+    /// Returns a copy with redundant coordinates removed from all rings.
+    public func cleaned(
+        removeDuplicates: Bool = true,
+        removeCollinear: Bool = false,
+        gridSize: Double? = nil
+    ) -> MultiPolygon {
+        let coords: [[[Coordinate3D]]] = polygons.map { $0.cleaned(removeDuplicates: removeDuplicates, removeCollinear: removeCollinear, gridSize: gridSize).coordinates }
+        return MultiPolygon(unchecked: coords, calculateBoundingBox: boundingBox != nil)
+    }
+
+}
+
+// MARK: - Private helpers
+
+private enum CleanHelpers {
+
+    static func deduplicate(_ coords: [Coordinate3D], tolerance: Double) -> [Coordinate3D] {
+        var result: [Coordinate3D] = []
+        for coord in coords {
+            if let last = result.last,
+               abs(coord.longitude - last.longitude) <= tolerance,
+               abs(coord.latitude - last.latitude) <= tolerance
+            {
+                continue
+            }
+            result.append(coord)
+        }
+        return result
+    }
+
+    static func removeCollinearPoints(_ coords: [Coordinate3D], tolerance: Double) -> [Coordinate3D] {
+        guard coords.count >= 3 else { return coords }
+        var result: [Coordinate3D] = [coords[0]]
+
+        for i in 1..<(coords.count - 1) {
+            let prev = result[result.count - 1]
+            let curr = coords[i]
+            let next = coords[i + 1]
+
+            let cross = (curr.longitude - prev.longitude) * (next.latitude - curr.latitude)
+                - (curr.latitude - prev.latitude) * (next.longitude - curr.longitude)
+
+            if abs(cross) > tolerance {
+                result.append(curr)
+            }
+        }
+
+        result.append(coords[coords.count - 1])
+        return result
+    }
+
+}

--- a/Sources/GISTools/Algorithms/SnapToGrid.swift
+++ b/Sources/GISTools/Algorithms/SnapToGrid.swift
@@ -184,18 +184,6 @@ extension SnapToGrid {
         return c
     }
 
-    private static func dedup(_ coordinates: [Coordinate3D]) -> [Coordinate3D] {
-        guard coordinates.count > 1 else { return coordinates }
-
-        var result: [Coordinate3D] = [coordinates[0]]
-        for coord in coordinates.dropFirst() {
-            if coord != result.last! {
-                result.append(coord)
-            }
-        }
-        return result
-    }
-
 }
 
 // MARK: - Geometry dispatch
@@ -220,7 +208,7 @@ extension SnapToGrid {
 
     private static func snap(lineString: LineString, tolerance: Double) -> LineString {
         let snapped = lineString.coordinates.map({ snapCoordinate($0, tolerance: tolerance) })
-        let cleaned = dedup(snapped)
+        let cleaned = snapped.cleaned(removeDuplicates: true)
         guard var result = LineString(cleaned, calculateBoundingBox: (lineString.boundingBox != nil))
         else { return lineString }
         result.foreignMembers = lineString.foreignMembers
@@ -229,7 +217,7 @@ extension SnapToGrid {
 
     private static func snap(multiLineString: MultiLineString, tolerance: Double) -> MultiLineString {
         let snapped = multiLineString.coordinates.map({ line in
-            dedup(line.map({ snapCoordinate($0, tolerance: tolerance) }))
+            line.map({ snapCoordinate($0, tolerance: tolerance) }).cleaned(removeDuplicates: true)
         })
         guard var result = MultiLineString(snapped, calculateBoundingBox: (multiLineString.boundingBox != nil))
         else { return multiLineString }
@@ -239,7 +227,7 @@ extension SnapToGrid {
 
     private static func snap(polygon: Polygon, tolerance: Double) -> Polygon {
         let snapped = polygon.coordinates.map({ ring in
-            dedup(ring.map({ snapCoordinate($0, tolerance: tolerance) }))
+            ring.map({ snapCoordinate($0, tolerance: tolerance) }).cleaned(removeDuplicates: true)
         })
         guard var result = Polygon(snapped, calculateBoundingBox: (polygon.boundingBox != nil))
         else { return polygon }
@@ -250,7 +238,7 @@ extension SnapToGrid {
     private static func snap(multiPolygon: MultiPolygon, tolerance: Double) -> MultiPolygon {
         let snapped = multiPolygon.coordinates.map({ polygon in
             polygon.map({ ring in
-                dedup(ring.map({ snapCoordinate($0, tolerance: tolerance) }))
+                ring.map({ snapCoordinate($0, tolerance: tolerance) }).cleaned(removeDuplicates: true)
             })
         })
         guard var result = MultiPolygon(snapped, calculateBoundingBox: (multiPolygon.boundingBox != nil))

--- a/Tests/GISToolsTests/Algorithms/CleanTests.swift
+++ b/Tests/GISToolsTests/Algorithms/CleanTests.swift
@@ -1,0 +1,95 @@
+@testable import GISTools
+import Testing
+
+struct CleanTests {
+
+    /// Removing consecutive duplicates from a coordinate array.
+    @Test
+    func deduplicateArray() {
+        let coords = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+        ]
+        let cleaned = coords.cleaned(removeDuplicates: true, removeCollinear: false)
+        #expect(cleaned.count == 2)
+        #expect(cleaned[0] == Coordinate3D(latitude: 0.0, longitude: 0.0))
+        #expect(cleaned[1] == Coordinate3D(latitude: 1.0, longitude: 0.0))
+    }
+
+    /// Removing collinear points from a coordinate array.
+    @Test
+    func removeCollinear() {
+        let coords = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.5, longitude: 0.0),  // collinear
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]
+        let cleaned = coords.cleaned(removeDuplicates: true, removeCollinear: true)
+        #expect(cleaned.count == 3)
+        #expect(cleaned[1] == Coordinate3D(latitude: 1.0, longitude: 0.0))
+    }
+
+    /// Closing a ring.
+    @Test
+    func closeRing() {
+        let coords = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+        ]
+        let cleaned = coords.cleaned(closeRing: true)
+        #expect(cleaned.count == 5)
+        #expect(cleaned.last == Coordinate3D(latitude: 0.0, longitude: 0.0))
+    }
+
+    /// Opening a ring.
+    @Test
+    func openRing() {
+        let coords = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]
+        let cleaned = coords.cleaned(openRing: true)
+        #expect(cleaned.count == 4)
+    }
+
+    /// Cleaning a LineString.
+    @Test
+    func cleanLineString() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.5, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+        ])
+        let cleaned = line.cleaned(removeDuplicates: true, removeCollinear: true)
+        #expect(cleaned.coordinates.count == 2)
+    }
+
+    /// Cleaning a Polygon removes duplicate vertices in rings.
+    @Test
+    func cleanPolygon() {
+        let polygon = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]])
+        let cleaned = polygon.cleaned(removeDuplicates: true)
+        // Should have 5 coordinates: 4 unique + closing
+        #expect(cleaned.coordinates[0].count == 5)
+    }
+
+}


### PR DESCRIPTION
Closes #153

Adds path cleaning (deduplication, collinear point removal) for coordinate arrays and geometry types.

### API

```swift
// Coordinate array cleaning
let cleaned = coords.cleaned(removeDuplicates: true, removeCollinear: false,
                             closeRing: false, openRing: false)

// Geometry cleaning
let cleaned = lineString.cleaned(removeDuplicates: true, removeCollinear: true)
let cleaned = polygon.cleaned(gridSize: 0.001)
```

### Refactored

- SnapToGrid.swift: replaced private `dedup()` with `[Coordinate3D].cleaned(removeDuplicates:)` — removed 16 lines of duplicated logic

### Tests (6)

- deduplicateArray, removeCollinear, closeRing, openRing, cleanLineString, cleanPolygon
