### PR TITLE
Add Minkowski sum and difference

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,6 +985,8 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | line-split                  | `let segments = lineString.lineSplit(with: splitter)`                                                                                 |     | [Source][211] / [Tests][212] |
 | mask                        | `let masked = polygon.mask()`                                                                                                         |     | [Source][209] / [Tests][210] |
 | midpoint                    | `let middle = coordinate1.midpoint(to: coordinate2)`                                                                                  |     | [Source][90] / [Tests][91]   |
+| minkowski-difference        | `let eroded = polygon.minkowskiDifference(with: pattern)`                                                                             |     | [Source][231] / [Tests][232] |
+| minkowski-sum               | `let dilated = polygon.minkowskiSum(with: pattern)`                                                                                   |     | [Source][231] / [Tests][232] |
 | minimum-bounding-circle     | `let circle = anyGeometry.minimumBoundingCircle()`                                                                                    |     | [Source][203] / [Tests][204] |
 | minimum-bounding-radius     | `let r = anyGeometry.minimumBoundingRadius()`                                                                                         |     | [Source][203] / [Tests][204] |
 | nearest-point               | `let nearest = anyGeometry.nearestCoordinate(from: Coordinate3D(…))`                                                                  |     | [Source][92] / [Tests][138]  |
@@ -1268,6 +1270,8 @@ Thomas Rasch, Outdooractive
 [228]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/DifferenceTests.swift "DifferenceTests"
 [229]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/SymmetricDifference.swift "SymmetricDifference"
 [230]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/SymmetricDifferenceTests.swift "SymmetricDifferenceTests"
