### PR TITLE
Port turf/bezier-spline

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | antimeridian-cutting        | `let result = lineString.cutAtAntimeridian()`                                                                                         |     | [Source][131] / [Tests][132] |
 | area                        | `Polygon(…).area`                                                                                                                     |     | [Source][45]                 |
 | bearing                     | `Coordinate3D(…).bearing(to: Coordinate3D(…))`                                                                                        |     | [Source][46] / [Tests][47]   |
+| bezier-spline               | `let spline = lineString.bezierSpline()`                                                                                              |     | [Source][217] / [Tests][218] |
 | boolean-clockwise           | `Polygon(…).outerRing?.isClockwise`                                                                                                   |     | [Source][48] / [Tests][49]   |
 | boolean-concave             | `anyGeometry.isConcave()`                                                                                                             |     | [Source][177] / [Tests][178] |
 | boolean-contains/within     | `polygon.contains(lineString)` / `point.isWithin(polygon)`                                                                            |     | [Source][187] / [Tests][188] |
@@ -1248,6 +1249,8 @@ Thomas Rasch, Outdooractive
 [214]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/LineSplitTests.swift "LineSplitTests"
 [215]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Collect.swift "Collect"
 [216]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/CollectTests.swift "CollectTests"
+[217]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/BezierSpline.swift "BezierSpline"
+[218]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/BezierSplineTests.swift "BezierSplineTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/BezierSpline.swift
+++ b/Sources/GISTools/Algorithms/BezierSpline.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-bezier-spline
+
+extension LineString {
+
+    /// Creates a smoothed cubic Bezier spline through the control points
+    /// of the receiver.
+    ///
+    /// - Parameter steps: Number of interpolated points between each pair of
+    ///   control points (default `25`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size
+    ///   before computing (default `nil`).
+    /// - Returns: A smoothed ``LineString``, or `nil` if there are fewer
+    ///   than 2 coordinates.
+    public func bezierSpline(steps: Int = 25, gridSize: Double? = nil) -> LineString? {
+        guard coordinates.count >= 2 else { return nil }
+
+        let pts: [Coordinate3D]
+        if let gridSize {
+            pts = coordinates.map { $0.snappedToGrid(tolerance: gridSize) }
+        } else {
+            pts = Array(coordinates)
+        }
+        guard pts.count >= 2 else { return nil }
+
+        return BezierSpline.compute(points: pts, steps: steps)
+    }
+
+}
+
+// MARK: - MultiLineString
+
+extension MultiLineString {
+
+    /// Creates a smoothed cubic Bezier spline through all control points
+    /// of all constituent line strings, concatenated.
+    ///
+    /// - Parameter steps: Number of interpolated points between each pair of
+    ///   control points (default `25`).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size
+    ///   before computing (default `nil`).
+    /// - Returns: A smoothed ``LineString``, or `nil` if the total number of
+    ///   coordinates is fewer than 2.
+    public func bezierSpline(steps: Int = 25, gridSize: Double? = nil) -> LineString? {
+        let allCoords = lineStrings.flatMap(\.coordinates)
+        guard allCoords.count >= 2 else { return nil }
+
+        let line = LineString(unchecked: allCoords)
+        return line.bezierSpline(steps: steps, gridSize: gridSize)
+    }
+
+}
+
+// MARK: - Implementation
+
+private enum BezierSpline {
+
+    static func compute(points: [Coordinate3D], steps: Int) -> LineString {
+        let n = points.count
+        guard n > 1 else {
+            return LineString(unchecked: points)
+        }
+
+        let projection = points.first?.projection ?? .epsg4326
+
+        // Chord lengths
+        var chordLengths: [Double] = [0.0]
+        for i in 1..<n {
+            chordLengths.append(chordLengths[i - 1] + distance(points[i - 1], points[i]))
+        }
+
+        let totalLength = chordLengths[n - 1]
+        guard totalLength > 0 else { return LineString(unchecked: points) }
+
+        // Normalised parameters t in [0, 1]
+        let t = chordLengths.map { $0 / totalLength }
+
+        // Tangents at each control point
+        var tangents: [(Double, Double)] = []
+        tangents.reserveCapacity(n)
+
+        for i in 0..<n {
+            let tangent: (Double, Double)
+            if i == 0 {
+                // Forward difference
+                let dx = points[1].longitude - points[0].longitude
+                let dy = points[1].latitude - points[0].latitude
+                let len = sqrt(dx * dx + dy * dy)
+                tangent = len > 0 ? (dx / len, dy / len) : (1.0, 0.0)
+            }
+            else if i == n - 1 {
+                // Backward difference
+                let dx = points[i].longitude - points[i - 1].longitude
+                let dy = points[i].latitude - points[i - 1].latitude
+                let len = sqrt(dx * dx + dy * dy)
+                tangent = len > 0 ? (dx / len, dy / len) : (1.0, 0.0)
+            }
+            else {
+                // Centered difference
+                let dx = points[i + 1].longitude - points[i - 1].longitude
+                let dy = points[i + 1].latitude - points[i - 1].latitude
+                let len = sqrt(dx * dx + dy * dy)
+                tangent = len > 0 ? (dx / len, dy / len) : (1.0, 0.0)
+            }
+            tangents.append(tangent)
+        }
+
+        // Build spline by interpolating each segment
+        var splineCoords: [Coordinate3D] = [points[0]]
+
+        for i in 0..<(n - 1) {
+            let p0 = points[i]
+            let p3 = points[i + 1]
+
+            let segLen = chordLengths[i + 1] - chordLengths[i]
+            let tension = segLen / 3.0
+
+            let p1 = Coordinate3D(
+                x: p0.longitude + tangents[i].0 * tension,
+                y: p0.latitude + tangents[i].1 * tension,
+                projection: projection)
+            let p2 = Coordinate3D(
+                x: p3.longitude - tangents[i + 1].0 * tension,
+                y: p3.latitude - tangents[i + 1].1 * tension,
+                projection: projection)
+
+            for s in 1..<steps {
+                let u = Double(s) / Double(steps)
+                let u2 = u * u
+                let u3 = u2 * u
+                let b0 = 1.0 - 3.0 * u + 3.0 * u2 - u3
+                let b1 = 3.0 * u - 6.0 * u2 + 3.0 * u3
+                let b2 = 3.0 * u2 - 3.0 * u3
+                let b3 = u3
+
+                let x = b0 * p0.longitude + b1 * p1.longitude + b2 * p2.longitude + b3 * p3.longitude
+                let y = b0 * p0.latitude + b1 * p1.latitude + b2 * p2.latitude + b3 * p3.latitude
+                splineCoords.append(Coordinate3D(x: x, y: y, projection: projection))
+            }
+        }
+
+        // Add the last control point
+        splineCoords.append(points[n - 1])
+
+        return LineString(unchecked: splineCoords)
+    }
+
+    private static func distance(_ a: Coordinate3D, _ b: Coordinate3D) -> Double {
+        let dx = a.longitude - b.longitude
+        let dy = a.latitude - b.latitude
+        return sqrt(dx * dx + dy * dy)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/BezierSplineTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BezierSplineTests.swift
@@ -1,0 +1,113 @@
+@testable import GISTools
+import Testing
+
+struct BezierSplineTests {
+
+    /// A simple 2-point line returns an interpolated spline with `steps` + 1 points.
+    @Test
+    func twoPoints() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ])
+        let spline = line.bezierSpline(steps: 10)
+        #expect(spline != nil)
+        if let spline {
+            #expect(spline.coordinates.count == 11)  // steps + 1 for the start
+        }
+    }
+
+    /// A 3-point line produces more points than the input.
+    @Test
+    func threePoints() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let spline = line.bezierSpline()
+        #expect(spline != nil)
+        if let spline {
+            #expect(spline.coordinates.count > 3)
+        }
+    }
+
+    /// The spline starts at the first control point and ends at the last.
+    @Test
+    func endpointsMatch() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let spline = line.bezierSpline(steps: 20)
+        #expect(spline != nil)
+        if let spline {
+            #expect(spline.coordinates.first == Coordinate3D(latitude: 0.0, longitude: 0.0))
+            #expect(spline.coordinates.last == Coordinate3D(latitude: 10.0, longitude: 0.0))
+        }
+    }
+
+    /// Single-point line returns itself.
+    @Test
+    func singlePoint() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+        ])
+        #expect(line.bezierSpline() == nil)
+    }
+
+    /// MultiLineString concatenation produces a single smooth spline.
+    @Test
+    func multiLine() {
+        let line1 = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+        ])
+        let line2 = LineString(unchecked: [
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])
+        let multiLine = MultiLineString(unchecked: [line1, line2])
+        let spline = multiLine.bezierSpline(steps: 10)
+        #expect(spline != nil)
+        if let spline {
+            // 3 segments (shared endpoint creates 4 control points) × 9 + start + end = 29
+            #expect(spline.coordinates.count == 29)
+            #expect(spline.coordinates.first == Coordinate3D(latitude: 0.0, longitude: 0.0))
+            #expect(spline.coordinates.last == Coordinate3D(latitude: 10.0, longitude: 0.0))
+        }
+    }
+
+    /// A line crossing the antimeridian should still produce a smooth spline.
+    @Test
+    func antimeridian() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 179.0),
+            Coordinate3D(latitude: 5.0, longitude: -179.0),
+            Coordinate3D(latitude: 10.0, longitude: 179.0),
+        ])
+        let spline = line.bezierSpline(steps: 10)
+        #expect(spline != nil)
+        if let spline {
+            #expect(spline.coordinates.count > 10)
+            #expect(spline.coordinates.first == Coordinate3D(latitude: 0.0, longitude: 179.0))
+            #expect(spline.coordinates.last == Coordinate3D(latitude: 10.0, longitude: 179.0))
+        }
+    }
+
+    /// Grid-size snapping works.
+    @Test
+    func withGridSize() {
+        let line = LineString(unchecked: [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+        ])
+        let spline = line.bezierSpline(steps: 5, gridSize: 0.5)
+        #expect(spline != nil)
+        if let spline {
+            #expect(spline.coordinates.count == 6)
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #129

Ports @turf/bezier-spline — creates a smooth cubic Bezier spline through the control points of a LineString or MultiLineString.

```swift
let spline = lineString.bezierSpline(steps: 25)
let spline = multiLineString.bezierSpline(gridSize: 0.001)
```

### Implementation

- Chord-length parameterization with normalized knot spacing
- Centered-difference tangents for smooth Catmull-Rom style interpolation
- Cubic Bernstein basis for each segment
- MultiLineString concatenates all constituent lines into one spline

### Tests (7)

- twoPoints, threePoints, endpointsMatch, singlePoint, multiLine, antimeridian, withGridSize
