### PR TITLE
Port turf/mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,6 +976,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | line-segments               | `let segments = anyGeometry.lineSegments`                                                                                             |     | [Source][84] / [Tests][85]   |
 | line-slice                  | `let slice = lineString.slice(start: Coordinate3D(…), end: Coordinate3D(…))`                                                          |     | [Source][86] / [Tests][87]   |
 | line-slice-along            | `let sliced = lineString.sliceAlong(startDistance: 50.0, stopDistance: 2000.0)`                                                       |     | [Source][88] / [Tests][89]   |
+| mask                        | `let masked = polygon.mask()`                                                                                                         |     | [Source][209] / [Tests][210] |
 | midpoint                    | `let middle = coordinate1.midpoint(to: coordinate2)`                                                                                  |     | [Source][90] / [Tests][91]   |
 | minimum-bounding-circle     | `let circle = anyGeometry.minimumBoundingCircle()`                                                                                    |     | [Source][203] / [Tests][204] |
 | minimum-bounding-radius     | `let r = anyGeometry.minimumBoundingRadius()`                                                                                         |     | [Source][203] / [Tests][204] |
@@ -1236,6 +1237,8 @@ Thomas Rasch, Outdooractive
 [206]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/OrientedEnvelopeTests.swift "OrientedEnvelopeTests"
 [207]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Clean.swift "Clean"
 [208]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/CleanTests.swift "CleanTests"
+[209]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Mask.swift "Mask"
+[210]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/MaskTests.swift "MaskTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Mask.swift
+++ b/Sources/GISTools/Algorithms/Mask.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-mask
+
+extension PolygonGeometry {
+
+    /// Creates a mask polygon by subtracting this geometry from a larger polygon.
+    ///
+    /// The result is ``outerPolygon`` with this geometry cut out as a hole (or holes).
+    /// If no outer polygon is provided, the world bounding box `(-180, -90, 180, 90)` is used.
+    ///
+    /// - Parameter outerPolygon: The polygon to mask (defaults to the world bounding box).
+    /// - Returns: A masked ``Polygon``, or `nil` if the geometry is empty.
+    public func mask(outerPolygon: Polygon? = nil) -> Polygon? {
+        let outer = outerPolygon ?? Polygon.world
+        guard let outerRing = outer.outerRing else { return nil }
+
+        let holes: [Ring] = polygons.compactMap { $0.outerRing }
+        guard holes.isNotEmpty else { return outer }
+
+        // Normalise antimeridian crossing so the Cartesian containment check works.
+        // If the outer polygon spans >180° (but < 360°) of longitude, shift all
+        // negative longitudes by +360° to make the coordinates contiguous.
+        let outerCoords = outerRing.coordinates
+        let minOuterLon = outerCoords.map(\.longitude).min() ?? 0
+        let maxOuterLon = outerCoords.map(\.longitude).max() ?? 0
+        let span = maxOuterLon - minOuterLon
+        let needShift = span > 180.0 && span < 360.0
+
+        let containedHoles: [Ring]
+        if needShift {
+            func shiftCoord(_ c: Coordinate3D) -> Coordinate3D {
+                Coordinate3D(latitude: c.latitude,
+                             longitude: c.longitude < 0 ? c.longitude + 360.0 : c.longitude,
+                             altitude: c.altitude, m: c.m)
+            }
+
+            let shiftedOuter = Polygon(unchecked: [
+                Ring(unchecked: outerCoords.map(shiftCoord))
+            ])
+
+            containedHoles = holes.filter { hole in
+                guard let pt = hole.coordinates.first else { return false }
+                return shiftedOuter.contains(shiftCoord(pt), ignoringBoundary: true)
+            }
+        }
+        else {
+            containedHoles = holes.filter { hole in
+                guard let pt = hole.coordinates.first else { return false }
+                return outer.contains(pt, ignoringBoundary: true)
+            }
+        }
+
+        guard containedHoles.isNotEmpty else { return outer }
+
+        return Polygon(unchecked: [outerRing] + containedHoles)
+    }
+
+}
+
+extension Polygon {
+
+    /// A polygon representing the world bounding box `(-180, -90, 180, 90)`.
+    public static let world: Polygon = Polygon(unchecked: [[
+        Coordinate3D(latitude: -90.0, longitude: -180.0),
+        Coordinate3D(latitude: -90.0, longitude: 180.0),
+        Coordinate3D(latitude: 90.0, longitude: 180.0),
+        Coordinate3D(latitude: 90.0, longitude: -180.0),
+        Coordinate3D(latitude: -90.0, longitude: -180.0),
+    ]])
+
+}

