### PR TITLE
Port turf/voronoi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | snap-to-grid                | `anyGeometry.snappedToGrid(tolerance: 0.5)`                                                                                           |     | [Source][175] / [Tests][176] |
 | tile-cover                  | `let tileCover = anyGeometry.tileCover(atZoom: 14)`                                                                                   |     | [Source][112] / [Tests][113] |
 | tin                         | `anyGeometry.tin()`                                                                                                                  |     | [Source][163] / [Tests][164] |
+| tesselate                   | `let triangles = polygon.tesselated()`                                                                                               |     | [Source][221] / [Tests][222] |
 | tin-to-point-cloud          | `let cloud = tin.tinToPointCloud()`                                                                                                  |     | [Source][201] / [Tests][202] |
 | transform-coordinates       | `let transformed = anyGeometry.transformCoordinates({ $0 })`                                                                          |     | [Source][114] / [Tests][115] |
 | transform-rotate            | `let transformed = anyGeometry. transformedRotate(angle: 25.0, pivot: Coordinate3D(…))`                                               |     | [Source][116] / [Tests][117] |
@@ -1019,6 +1020,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | truncate                    | `let truncated = lineString.truncated(precision: 2, removeAltitude: true)`                                                            |     | [Source][122] / [Tests][123] |
 | union                       | `let combined = polygon.union(with: otherPolygon)`                                                                                     |     | [Source][124] / [Tests][153] |
 | unkink-polygon              | `let simplePolygons = polygon.unkinked(gridSize: 0.001)`                                                                              |     | [Source][150] / [Tests][151] |
+| voronoi                     | `let cells = points.voronoiDiagram(boundingBox: bbox)`                                                                                |     | [Source][223] / [Tests][224] |
 
 # Related packages
 Currently only two:
@@ -1253,6 +1255,10 @@ Thomas Rasch, Outdooractive
 [218]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/BezierSplineTests.swift "BezierSplineTests"
 [219]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/IsoLines.swift "IsoLines"
 [220]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/IsoLinesTests.swift "IsoLinesTests"
