### PR TITLE
Preserve altitude through all BoundingBox operations

### DIFF
--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -58,6 +58,9 @@ public struct BoundingBox:
 
         var southWest = Coordinate3D(x: .infinity, y: .infinity, projection: projection)
         var northEast = Coordinate3D(x: -.infinity, y: -.infinity, projection: projection)
+        var minAltitude: Double?
+        var maxAltitude: Double?
+        var allHaveAltitude = true
 
         for currentLocation in coordinates {
             let currentLocationLatitude = currentLocation.latitude
@@ -67,6 +70,19 @@ public struct BoundingBox:
             southWest.longitude = min(southWest.longitude, currentLocationLongitude)
             northEast.latitude = max(northEast.latitude, currentLocationLatitude)
             northEast.longitude = max(northEast.longitude, currentLocationLongitude)
+
+            if let altitude = currentLocation.altitude {
+                minAltitude = minAltitude.map { min($0, altitude) } ?? altitude
+                maxAltitude = maxAltitude.map { max($0, altitude) } ?? altitude
+            }
+            else {
+                allHaveAltitude = false
+            }
+        }
+
+        if allHaveAltitude, let minAltitude, let maxAltitude {
+            southWest.altitude = minAltitude
+            northEast.altitude = maxAltitude
         }
 
         if padding > 0.0 {
@@ -228,8 +244,14 @@ public struct BoundingBox:
 
         case .epsg4326:
             return BoundingBox(
-                southWest: Coordinate3D(latitude: southWest.latitude - dy, longitude: southWest.longitude - dx),
-                northEast: Coordinate3D(latitude: northEast.latitude + dy, longitude: northEast.longitude + dx))
+                southWest: Coordinate3D(
+                    latitude: southWest.latitude - dy,
+                    longitude: southWest.longitude - dx,
+                    altitude: southWest.altitude),
+                northEast: Coordinate3D(
+                    latitude: northEast.latitude + dy,
+                    longitude: northEast.longitude + dx,
+                    altitude: northEast.altitude))
 
         case .noSRID:
             return self // Don't know what to do -> ignore
@@ -247,9 +269,11 @@ public struct BoundingBox:
     /// - Parameters:
     ///    - distance: The distance from the receiver, in meters
     public func expanded(byDistance distance: CLLocationDistance) -> BoundingBox {
-        BoundingBox(
-            southWest: southWest.destination(distance: distance, bearing: 225.0),
-            northEast: northEast.destination(distance: distance, bearing: 45.0))
+        var sw = southWest.destination(distance: distance, bearing: 225.0)
+        var ne = northEast.destination(distance: distance, bearing: 45.0)
+        sw.altitude = southWest.altitude
+        ne.altitude = northEast.altitude
+        return BoundingBox(southWest: sw, northEast: ne)
     }
 
     /// Returns a copy of the receiver that also includes `coordinate`.
@@ -452,10 +476,12 @@ extension BoundingBox {
                 southWest: Coordinate3D(
                     x: southWest.longitude,
                     y: southWest.latitude - pad,
+                    z: southWest.altitude,
                     projection: projection),
                 northEast: Coordinate3D(
                     x: northEast.longitude,
                     y: northEast.latitude + pad,
+                    z: northEast.altitude,
                     projection: projection))
         }
         else {
@@ -464,10 +490,12 @@ extension BoundingBox {
                 southWest: Coordinate3D(
                     x: southWest.longitude - pad,
                     y: southWest.latitude,
+                    z: southWest.altitude,
                     projection: projection),
                 northEast: Coordinate3D(
                     x: northEast.longitude + pad,
                     y: northEast.latitude,
+                    z: northEast.altitude,
                     projection: projection))
         }
     }
@@ -838,14 +866,32 @@ extension BoundingBox {
     ) -> BoundingBox {
         let rhs = rhs.projected(to: lhs.projection)
 
+        var minAltitude = lhs.southWest.altitude
+        var maxAltitude = lhs.northEast.altitude
+        var allHaveAltitude = lhs.southWest.altitude != nil && lhs.northEast.altitude != nil
+        if let a = rhs.southWest.altitude {
+            minAltitude = minAltitude.map { min($0, a) } ?? a
+        }
+        else {
+            allHaveAltitude = false
+        }
+        if let a = rhs.northEast.altitude {
+            maxAltitude = maxAltitude.map { max($0, a) } ?? a
+        }
+        else {
+            allHaveAltitude = false
+        }
+
         return BoundingBox(
             southWest: Coordinate3D(
                 x: min(lhs.southWest.x, rhs.southWest.x),
                 y: min(lhs.southWest.y, rhs.southWest.y),
+                z: allHaveAltitude ? minAltitude : nil,
                 projection: lhs.projection),
             northEast: Coordinate3D(
                 x: max(lhs.northEast.x, rhs.northEast.x),
                 y: max(lhs.northEast.y, rhs.northEast.y),
+                z: allHaveAltitude ? maxAltitude : nil,
                 projection: lhs.projection))
     }
 

