### PR TITLE
Add sharedPaths operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | rhumb-distance              | `let distance = coordinate1.rhumbDistance(from: coordinate2)`                                                                         |     | [Source][108] / [Tests][109] |
 | sample                      | `let sampled = featureCollection.sample(size: 10)`                                                                                    |     | [Source][181] / [Tests][182] |
 | sector                      | `let sector = coordinate.sector(radius: 5000.0, bearing1: 0.0, bearing2: 90.0)`                                                       |     | [Source][189] / [Tests][190] |
+| shared-paths                | `let shared = a.sharedPaths(with: b)`                                                                                                  |     | [Source][235] / [Tests][236] |
 | square                      | `let squared = boundingBox.squared()`                                                                                                 |     | [Source][193] / [Tests][194] |
 | symmetric-difference        | `let xor = polygon.symmetricDifference(with: other)`                                                                                  |     | [Source][229] / [Tests][230] |
 | simplify                    | `let simplified = lineString. simplified(tolerance: 5.0, highQuality: false)`                                                         |     | [Source][110] / [Tests][111] |
@@ -1275,6 +1276,8 @@ Thomas Rasch, Outdooractive
 [232]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/MinkowskiSumTests.swift "MinkowskiSumTests"
 [233]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/Densify.swift "Densify"
 [234]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/DensifyTests.swift "DensifyTests"
