### PR TITLE
Port turf/collect

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | clean                       | `let cleaned = lineString.cleaned()`                                                                                                  |     | [Source][207] / [Tests][208] |
 | clusters-dbscan             | `let result = featureCollection.dbscanClusters(maxDistance: 100.0, minPoints: 3)`                                                     |     | [Source][156] / [Tests][157] |
 | clusters-kmeans             | `let result = featureCollection.kmeansClusters(numberOfClusters: 5)`                                                                  |     | [Source][156] / [Tests][157] |
+| collect                     | `let result = polygons.collect(from: points, inProperty: "p", outProperty: "vals")`                                                  |     | [Source][215] / [Tests][216] |
 | concave-hull                | `anyGeometry.concaveHull(maxEdgeLength: 500.0)`                                                                                     |     | [Source][161] / [Tests][162] |
 | conversions/helpers         | `let distance = GISTool.convert(length: 1.0, from: .miles, to: .meters)`                                                              |     | [Source][65] / [Tests][143]  |
 | convex-hull                 | `let hull = anyGeometry.convexHull()`                                                                                                   |     | [Source][146] / [Tests][147] |
@@ -1245,6 +1246,8 @@ Thomas Rasch, Outdooractive
 [212]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/LineSplitTests.swift "LineSplitTests"
 [213]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Along.swift "Along"
 [214]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/LineSplitTests.swift "LineSplitTests"
+[215]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Collect.swift "Collect"
+[216]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/CollectTests.swift "CollectTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Collect.swift
+++ b/Sources/GISTools/Algorithms/Collect.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-collect
+
+extension FeatureCollection {
+
+    /// Collects property values from points that fall within each polygon feature
+    /// and adds them as an array property.
+    ///
+    /// For each polygon feature in the receiver, this finds all points from
+    /// `pointCollection` that lie inside it and collects the value of
+    /// `inProperty` from each matching point. The resulting array is stored
+    /// as `outProperty` on the polygon feature.
+    ///
+    /// - Parameter pointCollection: A ``FeatureCollection`` of ``Point`` features
+    /// - Parameter inProperty: The property key to collect from matching points
+    /// - Parameter outProperty: The property key to store the collected array on each polygon feature
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before checking (default `nil`).
+    /// - Returns: A new ``FeatureCollection`` with the collected property added to each polygon feature
+    public func collect(
+        from pointCollection: FeatureCollection,
+        inProperty: String,
+        outProperty: String,
+        gridSize: Double? = nil
+    ) -> FeatureCollection {
+        let pointFeatures = pointCollection.features
+
+        var result: [Feature] = []
+        result.reserveCapacity(features.count)
+
+        for polygonFeature in features {
+            guard let polygon = polygonFeature.geometry as? PolygonGeometry else {
+                result.append(polygonFeature)
+                continue
+            }
+
+            let collected: [Sendable] = pointFeatures.compactMap { pointFeature in
+                guard let point = pointFeature.geometry as? Point,
+                      polygon.contains(point.coordinate, ignoringBoundary: false, gridSize: gridSize)
+                else { return nil }
+
+                return pointFeature.properties[inProperty]
+            }
+
+            var updated = polygonFeature
+            updated.setProperty(collected, for: outProperty)
+            result.append(updated)
+        }
+
+        return FeatureCollection(result)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/CollectTests.swift
+++ b/Tests/GISToolsTests/Algorithms/CollectTests.swift
@@ -1,0 +1,90 @@
+@testable import GISTools
+import Testing
+
+struct CollectTests {
+
+    /// Collects population values from points inside two separate polygon bins.
+    @Test
+    func collectPopulation() {
+        let poly1 = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]])
+        let poly2 = Polygon(unchecked: [[
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 15.0, longitude: 10.0),
+            Coordinate3D(latitude: 15.0, longitude: 15.0),
+            Coordinate3D(latitude: 10.0, longitude: 15.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]])
+
+        var point1 = Feature(Point(Coordinate3D(latitude: 2.5, longitude: 2.5)))
+        point1.properties = ["pop": 100]
+        var point2 = Feature(Point(Coordinate3D(latitude: 3.0, longitude: 3.0)))
+        point2.properties = ["pop": 200]
+        var point3 = Feature(Point(Coordinate3D(latitude: 12.5, longitude: 12.5)))
+        point3.properties = ["pop": 300]
+
+        let polys = FeatureCollection([Feature(poly1), Feature(poly2)])
+        let points = FeatureCollection([point1, point2, point3])
+
+        let result = polys.collect(from: points, inProperty: "pop", outProperty: "collected_pop")
+
+        #expect(result.features.count == 2)
+
+        let collected1 = result.features[0].properties["collected_pop"] as? [Int]
+        #expect(collected1 != nil)
+        if let collected1 {
+            #expect(collected1.count == 2)
+            #expect(collected1.contains(100))
+            #expect(collected1.contains(200))
+        }
+
+        let collected2 = result.features[1].properties["collected_pop"] as? [Int]
+        #expect(collected2 != nil)
+        if let collected2 {
+            #expect(collected2.count == 1)
+            #expect(collected2[0] == 300)
+        }
+    }
+
+    /// A polygon with no points inside gets an empty array.
+    @Test
+    func emptyCollection() {
+        let poly = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]])
+        var point = Feature(Point(Coordinate3D(latitude: 50.0, longitude: 50.0)))
+        point.properties = ["val": 42]
+
+        let polys = FeatureCollection([Feature(poly)])
+        let result = polys.collect(from: FeatureCollection([point]), inProperty: "val", outProperty: "vals")
+
+        let vals = result.features[0].properties["vals"] as? [Int]
+        #expect(vals != nil)
+        #expect(vals?.isEmpty == true)
+    }
+
+    /// Non-polygon features in the collection pass through unchanged.
+    @Test
+    func nonPolygonFeature() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ])
+
+        let polys = FeatureCollection([Feature(line)])
+        let result = polys.collect(from: FeatureCollection(), inProperty: "x", outProperty: "y")
+
+        #expect(result.features.count == 1)
+        #expect(result.features[0].properties["y"] == nil)
+    }
+
+}


### PR DESCRIPTION
Closes #130

Ports @turf/collect — aggregates point property values into polygon features.

```swift
let result = polygons.collect(from: points, inProperty: "population", outProperty: "populations")
```

Each polygon feature gets an array property containing the values from all points that fall inside it.

### Tests (3)

- collectPopulation — two polygons with multiple points, correct aggregation
- emptyCollection — polygon with no points inside gets empty array
- nonPolygonFeature — non-polygon features pass through unchanged