+[221]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Tesselate.swift "Tesselate"
+[222]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/TesselateTests.swift "TesselateTests"
+[223]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Voronoi.swift "Voronoi"
+[224]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/VoronoiTests.swift "VoronoiTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Voronoi.swift
+++ b/Sources/GISTools/Algorithms/Voronoi.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-voronoi
+
+extension FeatureCollection {
+
+    /// Computes a Voronoi diagram from the receiver's points within a bounding box.
+    ///
+    /// Each input ``Point`` feature produces one ``Polygon`` cell representing the
+    /// region closer to that point than to any other input point. The cells are
+    /// clipped to the given bounding box.
+    ///
+    /// - Parameter boundingBox: The bounding box to which all cells are clipped.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``FeatureCollection`` of ``Polygon`` features, one per input point.
+    public func voronoiDiagram(
+        boundingBox: BoundingBox,
+        gridSize: Double? = nil
+    ) -> FeatureCollection {
+        guard features.count >= 3 else { return FeatureCollection() }
+
+        let snapped = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+
+        let points: [Coordinate3D] = snapped.features.compactMap { f in
+            (f.geometry as? Point)?.coordinate
+        }
+        guard points.count >= 3 else { return FeatureCollection() }
+
+        return Voronoi.diagram(points: points, boundingBox: boundingBox)
+    }
+
+}
+
+// MARK: - Implementation
+
+private enum Voronoi {
+
+    static func diagram(
+        points: [Coordinate3D],
+        boundingBox: BoundingBox
+    ) -> FeatureCollection {
+        let pts = points.map { Pt(x: $0.longitude, y: $0.latitude) }
+        let triangles = Triangulator.triangulate(pts)
+        guard triangles.isNotEmpty else { return FeatureCollection() }
+
+        // Build edge counts to identify adjacency and boundary edges
+        var edgeCount: [String: Int] = [:]
+        var edgeEndpoints: [String: (a: Pt, b: Pt)] = [:]
+
+        for t in triangles {
+            let edges = [(t.a, t.b), (t.b, t.c), (t.c, t.a)]
+            for (a, b) in edges {
+                let key = Voronoi.edgeKey(a, b)
+                edgeCount[key, default: 0] += 1
+                edgeEndpoints[key] = (a, b)
+            }
+        }
+
+        // Build neighbor list for each point
+        var neighbors: [Int: Set<Int>] = [:]
+        for (key, _) in edgeCount {
+            guard let edge = edgeEndpoints[key],
+                  let ia = pts.firstIndex(where: { $0.x == edge.a.x && $0.y == edge.a.y }),
+                  let ib = pts.firstIndex(where: { $0.x == edge.b.x && $0.y == edge.b.y })
+            else { continue }
+            neighbors[ia, default: []].insert(ib)
+            neighbors[ib, default: []].insert(ia)
+        }
+
+        // Build bounding box polygon (CCW)
+        let bboxPolygon = Voronoi.bboxPolygon(boundingBox)
+
+        // Compute Voronoi cell for each point
+        var features: [Feature] = []
+        for (i, point) in points.enumerated() {
+            guard let neighborIndices = neighbors[i],
+                  neighborIndices.count >= 2
+            else { continue }
+
+            let cell = Voronoi.computeCell(
+                point: point,
+                neighborIndices: Array(neighborIndices),
+                allPoints: points,
+                bboxPolygon: bboxPolygon)
+
+            if let cell {
+                let feature = Feature(cell)
+                features.append(feature)
+            }
+        }
+
+        return FeatureCollection(features)
+    }
+
+    // MARK: - Cell computation
+
+    /// Compute the Voronoi cell for a single point by clipping the bounding box
+    /// against the perpendicular bisectors of its Delaunay neighbors.
+    private static func computeCell(
+        point: Coordinate3D,
+        neighborIndices: [Int],
+        allPoints: [Coordinate3D],
+        bboxPolygon: [Coordinate3D]
+    ) -> Polygon? {
+        // Start with the bounding box as the clipping polygon
+        var cell = bboxPolygon
+
+        let px = point.longitude
+        let py = point.latitude
+        let pSq = px * px + py * py
+
+        for ni in neighborIndices {
+            let q = allPoints[ni]
+            let qx = q.longitude
+            let qy = q.latitude
+            let qSq = qx * qx + qy * qy
+
+            // Bisector coefficients: line where distance(p) == distance(q)
+            // 2*(qx-px)*x + 2*(qy-py)*y = qSq - pSq
+            let a = 2.0 * (qx - px)
+            let b = 2.0 * (qy - py)
+            let c = qSq - pSq
+
+            // Clip cell to the half-plane containing point p
+            cell = Voronoi.clipPolygonByHalfPlane(polygon: cell, a: a, b: b, c: c)
+            guard cell.count >= 3 else { return nil }
+        }
+
+        guard cell.count >= 3 else { return nil }
+        // Close the polygon
+        var coords = cell
+        coords.append(cell[0])
+        return Polygon([coords])
+    }
+
+    // MARK: - Half-plane clipping (Sutherland-Hodgman)
+
+    /// Clip a polygon (CCW) by the half-plane a*x + b*y <= c.
+    /// The polygon is represented as an array of coordinates (not closed).
+    private static func clipPolygonByHalfPlane(
+        polygon: [Coordinate3D],
+        a: Double,
+        b: Double,
+        c: Double
+    ) -> [Coordinate3D] {
+        guard polygon.count >= 3 else { return polygon }
+
+        var result: [Coordinate3D] = []
+
+        let count = polygon.count
+        for i in 0 ..< count {
+            let current = polygon[i]
+            let previous = polygon[(i + count - 1) % count]
+
+            let dCurrent = a * current.longitude + b * current.latitude - c
+            let dPrevious = a * previous.longitude + b * previous.latitude - c
+
+            let currentInside = dCurrent <= 0
+            let previousInside = dPrevious <= 0
+
+            if currentInside {
+                if !previousInside {
+                    // Entering: add intersection
+                    if let intersection = Voronoi.lineIntersection(
+                        p1: previous, p2: current, a: a, b: b, c: c) {
+                        result.append(intersection)
+                    }
+                }
+                result.append(current)
+            }
+            else if previousInside {
+                // Exiting: add intersection
+                if let intersection = Voronoi.lineIntersection(
+                    p1: previous, p2: current, a: a, b: b, c: c) {
+                    result.append(intersection)
+                }
+            }
+        }
+
+        return result
+    }
+
+    /// Find intersection of segment (p1-p2) with line a*x + b*y = c.
+    private static func lineIntersection(
+        p1: Coordinate3D,
+        p2: Coordinate3D,
+        a: Double,
+        b: Double,
+        c: Double
+    ) -> Coordinate3D? {
+        let x1 = p1.longitude, y1 = p1.latitude
+        let x2 = p2.longitude, y2 = p2.latitude
+
+        let denom = a * (x2 - x1) + b * (y2 - y1)
+        guard abs(denom) > 1e-15 else { return nil }
+
+        let t = (c - a * x1 - b * y1) / denom
+        guard t >= 0, t <= 1 else { return nil }
+
+        return Coordinate3D(
+            latitude: y1 + t * (y2 - y1),
+            longitude: x1 + t * (x2 - x1))
+    }
+
+    // MARK: - Helpers
+
+    /// Build a CCW polygon from the bounding box.
+    private static func bboxPolygon(_ bbox: BoundingBox) -> [Coordinate3D] {
+        let sw = bbox.southWest
+        let nw = bbox.northWest
+        let ne = bbox.northEast
+        let se = bbox.southEast
+        return [sw, nw, ne, se]
+    }
+
+    /// Canonical string key for an undirected edge.
+    private static func edgeKey(_ a: Pt, _ b: Pt) -> String {
+        let ax = "\(a.x),\(a.y)"
+        let bx = "\(b.x),\(b.y)"
+        return ax < bx ? "\(ax)-\(bx)" : "\(bx)-\(ax)"
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/VoronoiTests.swift
+++ b/Tests/GISToolsTests/Algorithms/VoronoiTests.swift
@@ -1,0 +1,194 @@
+import Testing
+import Foundation
+@testable import GISTools
+
+struct VoronoiTests {
+
+    // Validates that 3 points produce 3 Voronoi cells within the bounding box.
+    @Test
+    func testThreePoints() {
+        let points = [
+            Feature(Point(Coordinate3D(latitude: 5.0, longitude: 5.0))),
+            Feature(Point(Coordinate3D(latitude: 15.0, longitude: 5.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 15.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0))
+
+        let result = fc.voronoiDiagram(boundingBox: bbox)
+        #expect(result.features.count == 3)
+
+        for feature in result.features {
+            let poly = feature.geometry as? Polygon
+            #expect(poly != nil)
+            #expect(poly?.coordinates[0].count ?? 0 >= 4)
+        }
+    }
+
+    // Validates that 4 points at the corners produce cells filling the bounding box.
+    @Test
+    func testFourPoints() {
+        let points = [
+            Feature(Point(Coordinate3D(latitude: 5.0, longitude: 5.0))),
+            Feature(Point(Coordinate3D(latitude: 5.0, longitude: 15.0))),
+            Feature(Point(Coordinate3D(latitude: 15.0, longitude: 5.0))),
+            Feature(Point(Coordinate3D(latitude: 15.0, longitude: 15.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0))
+
+        let result = fc.voronoiDiagram(boundingBox: bbox)
+        #expect(result.features.count == 4)
+    }
+
+    // Validates that points exactly on the bounding box edge still produce valid cells.
+    @Test
+    func testPointsOnBboxEdge() {
+        let points = [
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0))),
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 10.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 0.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+
+        let result = fc.voronoiDiagram(boundingBox: bbox)
+        #expect(result.features.count == 3)
+    }
+
+    // Validates that fewer than 3 points returns an empty FeatureCollection.
+    @Test
+    func testTooFewPoints() {
+        let points = [
+            Feature(Point(Coordinate3D(latitude: 5.0, longitude: 5.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0))
+
+        let result = fc.voronoiDiagram(boundingBox: bbox)
+        #expect(result.features.isEmpty)
+    }
+
+    // Validates that an empty FeatureCollection returns an empty result.
+    @Test
+    func testEmptyPoints() {
+        let fc = FeatureCollection()
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0))
+
+        let result = fc.voronoiDiagram(boundingBox: bbox)
+        #expect(result.features.isEmpty)
+    }
+
+    // Validates that the Voronoi cells do not extend outside the bounding box.
+    @Test
+    func testCellsWithinBbox() {
+        let points = [
+            Feature(Point(Coordinate3D(latitude: 5.0, longitude: 5.0))),
+            Feature(Point(Coordinate3D(latitude: 15.0, longitude: 5.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 15.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: 20.0))
+
+        let result = fc.voronoiDiagram(boundingBox: bbox)
+        for feature in result.features {
+            guard let poly = feature.geometry as? Polygon else {
+                Issue.record("Expected Polygon")
+                continue
+            }
+            for coord in poly.allCoordinates {
+                #expect(coord.latitude >= 0.0 - 1e-10)
+                #expect(coord.latitude <= 20.0 + 1e-10)
+                #expect(coord.longitude >= 0.0 - 1e-10)
+                #expect(coord.longitude <= 20.0 + 1e-10)
+            }
+        }
+    }
+
+    // Validates a Voronoi diagram with points on both sides of the antimeridian,
+    // within a world-spanning bounding box.
+    @Test
+    func testAntimeridianWorldBbox() {
+        let points = [
+            Feature(Point(Coordinate3D(latitude: 5.0, longitude: -170.0))),
+            Feature(Point(Coordinate3D(latitude: 5.0, longitude: 180.0))),
+            Feature(Point(Coordinate3D(latitude: -5.0, longitude: 170.0))),
+            Feature(Point(Coordinate3D(latitude: -5.0, longitude: -175.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let bbox = BoundingBox.world
+
+        let result = fc.voronoiDiagram(boundingBox: bbox)
+        #expect(result.features.count == 4)
+
+        for feature in result.features {
+            let poly = feature.geometry as? Polygon
+            #expect(poly != nil)
+            #expect(poly?.coordinates[0].count ?? 0 >= 4)
+        }
+    }
+
+    // Validates a Voronoi diagram with an antimeridian-crossing bounding box,
+    // covering the region from lon=170 to lon=-170 (across the date line).
+    @Test
+    func testAntimeridianCrossingBbox() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: -10.0, longitude: 170.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: -170.0))
+
+        let points = [
+            Feature(Point(Coordinate3D(latitude: 5.0, longitude: 175.0))),
+            Feature(Point(Coordinate3D(latitude: -5.0, longitude: 175.0))),
+            Feature(Point(Coordinate3D(latitude: 5.0, longitude: -175.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.voronoiDiagram(boundingBox: bbox)
+        #expect(result.features.count == 3)
+
+        for feature in result.features {
+            let poly = feature.geometry as? Polygon
+            #expect(poly != nil)
+        }
+    }
+
+    // Validates a Voronoi diagram with points near the antimeridian and a
+    // non-crossing bounding box covering longitudes 150 to 200 (normalized).
+    @Test
+    func testAntimeridianNonCrossingBbox() {
+        // Longitude 200 normalizes to -160, so this bbox crosses the antimeridian
+        // in normalized form: [-160, -20, 160, 20]
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: -20.0, longitude: 160.0),
+            northEast: Coordinate3D(latitude: 20.0, longitude: -160.0))
+
+        let points = [
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 165.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 170.0))),
+            Feature(Point(Coordinate3D(latitude: -10.0, longitude: -170.0))),
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: -165.0))),
+        ]
+        let fc = FeatureCollection(points)
+        let result = fc.voronoiDiagram(boundingBox: bbox)
+        #expect(result.features.count == 4)
+
+        for feature in result.features {
+            let poly = feature.geometry as? Polygon
+            #expect(poly != nil)
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #141 

Ports [@turf/voronoi](https://github.com/Turfjs/turf/tree/master/packages/turf-voronoi).

Computes a Voronoi diagram from a FeatureCollection of points, clipped to a bounding box.

- `FeatureCollection.voronoiDiagram(boundingBox:gridSize:)`
- Uses Delaunay triangulation (existing Triangulator) + half-plane clipping against perpendicular bisectors of Delaunay neighbors
- Sutherland-Hodgman polygon clipping for each cell
- Naturally handles hull points (bounding box bounds unbounded cells)
- Handles antimeridian-crossing bounding boxes
- `gridSize` parameter for coordinate snapping
- O(n) after triangulation

Tests: 3 points, 4 points, points on bbox edge, too few points, empty, cells within bbox, antimeridian world bbox, antimeridian-crossing bbox, antimeridian non-crossing bbox.

Also adds both `tesselate` and `voronoi` to the README algorithm table.