+[235]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/SharedPaths.swift "SharedPaths"
+[236]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/SharedPathsTests.swift "SharedPathsTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/SharedPaths.swift
+++ b/Sources/GISTools/Algorithms/SharedPaths.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+// Ported from GEOS SharedPathsOperation
+
+extension GeoJson {
+
+    /// Finds path segments that are common between the receiver and another geometry.
+    ///
+    /// Both geometries are decomposed into line segments. A segment from the first
+    /// geometry is included in the result if an identical segment (same start and end,
+    /// or reversed) exists in the second geometry.
+    ///
+    /// - Parameter other: The other geometry to compare against.
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
+    /// - Returns: A ``MultiLineString`` of shared segments, or `nil` if none are found.
+    public func sharedPaths(
+        with other: GeoJson,
+        gridSize: Double? = nil
+    ) -> MultiLineString? {
+        let a = gridSize.map { gs in self.snappedToGrid(tolerance: gs) } ?? self
+        let b = gridSize.map { gs in other.snappedToGrid(tolerance: gs) } ?? other
+
+        let segmentsA = a.lineSegments
+        let segmentsB = b.lineSegments
+
+        guard segmentsA.isNotEmpty,
+              segmentsB.isNotEmpty
+        else { return nil }
+
+        var matched: [LineSegment] = []
+
+        for segA in segmentsA {
+            for segB in segmentsB {
+                guard SharedPaths.segmentsMatch(segA, segB) else { continue }
+
+                // Avoid adding the same segment twice
+                let isDuplicate = matched.contains { existing in
+                    SharedPaths.segmentsMatch(existing, segA)
+                }
+                if !isDuplicate {
+                    matched.append(segA)
+                }
+                break
+            }
+        }
+
+        guard matched.isNotEmpty else { return nil }
+
+        let lineStrings: [LineString] = matched.map { seg in
+            LineString(unchecked: [seg.first, seg.second])
+        }
+        return MultiLineString(unchecked: lineStrings)
+    }
+
+}
+
+// MARK: - Implementation
+
+private enum SharedPaths {
+
+    /// Check if two segments match (same direction or reversed).
+    static func segmentsMatch(_ a: LineSegment, _ b: LineSegment) -> Bool {
+        let aFirst = a.first
+        let aSecond = a.second
+        let bFirst = b.first
+        let bSecond = b.second
+
+        // Same direction: a.first→a.second == b.first→b.second
+        if aFirst.isCoincident(to: bFirst) && aSecond.isCoincident(to: bSecond) {
+            return true
+        }
+        // Reversed: a.first→a.second == b.second→b.first
+        if aFirst.isCoincident(to: bSecond) && aSecond.isCoincident(to: bFirst) {
+            return true
+        }
+        return false
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/SharedPathsTests.swift
+++ b/Tests/GISToolsTests/Algorithms/SharedPathsTests.swift
@@ -1,0 +1,236 @@
+import Testing
+import Foundation
+@testable import GISTools
+
+struct SharedPathsTests {
+
+    // Validates that two identical LineStrings share all their segments.
+    @Test
+    func identicalLineStrings() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+
+        let result = a.sharedPaths(with: b)
+        #expect(result != nil)
+        #expect(result!.lineStrings.count == 2)
+    }
+
+    // Validates that two LineStrings with one shared segment find that segment.
+    @Test
+    func partiallyShared() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 15.0, longitude: 0.0),
+        ])!
+
+        let result = a.sharedPaths(with: b)
+        #expect(result != nil)
+        // Shared: (5,0)→(10,0)
+        #expect(result!.lineStrings.count == 1)
+    }
+
+    // Validates that reversed segments also match.
+    @Test
+    func reversedSegment() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ])!
+
+        let result = a.sharedPaths(with: b)
+        #expect(result != nil)
+        #expect(result!.lineStrings.count == 1)
+    }
+
+    // Validates that non-overlapping geometries return nil.
+    @Test
+    func noSharedPaths() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 15.0, longitude: 0.0),
+        ])!
+
+        let result = a.sharedPaths(with: b)
+        #expect(result == nil)
+    }
+
+    // Validates that sharedPaths works with MultiLineString inputs.
+    @Test
+    func multiLineStrings() async throws {
+        let a = MultiLineString([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+            ],
+            [
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+                Coordinate3D(latitude: 15.0, longitude: 0.0),
+            ],
+        ])!
+        let b = MultiLineString([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+            ],
+            [
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.sharedPaths(with: b)
+        #expect(result != nil)
+        // Shared: (0,0)→(5,0)
+        #expect(result!.lineStrings.count == 1)
+    }
+
+    // Validates that sharedPaths deduplicates matching segments.
+    @Test
+    func duplicateSegments() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let b = MultiLineString([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+            ],
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.sharedPaths(with: b)
+        #expect(result != nil)
+        // Should only report (0,0)→(5,0) once
+        #expect(result!.lineStrings.count == 1)
+    }
+
+    // Validates that gridSize parameter snaps coordinates for matching.
+    @Test
+    func sharedWithGridSize() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.001),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+
+        // Without gridSize, these don't match (0.001 diff)
+        let without = a.sharedPaths(with: b)
+        #expect(without == nil)
+
+        // With gridSize=1.0, coordinates snap to integer grid
+        let with = a.sharedPaths(with: b, gridSize: 1.0)
+        #expect(with != nil)
+        #expect(with!.lineStrings.count == 1)
+    }
+
+    // Validates shared paths between a LineString and a Polygon (extracts ring segments).
+    @Test
+    func lineAndPolygon() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = Polygon([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 5.0),
+                Coordinate3D(latitude: 5.0, longitude: 10.0),
+                Coordinate3D(latitude: 0.0, longitude: 5.0),
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+            ],
+        ])!
+
+        let result = a.sharedPaths(with: b)
+        #expect(result != nil)
+        #expect(result!.lineStrings.count == 1)
+    }
+
+    // Validates that FeatureCollections extract their geometries' segments.
+    @Test
+    func featureCollections() async throws {
+        let a = FeatureCollection([
+            Feature(LineString([
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+            ])!),
+        ])
+        let b = FeatureCollection([
+            Feature(LineString([
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+            ])!),
+        ])
+
+        let result = a.sharedPaths(with: b)
+        #expect(result != nil)
+    }
+
+    // Validates shared paths between two LineStrings crossing the antimeridian.
+    @Test
+    func antimeridianLineStrings() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+            Coordinate3D(latitude: 5.0, longitude: -170.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+            Coordinate3D(latitude: 5.0, longitude: -170.0),
+        ])!
+
+        let result = a.sharedPaths(with: b)
+        #expect(result != nil)
+        // Two shared segments (170,0)→(-170,0) and (-170,0)→(-170,5)
+        #expect(result!.lineStrings.count == 2)
+    }
+
+    // Validates shared paths across the antimeridian with reversed segment.
+    @Test
+    func antimeridianReversed() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+        ])!
+
+        let result = a.sharedPaths(with: b)
+        #expect(result != nil)
+        #expect(result!.lineStrings.count == 1)
+    }
+
+}


### PR DESCRIPTION
Adds `sharedPaths(with:gridSize:)` that finds common line segments between two geometries, corresponding to GEOS `SharedPathsOperation`.

- Decomposes both geometries into line segments via the existing `GeoJson.lineSegments` property
- Matches segments in both directions (same or reversed order)
- Deduplicates matching segments (each segment reported once)
- `gridSize` parameter snaps coordinates before matching
- Works on any GeoJson type (LineString, MultiLineString, Polygon, etc.)

Tests: 11 total — identical, partially shared, reversed, no match, MultiLineString, duplicates, gridSize, line+polygon, FeatureCollection, and 2 antimeridian-crossing.

Closes #167.