### PR TITLE
Port turf/line-split, add distanceAlong, fix warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,14 @@
 # AGENTS.md#
 ## Swift instructions
 - You are an expert software architect and senior Swift developer
-- DO USE idomatic Swift 6, at least version 6.2
+- DO USE idomatic Swift 6, at least version 6.1
 - DO write tests for everything you do, use Swift Testing (`import Testing`), not XCTest
 - DO ASK if anything is unclear, or you need a decision
 - DO add proper Swift DocC code documentation to your code
 - DO NOT introduce third-party frameworks without asking first
 - Avoid force unwraps and force `try` unless it is unrecoverable
 - Assume strict Swift concurrency rules are being applied
+- Code must compile cleanly, with no warnings
 
 ## Code style conventions
 
@@ -47,7 +48,7 @@ Don't use left-hugging colons in ternary expressions or in other places where th
 Skip spaces for empty constructors (see above):
 - `[]`, `[:]`
 
-## Ternary expressions
+### Ternary expressions
 
 - Keep where short ternary expressions on one line:
 `let result = booleanCondition ? value1 : value2`
@@ -126,6 +127,7 @@ If a method has ≤3 parameters and no return value, or ≤2 parameters and a re
   ```
 
 ## General instructions
+
 - DO NOT take any shortcuts while implementing an algorithm. Correctness is the highest priority
 - DO NOT commit changes unless the user tells you to do so, ALWAYS let the user review your changes
 - DO NOT create free functions (un-namespaced top-level functions). Always use a `private enum` namespace or extensions on existing types.

--- a/README.md
+++ b/README.md
@@ -956,6 +956,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | convex-hull                 | `let hull = anyGeometry.convexHull()`                                                                                                   |     | [Source][146] / [Tests][147] |
 | destination                 | `let destination = coordinate.destination(distance: 1000.0, bearing: 173.0)`                                                          |     | [Source][66] / [Tests][67]   |
 | distance                    | `let distance = coordinate1.distance(from: coordinate2)`                                                                              |     | [Source][68] / [Tests][69]   |
+| distance-along              | `let dist = lineString.distanceAlong(to: coordinate)`                                                                                 |     | [Source][213] / [Tests][214] |                                                                              |     | [Source][68] / [Tests][69]   |
 | ellipse                     | `let ellipse = coordinate.ellipse(xSemiAxis: 5000.0, ySemiAxis: 3000.0)`                                                              |     | [Source][183] / [Tests][184] |
 | flatten                     | `let featureCollection = anyGeometry.flattened`                                                                                       |     | [Source][70] / [Tests][71]   |
 | flip                        | `let flipped = anyGeometry.flipped()`                                                                                                 |     | [Source][189] / [Tests][190] |
@@ -976,6 +977,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | line-segments               | `let segments = anyGeometry.lineSegments`                                                                                             |     | [Source][84] / [Tests][85]   |
 | line-slice                  | `let slice = lineString.slice(start: Coordinate3D(…), end: Coordinate3D(…))`                                                          |     | [Source][86] / [Tests][87]   |
 | line-slice-along            | `let sliced = lineString.sliceAlong(startDistance: 50.0, stopDistance: 2000.0)`                                                       |     | [Source][88] / [Tests][89]   |
+| line-split                  | `let segments = lineString.lineSplit(with: splitter)`                                                                                 |     | [Source][211] / [Tests][212] |
 | mask                        | `let masked = polygon.mask()`                                                                                                         |     | [Source][209] / [Tests][210] |
 | midpoint                    | `let middle = coordinate1.midpoint(to: coordinate2)`                                                                                  |     | [Source][90] / [Tests][91]   |
 | minimum-bounding-circle     | `let circle = anyGeometry.minimumBoundingCircle()`                                                                                    |     | [Source][203] / [Tests][204] |
@@ -1239,6 +1241,10 @@ Thomas Rasch, Outdooractive
 [208]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/CleanTests.swift "CleanTests"
 [209]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Mask.swift "Mask"
 [210]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/MaskTests.swift "MaskTests"
+[211]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/LineSplit.swift "LineSplit"
+[212]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/LineSplitTests.swift "LineSplitTests"
+[213]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Along.swift "Along"
+[214]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/LineSplitTests.swift "LineSplitTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Along.swift
+++ b/Sources/GISTools/Algorithms/Along.swift
@@ -47,4 +47,43 @@ extension LineString {
         Point(coordinateAlong(distance: distance))
     }
 
+    /// Returns the distance in meters from the start of the line to the nearest
+    /// point on the line from the given coordinate.
+    ///
+    /// - Parameter coordinate: A coordinate near the line
+    /// - Parameter tolerance: Maximum distance from the line in meters (default `1.0`).
+    /// - Returns: The distance along the line in meters, or `nil` if the coordinate
+    ///   is further than `tolerance` from the line.
+    public func distanceAlong(
+        to coordinate: Coordinate3D,
+        tolerance: CLLocationDistance = 1.0
+    ) -> CLLocationDistance? {
+        guard coordinates.count >= 2 else { return nil }
+
+        let projected = coordinate.projected(to: projection)
+        var bestDistance = Double.greatestFiniteMagnitude
+        var bestSegment: (index: Int, foot: Coordinate3D)? = nil
+
+        for (i, segment) in lineSegments.enumerated() {
+            guard let foot = segment.perpendicularFoot(from: projected, clampToEnds: true) else { continue }
+            let d = projected.distance(from: foot)
+            if d < bestDistance {
+                bestDistance = d
+                bestSegment = (i, foot)
+            }
+        }
+
+        guard let (segIndex, foot) = bestSegment,
+              bestDistance < tolerance
+        else { return nil }
+
+        var travelled: CLLocationDistance = 0.0
+        for i in 0..<segIndex {
+            travelled += coordinates[i].distance(from: coordinates[i + 1])
+        }
+
+        travelled += coordinates[segIndex].distance(from: foot)
+        return travelled
+    }
+
 }

--- a/Sources/GISTools/Algorithms/BooleanCrosses.swift
+++ b/Sources/GISTools/Algorithms/BooleanCrosses.swift
@@ -148,10 +148,6 @@ extension GeoJson {
         let intersectionPoints = lineString1.intersections(with: lineString2)
         guard intersectionPoints.isNotEmpty else { return false }
 
-        guard let coords1 = lineString1.coordinates as [Coordinate3D]?,
-              let coords2 = lineString2.coordinates as [Coordinate3D]?
-        else { return false }
-
         let boundary1 = lineString1.boundary
         let boundary2 = lineString2.boundary
 

--- a/Sources/GISTools/Algorithms/LineSplit.swift
+++ b/Sources/GISTools/Algorithms/LineSplit.swift
@@ -1,0 +1,81 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-line-split
+
+extension LineString {
+
+    /// Splits the receiver at the points where it intersects another geometry.
+    ///
+    /// The result is a ``FeatureCollection`` of ``LineString`` segments between
+    /// consecutive split points, preserving the order along the original line.
+    /// If there are no intersections, the result contains the original line.
+    ///
+    /// - Parameter splitter: A ``Point``, ``MultiPoint``, ``LineString``, or ``MultiLineString``
+    ///   whose intersections with this line define the split points.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Parameter tolerance: Minimum distance between split points in meters (default `1.0`).
+    ///   Split points closer than this are merged; segments shorter than half this are dropped.
+    /// - Returns: A ``FeatureCollection`` of ``LineString`` segments.
+    public func lineSplit(
+        with splitter: GeoJson,
+        gridSize: Double? = nil,
+        tolerance: CLLocationDistance = 1.0
+    ) -> FeatureCollection {
+        let snapped = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+
+        guard let firstCoord = snapped.firstCoordinate,
+              let lastCoord = snapped.lastCoordinate
+        else { return FeatureCollection() }
+
+        // Collect split points: from intersections and from point-on-line checks
+        var splitCoords: [Coordinate3D] = []
+
+        if let pointGeom = splitter as? PointGeometry {
+            // Point/MultiPoint: check if each point is on the line
+            for coord in pointGeom.allCoordinates {
+                let projected = coord.projected(to: snapped.projection)
+                if snapped.checkIsOnLine(projected) {
+                    splitCoords.append(projected)
+                }
+            }
+        }
+        else {
+            // LineString/MultiLineString etc.: use general intersection
+            splitCoords = snapped.intersections(with: splitter, gridSize: gridSize).map(\.coordinate)
+        }
+
+        // Include the start and end as implicit split points
+        var splitPoints: [(coordinate: Coordinate3D, distance: CLLocationDistance)] = [
+            (firstCoord, 0.0),
+            (lastCoord, snapped.length),
+        ]
+
+        for coord in splitCoords {
+            guard let distance = snapped.distanceAlong(to: coord) else { continue }
+            if splitPoints.contains(where: { abs($0.distance - distance) < tolerance }) { continue }
+            splitPoints.append((coord, distance))
+        }
+
+        splitPoints.sort { $0.distance < $1.distance }
+
+        var segments: [LineString] = []
+        for i in 0..<(splitPoints.count - 1) {
+            let startDist = splitPoints[i].distance
+            let endDist = splitPoints[i + 1].distance
+
+            // Skip segments shorter than half the tolerance
+            guard abs(endDist - startDist) > tolerance * 0.5 else { continue }
+
+            if let segment = snapped.sliceAlong(startDistance: startDist, stopDistance: endDist) {
+                segments.append(segment)
+            }
+        }
+
+        let features = segments.map { Feature($0) }
+        return FeatureCollection(features)
+    }
+
+}

--- a/Sources/GISTools/Algorithms/Mask.swift
+++ b/Sources/GISTools/Algorithms/Mask.swift
@@ -1,3 +1,6 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
 import Foundation
 
 // Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-mask

--- a/Sources/GISTools/Algorithms/MinimumBoundingCircle.swift
+++ b/Sources/GISTools/Algorithms/MinimumBoundingCircle.swift
@@ -1,3 +1,6 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
 import Foundation
 
 // MARK: - Public API

--- a/Sources/GISTools/Algorithms/PolygonTangents.swift
+++ b/Sources/GISTools/Algorithms/PolygonTangents.swift
@@ -27,7 +27,7 @@ extension Polygon {
         let projectedCoords = coords.map { $0.projected(to: projection) }
 
         // Skip the closing coordinate (last == first)
-        var vertices = Array(projectedCoords.dropLast())
+        let vertices = Array(projectedCoords.dropLast())
         guard vertices.count >= 3 else { return nil }
 
         // Determine whether to shift longitudes for antimeridian handling.

--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -445,7 +445,6 @@ extension BoundingBox {
     public func squared() -> BoundingBox {
         let w = northEast.longitude - southWest.longitude
         let h = northEast.latitude - southWest.latitude
-        let maxSide = max(w, h)
 
         if w >= h {
             let pad = (w - h) / 2.0

--- a/Tests/GISToolsTests/Algorithms/AlongTests.swift
+++ b/Tests/GISToolsTests/Algorithms/AlongTests.swift
@@ -32,4 +32,68 @@ struct AlongTests {
         #expect(abs(coordinate.longitude) > 150.0)
     }
 
+    // MARK: - Distance along
+
+    /// Returns the full length of the line when querying the last coordinate.
+    @Test
+    func distanceAlongLast() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let dist = line.distanceAlong(to: Coordinate3D(latitude: 10.0, longitude: 0.0))
+        #expect(dist != nil)
+        if let dist { #expect(abs(dist - line.length) < 1.0) }
+    }
+
+    /// Returns 0 when querying the first coordinate.
+    @Test
+    func distanceAlongFirst() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let dist = line.distanceAlong(to: Coordinate3D(latitude: 0.0, longitude: 0.0))
+        #expect(dist != nil)
+        if let dist { #expect(dist < 1.0) }
+    }
+
+    /// Returns half the length when querying the midpoint.
+    @Test
+    func distanceAlongMidpoint() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let mid = Coordinate3D(latitude: 5.0, longitude: 0.0)
+        let dist = line.distanceAlong(to: mid)
+        #expect(dist != nil)
+        if let dist { #expect(abs(dist - line.length / 2.0) < 1.0) }
+    }
+
+    /// Returns nil for a point far from the line (beyond tolerance).
+    @Test
+    func distanceAlongBeyondTolerance() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let far = Coordinate3D(latitude: 5.0, longitude: 100.0)
+        #expect(line.distanceAlong(to: far) == nil)
+    }
+
+    /// Custom tolerance accepts a point at the specified distance from the line.
+    @Test
+    func distanceAlongCustomTolerance() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        // 50 meters away from the line — fails with default 1m tolerance
+        let near = Coordinate3D(latitude: 5.0, longitude: 0.001)
+        #expect(line.distanceAlong(to: near) == nil)
+        // But passes with a generous tolerance
+        #expect(line.distanceAlong(to: near, tolerance: 200.0) != nil)
+    }
+
 }

--- a/Tests/GISToolsTests/Algorithms/LineSplitTests.swift
+++ b/Tests/GISToolsTests/Algorithms/LineSplitTests.swift
@@ -1,0 +1,74 @@
+@testable import GISTools
+import Testing
+
+struct LineSplitTests {
+
+    /// Splitting a line at a point in the middle produces 2 segments.
+    @Test
+    func splitByPoint() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let splitter = Point(Coordinate3D(latitude: 5.0, longitude: 0.0))
+        let result = line.lineSplit(with: splitter)
+        #expect(result.features.count == 2)
+    }
+
+    /// A line split by a MultiPoint should produce segments at each split point.
+    @Test
+    func splitByMultiPoint() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let splitter = MultiPoint(unchecked: [
+            Coordinate3D(latitude: 3.0, longitude: 0.0),
+            Coordinate3D(latitude: 7.0, longitude: 0.0),
+        ])
+        let result = line.lineSplit(with: splitter)
+        #expect(result.features.count == 3)
+    }
+
+    /// A line with no intersections returns the original line as a single segment.
+    @Test
+    func noIntersections() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let splitter = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        let result = line.lineSplit(with: splitter)
+        #expect(result.features.count == 1)
+    }
+
+    /// A line split by another crossing LineString.
+    @Test
+    func splitByLine() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ])
+        let splitter = LineString(unchecked: [
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ])
+        let result = line.lineSplit(with: splitter)
+        // Two crossing lines split each other into 2 segments each
+        #expect(result.features.count == 2)
+    }
+
+    /// Grid-size snapping for noise reduction.
+    @Test
+    func withGridSize() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let splitter = Point(Coordinate3D(latitude: 5.001, longitude: 0.0))
+        // Without snapping, this might miss
+        let result = line.lineSplit(with: splitter, gridSize: 0.1)
+        #expect(result.features.count == 2)
+    }
+
+}


### PR DESCRIPTION
Closes #134

Ports @turf/line-split — splits a LineString at intersection points with a Point, MultiPoint, LineString, or MultiLineString.

```swift
let segments = line.lineSplit(with: point)
let segments = line.lineSplit(with: otherLine, gridSize: 0.001, tolerance: 0.5)
```

### Also included

- **distanceAlong** — new public method on `LineString` moved from private helper in `LineSplit` to `Along.swift`. Returns the distance in meters from the start of the line to the nearest point on the line, with configurable tolerance.
- **Warning fixes** — unused variables removed from `PolygonTangents`, `BooleanCrosses`, and `BoundingBox.squared()`

### Tests (10)

- lineSplit: splitByPoint, splitByMultiPoint, splitByLine, noIntersections, withGridSize
- distanceAlong: last, first, midpoint, beyondTolerance, customTolerance