+[231]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/MinkowskiSum.swift "MinkowskiSum"
+[232]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/MinkowskiSumTests.swift "MinkowskiSumTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/MinkowskiSum.swift
+++ b/Sources/GISTools/Algorithms/MinkowskiSum.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+extension Polygon {
+
+    /// Returns the Minkowski sum of the receiver with a pattern polygon.
+    ///
+    /// The Minkowski sum of two sets A and B is the set of all points a + b
+    /// where a ∈ A and b ∈ B. This is useful for morphological dilation,
+    /// generating offset shapes, and path planning.
+    ///
+    /// - Parameter pattern: The pattern polygon to add.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``PolygonGeometry`` representing the Minkowski sum, or `nil` if empty.
+    public func minkowskiSum(
+        with pattern: PolygonGeometry,
+        gridSize: Double? = nil
+    ) -> PolygonGeometry? {
+        let a = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let b = gridSize.map { pattern.snappedToGrid(tolerance: $0) } ?? pattern
+        let bPolygons = b.polygons
+        return Minkowski.computeSum(a, bPolygons)
+    }
+
+    /// Returns the Minkowski difference of the receiver and a pattern polygon.
+    ///
+    /// The Minkowski difference is A ⊕ (−B), i.e. the Minkowski sum with the
+    /// pattern reflected through the origin. Useful for morphological erosion.
+    ///
+    /// - Parameter pattern: The pattern polygon to subtract.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``PolygonGeometry`` representing the Minkowski difference, or `nil` if empty.
+    public func minkowskiDifference(
+        with pattern: PolygonGeometry,
+        gridSize: Double? = nil
+    ) -> PolygonGeometry? {
+        let a = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let b = gridSize.map { pattern.snappedToGrid(tolerance: $0) } ?? pattern
+        let reflected = b.projected(to: b.projection)  // keep projection
+        let reflectedPolygons = reflected.polygons.map { $0.reflectedThroughOrigin() }
+        return Minkowski.computeSum(a, reflectedPolygons)
+    }
+
+}
+
+extension MultiPolygon {
+
+    /// Returns the Minkowski sum of the receiver with a pattern polygon.
+    ///
+    /// - Parameter pattern: The pattern polygon to add.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``PolygonGeometry`` representing the Minkowski sum, or `nil` if empty.
+    public func minkowskiSum(
+        with pattern: PolygonGeometry,
+        gridSize: Double? = nil
+    ) -> PolygonGeometry? {
+        let a = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let b = gridSize.map { pattern.snappedToGrid(tolerance: $0) } ?? pattern
+        let bPolygons = b.polygons
+        return Minkowski.computeSum(a, bPolygons)
+    }
+
+    /// Returns the Minkowski difference of the receiver and a pattern polygon.
+    ///
+    /// - Parameter pattern: The pattern polygon to subtract.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``PolygonGeometry`` representing the Minkowski difference, or `nil` if empty.
+    public func minkowskiDifference(
+        with pattern: PolygonGeometry,
+        gridSize: Double? = nil
+    ) -> PolygonGeometry? {
+        let a = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let b = gridSize.map { pattern.snappedToGrid(tolerance: $0) } ?? pattern
+        let reflectedPolygons = b.polygons.map { $0.reflectedThroughOrigin() }
+        return Minkowski.computeSum(a, reflectedPolygons)
+    }
+
+}
+
+// MARK: - Implementation
+
+private enum Minkowski {
+
+    /// Compute the Minkowski sum of a polygon/polygon-coverage and a pattern.
+    static func computeSum(
+        _ geoJson: GeoJson,
+        _ patterns: [Polygon]
+    ) -> PolygonGeometry? {
+        guard patterns.isNotEmpty else { return nil }
+        guard let sourcePolygons = (geoJson as? PolygonGeometry)?.polygons,
+              sourcePolygons.isNotEmpty
+        else { return nil }
+
+        let projection = sourcePolygons.first!.projection
+
+        // Tessellate source and pattern into convex triangles
+        let sourceParts = tessellateConvex(sourcePolygons, projection: projection)
+        let patternParts = tessellateConvex(patterns, projection: projection)
+
+        guard sourceParts.isNotEmpty,
+              patternParts.isNotEmpty
+        else { return nil }
+
+        // Compute convex Minkowski sum for each pair and collect results
+        var results: [Polygon] = []
+        for sa in sourceParts {
+            for sb in patternParts {
+                if let sum = convexSum(sa, sb) {
+                    results.append(sum)
+                }
+            }
+        }
+
+        guard results.isNotEmpty else { return nil }
+
+        // Union all partial results
+        guard let union = Union.unionPolygons(results) else { return nil }
+
+        let projected = union.projected(to: projection)
+        if projected.polygons.count == 1 {
+            return projected.polygons[0]
+        }
+        return projected
+    }
+
+    /// Decompose polygons into convex triangles.
+    private static func tessellateConvex(
+        _ polygons: [Polygon],
+        projection: Projection
+    ) -> [Polygon] {
+        var parts: [Polygon] = []
+        for poly in polygons {
+            if !poly.isConcave() {
+                parts.append(poly)
+            }
+            else {
+                let triangles = poly.tesselated()
+                for f in triangles.features {
+                    if let t = f.geometry as? Polygon {
+                        parts.append(t)
+                    }
+                }
+            }
+        }
+        return parts
+    }
+
+    /// Compute Minkowski sum of two convex polygons using pairwise vertex sums
+    /// plus convex hull.
+    private static func convexSum(_ a: Polygon, _ b: Polygon) -> Polygon? {
+        let coordsA = a.allCoordinates
+        let coordsB = b.allCoordinates
+        guard coordsA.isNotEmpty,
+              coordsB.isNotEmpty
+        else { return nil }
+
+        var sums: [Coordinate3D] = []
+        sums.reserveCapacity(coordsA.count * coordsB.count)
+
+        for va in coordsA {
+            for vb in coordsB {
+                let coord = Coordinate3D(
+                    x: va.x + vb.x,
+                    y: va.y + vb.y,
+                    z: nil,
+                    projection: va.projection)
+                sums.append(coord)
+            }
+        }
+
+        // Compute convex hull of the sums
+        let temp = FeatureCollection(sums.map { Feature(Point($0)) })
+        return temp.convexHull()
+    }
+
+}
+
+// MARK: - Reflection
+
+extension Polygon {
+
+    /// Reflect the polygon through the origin (negate all coordinates).
+    fileprivate func reflectedThroughOrigin() -> Polygon {
+        let reflectedRings: [[Coordinate3D]] = rings.map { ring in
+            ring.coordinates.map { coord in
+                Coordinate3D(
+                    x: -coord.x,
+                    y: -coord.y,
+                    z: coord.altitude,
+                    projection: coord.projection)
+            }
+        }
+        return Polygon(unchecked: reflectedRings)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/MinkowskiSumTests.swift
+++ b/Tests/GISToolsTests/Algorithms/MinkowskiSumTests.swift
@@ -1,0 +1,317 @@
+import Testing
+import Foundation
+@testable import GISTools
+
+struct MinkowskiSumTests {
+
+    // Validates Minkowski sum of two small squares produces an expanded shape.
+    @Test
+    func sumTwoSquares() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 2.0, longitude: 0.0),
+                Coordinate3D(latitude: 2.0, longitude: 2.0),
+                Coordinate3D(latitude: 0.0, longitude: 2.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiSum(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski sum of a convex polygon with a triangle.
+    @Test
+    func sumConvexAndTriangle() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 2.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 2.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiSum(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski sum with a point-like pattern (single vertex triangle)
+    // should return the original polygon.
+    @Test
+    func sumWithZeroPattern() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+        // Tiny triangle at the origin
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiSum(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski difference of a square with a small triangle.
+    @Test
+    func difference() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 1.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiDifference(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski sum with gridSize parameter.
+    @Test
+    func sumWithGridSize() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.001),
+                Coordinate3D(latitude: 10.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 1.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiSum(with: b, gridSize: 1.0)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski sum with a concave polygon.
+    @Test
+    func sumConcave() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 5.0),
+                Coordinate3D(latitude: 5.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 1.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiSum(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski sum on MultiPolygon.
+    @Test
+    func sumMultiPolygon() async throws {
+        let a = MultiPolygon([
+            Polygon([
+                [
+                    Coordinate3D(latitude: 0.0, longitude: 0.0),
+                    Coordinate3D(latitude: 5.0, longitude: 0.0),
+                    Coordinate3D(latitude: 5.0, longitude: 5.0),
+                    Coordinate3D(latitude: 0.0, longitude: 5.0),
+                    Coordinate3D(latitude: 0.0, longitude: 0.0),
+                ],
+            ])!,
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 1.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiSum(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski difference on MultiPolygon.
+    @Test
+    func differenceMultiPolygon() async throws {
+        let a = MultiPolygon([
+            Polygon([
+                [
+                    Coordinate3D(latitude: 0.0, longitude: 0.0),
+                    Coordinate3D(latitude: 5.0, longitude: 0.0),
+                    Coordinate3D(latitude: 5.0, longitude: 5.0),
+                    Coordinate3D(latitude: 0.0, longitude: 5.0),
+                    Coordinate3D(latitude: 0.0, longitude: 0.0),
+                ],
+            ])!,
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 1.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiDifference(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski sum where the source polygon crosses the antimeridian.
+    @Test
+    func sumAntimeridianSource() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 170.0),
+                Coordinate3D(latitude: 10.0, longitude: 170.0),
+                Coordinate3D(latitude: 10.0, longitude: -170.0),
+                Coordinate3D(latitude: 0.0, longitude: -170.0),
+                Coordinate3D(latitude: 0.0, longitude: 170.0),
+            ],
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 1.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiSum(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski sum where the pattern polygon crosses the antimeridian.
+    @Test
+    func sumAntimeridianPattern() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 175.0),
+                Coordinate3D(latitude: 2.0, longitude: 175.0),
+                Coordinate3D(latitude: 2.0, longitude: -175.0),
+                Coordinate3D(latitude: 0.0, longitude: -175.0),
+                Coordinate3D(latitude: 0.0, longitude: 175.0),
+            ],
+        ])!
+
+        let result = a.minkowskiSum(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski difference where the source polygon crosses the antimeridian.
+    @Test
+    func differenceAntimeridianSource() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 170.0),
+                Coordinate3D(latitude: 10.0, longitude: 170.0),
+                Coordinate3D(latitude: 10.0, longitude: -170.0),
+                Coordinate3D(latitude: 0.0, longitude: -170.0),
+                Coordinate3D(latitude: 0.0, longitude: 170.0),
+            ],
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 1.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.minkowskiDifference(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates Minkowski sum where both inputs cross the antimeridian.
+    @Test
+    func sumAntimeridianBoth() async throws {
+        let a = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 170.0),
+                Coordinate3D(latitude: 5.0, longitude: 170.0),
+                Coordinate3D(latitude: 5.0, longitude: -170.0),
+                Coordinate3D(latitude: 0.0, longitude: -170.0),
+                Coordinate3D(latitude: 0.0, longitude: 170.0),
+            ],
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 175.0),
+                Coordinate3D(latitude: 2.0, longitude: 175.0),
+                Coordinate3D(latitude: 2.0, longitude: -175.0),
+                Coordinate3D(latitude: 0.0, longitude: -175.0),
+                Coordinate3D(latitude: 0.0, longitude: 175.0),
+            ],
+        ])!
+
+        let result = a.minkowskiSum(with: b)
+        #expect(result != nil)
+    }
+
+}


### PR DESCRIPTION
Adds Minkowski sum and Minkowski difference operations for morphological dilation/erosion of polygons, matching Clipper2 semantics.

### API

| Operation | API |
|---|---|
| Minkowski sum | `polygon.minkowskiSum(with:pattern, gridSize:)` |
| Minkowski difference | `polygon.minkowskiDifference(with:pattern, gridSize:)` |

Both available on `Polygon` and `MultiPolygon`, return `PolygonGeometry?`.

### Implementation

- Non-convex polygons are decomposed into convex triangles via ear-clipping tessellation
- Convex Minkowski sum computed using pairwise vertex sums + convex hull (monotone chain)
- All partial results unioned together using the existing overlay infrastructure
- Minkowski difference = Minkowski sum with pattern reflected through origin
- Accepts `gridSize` parameter

### Tests (12)
- Two squares, convex + triangle, zero pattern, difference, gridSize, concave, MultiPolygon sum/diff
- 4 antimeridian-crossing: source crosses, pattern crosses, difference source crosses, both cross

Closes #152.