--- a/Tests/GISToolsTests/Algorithms/MaskTests.swift
+++ b/Tests/GISToolsTests/Algorithms/MaskTests.swift
@@ -1,0 +1,162 @@
+@testable import GISTools
+import Testing
+
+struct MaskTests {
+
+    /// A small square masked from the world produces a polygon with a hole (outer + 1 inner ring).
+    @Test
+    func squareMask() {
+        let maskPolygon = Polygon(unchecked: [[
+            Coordinate3D(latitude: -5.0, longitude: -5.0),
+            Coordinate3D(latitude: 5.0, longitude: -5.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: -5.0, longitude: 5.0),
+            Coordinate3D(latitude: -5.0, longitude: -5.0),
+        ]])
+        let result = maskPolygon.mask()
+        #expect(result != nil)
+        if let result {
+            #expect(result.rings.count == 2)
+        }
+    }
+
+    /// Masking the world polygon itself returns it unchanged (no hole).
+    @Test
+    func maskEntireWorld() {
+        let world = Polygon.world
+        let result = world.mask()
+        #expect(result != nil)
+        if let result {
+            #expect(result.rings.count == 1)
+        }
+    }
+
+    /// A MultiPolygon mask should create a hole for each polygon.
+    @Test
+    func multiPolygonMask() {
+        let poly1 = Polygon(unchecked: [[
+            Coordinate3D(latitude: -5.0, longitude: -5.0),
+            Coordinate3D(latitude: 5.0, longitude: -5.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: -5.0, longitude: 5.0),
+            Coordinate3D(latitude: -5.0, longitude: -5.0),
+        ]])
+        let poly2 = Polygon(unchecked: [[
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 20.0, longitude: 10.0),
+            Coordinate3D(latitude: 20.0, longitude: 20.0),
+            Coordinate3D(latitude: 10.0, longitude: 20.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]])
+        let multiPolygon = MultiPolygon([poly1, poly2])!
+        let result = multiPolygon.mask()
+        #expect(result != nil)
+        if let result {
+            #expect(result.rings.count == 3) // outer + 2 holes
+        }
+    }
+
+    /// Mask with a custom outer polygon.
+    @Test
+    func customOuter() {
+        let outer = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]])
+        let maskPolygon = Polygon(unchecked: [[
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 8.0, longitude: 2.0),
+            Coordinate3D(latitude: 8.0, longitude: 8.0),
+            Coordinate3D(latitude: 2.0, longitude: 8.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+        ]])
+        let result = maskPolygon.mask(outerPolygon: outer)
+        #expect(result != nil)
+        if let result {
+            #expect(result.rings.count == 2)
+            #expect(result.outerRing?.coordinates.count == 5)
+        }
+    }
+
+    /// An empty polygon (no area) as mask returns the outer polygon unchanged.
+    @Test
+    func emptyMask() {
+        let result = Polygon.world.mask()
+        #expect(result != nil)
+        if let result {
+            #expect(result.rings.count == 1)
+        }
+    }
+
+    // MARK: - Antimeridian
+
+    /// A mask crossing the antimeridian (lon 179 to -179) punched into the world polygon.
+    @Test
+    func antimeridianMask() {
+        let maskPolygon = Polygon(unchecked: [[
+            Coordinate3D(latitude: -5.0, longitude: 179.0),
+            Coordinate3D(latitude: 5.0, longitude: 179.0),
+            Coordinate3D(latitude: 5.0, longitude: -179.0),
+            Coordinate3D(latitude: -5.0, longitude: -179.0),
+            Coordinate3D(latitude: -5.0, longitude: 179.0),
+        ]])
+        let result = maskPolygon.mask()
+        #expect(result != nil)
+        if let result {
+            #expect(result.rings.count == 2)
+        }
+    }
+
+    /// A mask crossing the antimeridian with a non-crossing outer polygon.
+    @Test
+    func antimeridianCustomOuter() {
+        let outer = Polygon(unchecked: [[
+            Coordinate3D(latitude: -20.0, longitude: 150.0),
+            Coordinate3D(latitude: -20.0, longitude: -150.0),
+            Coordinate3D(latitude: 20.0, longitude: -150.0),
+            Coordinate3D(latitude: 20.0, longitude: 150.0),
+            Coordinate3D(latitude: -20.0, longitude: 150.0),
+        ]])
+        let maskPolygon = Polygon(unchecked: [[
+            Coordinate3D(latitude: -5.0, longitude: 175.0),
+            Coordinate3D(latitude: 5.0, longitude: 175.0),
+            Coordinate3D(latitude: 5.0, longitude: -175.0),
+            Coordinate3D(latitude: -5.0, longitude: -175.0),
+            Coordinate3D(latitude: -5.0, longitude: 175.0),
+        ]])
+        let result = maskPolygon.mask(outerPolygon: outer)
+        #expect(result != nil)
+        if let result {
+            #expect(result.rings.count == 2)
+        }
+    }
+
+    /// A MultiPolygon mask where both polygons cross the antimeridian, punched into the world.
+    @Test
+    func antimeridianMultiPolygonMask() {
+        let poly1 = Polygon(unchecked: [[
+            Coordinate3D(latitude: -5.0, longitude: 179.0),
+            Coordinate3D(latitude: 5.0, longitude: 179.0),
+            Coordinate3D(latitude: 5.0, longitude: -179.0),
+            Coordinate3D(latitude: -5.0, longitude: -179.0),
+            Coordinate3D(latitude: -5.0, longitude: 179.0),
+        ]])
+        let poly2 = Polygon(unchecked: [[
+            Coordinate3D(latitude: 10.0, longitude: 178.0),
+            Coordinate3D(latitude: 20.0, longitude: 178.0),
+            Coordinate3D(latitude: 20.0, longitude: -178.0),
+            Coordinate3D(latitude: 10.0, longitude: -178.0),
+            Coordinate3D(latitude: 10.0, longitude: 178.0),
+        ]])
+        let multiPolygon = MultiPolygon([poly1, poly2])!
+        let result = multiPolygon.mask()
+        #expect(result != nil)
+        if let result {
+            #expect(result.rings.count == 3) // outer + 2 holes
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #135

Ports @turf/mask — subtracts a polygon (or multipolygon) from a larger outer polygon, creating holes. Defaults to the world bounding box as the outer polygon.

```swift
let masked = polygon.mask()                          // punch hole in world
let masked = polygon.mask(outerPolygon: continent)    // punch hole in continent
let masked = multiPolygon.mask()                     // punch multiple holes
```

### Antimeridian handling

When the outer polygon spans >180 degrees of longitude (crosses the date line), negative longitudes are shifted by +360 before containment checks, so holes crossing the date line are correctly identified as inside the outer polygon.

### Tests (8)

- squareMask, maskEntireWorld, multiPolygonMask, customOuter, emptyMask
- antimeridianMask (crossing hole in world)
- antimeridianCustomOuter (crossing hole in crossing outer)
- antimeridianMultiPolygonMask (two crossing holes in world)