--- a/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
+++ b/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
@@ -810,4 +810,236 @@ struct BoundingBoxTests {
         #expect(square.northEast.longitude == 20.0)
     }
 
+    // MARK: - 3D Bounding Box (altitude preservation)
+
+    // Validates that init(coordinates:padding:) preserves altitude.
+    @Test
+    func altitudeInitWithCoordinates() async throws {
+        let c1 = Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0)
+        let c2 = Coordinate3D(latitude: 30.0, longitude: 30.0, altitude: 500.0)
+        let c3 = Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 200.0)
+
+        let bbox: BoundingBox = try #require(BoundingBox(coordinates: [c1, c2, c3]))
+        #expect(bbox.southWest.altitude == 100.0)
+        #expect(bbox.northEast.altitude == 500.0)
+    }
+
+    // Validates that init(coordinates:padding:) preserves altitude with padding.
+    @Test
+    func altitudeInitWithCoordinatesAndPadding() async throws {
+        let c1 = Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 50.0)
+        let c2 = Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 150.0)
+
+        let bbox: BoundingBox = try #require(BoundingBox(coordinates: [c1, c2], padding: 1000.0))
+        #expect(bbox.southWest.altitude == 50.0)
+        #expect(bbox.northEast.altitude == 150.0)
+    }
+
+    // Validates that init(coordinates:) does NOT set altitude when no coordinate has one.
+    @Test
+    func altitudeInitWithoutAltitude() async throws {
+        let c1 = Coordinate3D(latitude: 0.0, longitude: 0.0)
+        let c2 = Coordinate3D(latitude: 30.0, longitude: 30.0)
+
+        let bbox: BoundingBox = try #require(BoundingBox(coordinates: [c1, c2]))
+        #expect(bbox.southWest.altitude == nil)
+        #expect(bbox.northEast.altitude == nil)
+    }
+
+    // Validates that init(coordinates:) does NOT set altitude when only some have altitude.
+    @Test
+    func altitudeInitMixedAltitude() async throws {
+        let c1 = Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0)
+        let c2 = Coordinate3D(latitude: 30.0, longitude: 30.0)  // no altitude
+
+        let bbox: BoundingBox = try #require(BoundingBox(coordinates: [c1, c2]))
+        #expect(bbox.southWest.altitude == nil)
+        #expect(bbox.northEast.altitude == nil)
+    }
+
+    // Validates that expanded(byIncluding:) for a coordinate preserves altitude.
+    @Test
+    func altitudeExpandedByIncludingCoordinate() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 30.0, altitude: 500.0))
+        let point = Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 200.0)
+
+        let expanded = bbox.expanded(byIncluding: point)
+        #expect(expanded.southWest.altitude == 100.0)
+        #expect(expanded.northEast.altitude == 500.0)
+    }
+
+    // Validates that expanded(byIncluding:) for a coordinate with lower altitude works.
+    @Test
+    func altitudeExpandedByIncludingCoordinateLower() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 30.0, altitude: 500.0))
+        let point = Coordinate3D(latitude: 20.0, longitude: 20.0, altitude: 50.0)
+
+        let expanded = bbox.expanded(byIncluding: point)
+        #expect(expanded.southWest.altitude == 50.0)
+        #expect(expanded.northEast.altitude == 500.0)
+    }
+
+    // Validates that expanded(byIncluding:) for a BoundingBox preserves altitude.
+    @Test
+    func altitudeExpandedByIncludingBox() async throws {
+        let bbox1 = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 30.0, altitude: 500.0))
+        let bbox2 = BoundingBox(
+            southWest: Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 200.0),
+            northEast: Coordinate3D(latitude: 40.0, longitude: 40.0, altitude: 800.0))
+
+        let expanded = bbox1.expanded(byIncluding: bbox2)
+        #expect(expanded.southWest.altitude == 100.0)
+        #expect(expanded.northEast.altitude == 800.0)
+    }
+
+    // Validates that expanded(byHorizontalDegrees:verticalDegrees:) preserves altitude.
+    @Test
+    func altitudeExpandedByHorizontalVerticalDegrees() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0, altitude: 500.0))
+
+        let expanded = bbox.expanded(byHorizontalDegrees: 5.0, verticalDegrees: 5.0)
+        #expect(expanded.southWest.altitude == 100.0)
+        #expect(expanded.northEast.altitude == 500.0)
+    }
+
+    // Validates that expanded(byDistance:) preserves altitude.
+    @Test
+    func altitudeExpandedByDistance() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0, altitude: 500.0))
+
+        let expanded = bbox.expanded(byDistance: 1000.0)
+        #expect(expanded.southWest.altitude == 100.0)
+        #expect(expanded.northEast.altitude == 500.0)
+    }
+
+    // Validates that squared() preserves altitude.
+    @Test
+    func altitudeSquared() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 20.0, altitude: 500.0))
+
+        let square = bbox.squared()
+        #expect(square.southWest.altitude == 100.0)
+        #expect(square.northEast.altitude == 500.0)
+    }
+
+    // Validates that the + operator preserves altitude (taking min/max).
+    @Test
+    func altitudePlusOperator() async throws {
+        let bbox1 = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 30.0, altitude: 500.0))
+        let bbox2 = BoundingBox(
+            southWest: Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 50.0),
+            northEast: Coordinate3D(latitude: 40.0, longitude: 40.0, altitude: 800.0))
+
+        let combined = bbox1 + bbox2
+        #expect(combined.southWest.altitude == 50.0)
+        #expect(combined.northEast.altitude == 800.0)
+    }
+
+    // Validates that formUnion preserves altitude.
+    @Test
+    func altitudeFormUnion() async throws {
+        var bbox1 = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 30.0, altitude: 500.0))
+        let bbox2 = BoundingBox(
+            southWest: Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 200.0),
+            northEast: Coordinate3D(latitude: 40.0, longitude: 40.0, altitude: 800.0))
+
+        bbox1.formUnion(bbox2)
+        #expect(bbox1.southWest.altitude == 100.0)
+        #expect(bbox1.northEast.altitude == 800.0)
+    }
+
+    // Validates that padded() preserves altitude.
+    @Test
+    func altitudePadded() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 500.0))
+
+        let padded = bbox.padded(1000.0)
+        #expect(padded.southWest.altitude == 100.0)
+        #expect(padded.northEast.altitude == 500.0)
+    }
+
+    // Validates that asJson includes altitude when both corners have it.
+    @Test
+    func altitudeAsJson() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 30.0, altitude: 500.0))
+
+        let json = bbox.asJson
+        #expect(json.count == 6)
+        #expect(json[0] == 0.0)   // sw lon
+        #expect(json[1] == 0.0)   // sw lat
+        #expect(json[2] == 100.0) // sw alt
+        #expect(json[3] == 30.0)  // ne lon
+        #expect(json[4] == 30.0)  // ne lat
+        #expect(json[5] == 500.0) // ne alt
+    }
+
+    // Validates that asJson omits altitude when corners lack it.
+    @Test
+    func altitudeAsJsonWithoutAltitude() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 30.0))
+
+        let json = bbox.asJson
+        #expect(json.count == 4)
+    }
+
+    // Validates that init?(json:) parses 6-element arrays with altitude.
+    @Test
+    func altitudeInitFromJson() async throws {
+        let json: [Double] = [0.0, 0.0, 100.0, 30.0, 30.0, 500.0]
+        let bbox: BoundingBox = try #require(BoundingBox(json: json))
+
+        #expect(bbox.southWest.longitude == 0.0)
+        #expect(bbox.southWest.latitude == 0.0)
+        #expect(bbox.southWest.altitude == 100.0)
+        #expect(bbox.northEast.longitude == 30.0)
+        #expect(bbox.northEast.latitude == 30.0)
+        #expect(bbox.northEast.altitude == 500.0)
+    }
+
+    // Validates that normalized() preserves altitude.
+    @Test
+    func altitudeNormalized() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 200.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 30.0, longitude: 220.0, altitude: 500.0))
+
+        let normalized = bbox.normalized()
+        #expect(normalized.southWest.altitude == 100.0)
+        #expect(normalized.northEast.altitude == 500.0)
+    }
+
+    // Validates that projected() preserves altitude.
+    @Test
+    func altitudeProjected() async throws {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 100.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0, altitude: 500.0))
+
+        let projected = bbox.projected(to: .epsg3857)
+        #expect(projected.southWest.altitude == 100.0)
+        #expect(projected.northEast.altitude == 500.0)
+    }
+
 }


### PR DESCRIPTION
Fixes #171.

All 8 methods that were silently dropping altitude now preserve it when both corners have altitude set.

| Method | Fix |
|---|---|
| `init(coordinates:padding:)` | Tracks min/max altitude; only sets when all input coordinates have altitude |
| `expanded(byHorizontalDegrees:verticalDegrees:)` | Passes `altitude:` through from original corners |
| `expanded(byDistance:)` | Restores altitude after `destination()` (which drops it) |
| `squared()` | Passes `z:` through from original corners |
| `+ / formUnion` | Takes min/max of altitudes; only sets when both boxes have altitude |
| `padded()` | Delegates to `init(coordinates:padding:)` — fixed automatically |
| `expanded(byIncluding:)` (both overloads) | Delegates to `init(coordinates:)` — fixed automatically |
| `normalized() / clamped() / projected()` | Already preserved altitude (no change needed) |

**Altitude semantics:** altitude is only carried forward when **all** inputs have it set. Mixed altitude/non-altitude inputs produce a bbox without altitude. This prevents silently baking altitude from only one corner while the other stays nil.

Adds 18 test cases covering all methods, JSON round-trip, and mixed/no-altitude edge cases.