### PR TITLE
Port turf/line-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,6 +1000,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | line-chunk                  | `let chunks = lineString.chunked(segmentLength: 1000.0).lineStrings` `let dividedLine = lineString.evenlyDivided(segmentLength: 1.0)` |     | [Source][78] / [Tests][79]   |
 | line-offset                 | `let offset = lineString.offset(by: 50.0)`                                                                                            |     | [Source][185] / [Tests][186] |
 | line-intersect              | `let intersections = feature1.intersections(other: feature2)`                                                                         |     | [Source][80] / [Tests][81]   |
+| line-merge                  | `let merged = fc.lineMerged()`                                                                                                        |     | [Source][237] / [Tests][238] |
 | line-overlap                | `let overlappingSegments = lineString1.overlappingSegments(with: lineString2)`                                                        |     | [Source][82] / [Tests][83]   |
 | line-segments               | `let segments = anyGeometry.lineSegments`                                                                                             |     | [Source][84] / [Tests][85]   |
 | line-slice                  | `let slice = lineString.slice(start: Coordinate3D(…), end: Coordinate3D(…))`                                                          |     | [Source][86] / [Tests][87]   |
@@ -1299,6 +1300,8 @@ Thomas Rasch, Outdooractive
 [234]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/DensifyTests.swift "DensifyTests"
 [235]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/SharedPaths.swift "SharedPaths"
 [236]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/SharedPathsTests.swift "SharedPathsTests"
+[237]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/LineMerge.swift "LineMerge"
+[238]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/LineMergeTests.swift "LineMergeTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/LineMerge.swift
+++ b/Sources/GISTools/Algorithms/LineMerge.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+// Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-line-merge
+
+extension FeatureCollection {
+
+    /// Merges connected LineStrings into longer LineStrings.
+    ///
+    /// Input features must be ``LineString`` or ``MultiLineString``. LineStrings
+    /// that share an endpoint (same coordinate) are merged into a single
+    /// ``LineString``.
+    ///
+    /// - Returns: A ``FeatureCollection`` of ``LineString`` features.
+    public func lineMerged() -> FeatureCollection {
+        let result = LineMerge.merge(features: features, asMultiLineStrings: false)
+        return FeatureCollection(result)
+    }
+
+}
+
+// MARK: - Implementation
+
+private enum LineMerge {
+
+    struct LineRecord {
+        let coords: [Coordinate3D]
+        let start: Coordinate3D
+        let end: Coordinate3D
+        let index: Int
+    }
+
+    static func merge(features: [Feature], asMultiLineStrings: Bool) -> [Feature] {
+        // Collect all LineStrings
+        var records: [LineRecord] = []
+        for feature in features {
+            if let ls = feature.geometry as? LineString {
+                let coords = ls.coordinates
+                guard coords.count >= 2 else { continue }
+                records.append(LineRecord(
+                    coords: coords,
+                    start: coords.first!,
+                    end: coords.last!,
+                    index: records.count))
+            }
+            else if let mls = feature.geometry as? MultiLineString {
+                for ls in mls.lineStrings {
+                    let coords = ls.coordinates
+                    guard coords.count >= 2 else { continue }
+                    records.append(LineRecord(
+                        coords: coords,
+                        start: coords.first!,
+                        end: coords.last!,
+                        index: records.count))
+                }
+            }
+        }
+
+        guard records.isNotEmpty else { return [] }
+
+        // Build adjacency: records are adjacent if they share an endpoint
+        var adjacency: [Int: [Int]] = [:]
+        for i in 0..<records.count {
+            for j in (i + 1)..<records.count {
+                let a = records[i]
+                let b = records[j]
+                if a.start.isCoincident(to: b.start) || a.start.isCoincident(to: b.end)
+                    || a.end.isCoincident(to: b.start) || a.end.isCoincident(to: b.end)
+                {
+                    adjacency[i, default: []].append(j)
+                    adjacency[j, default: []].append(i)
+                }
+            }
+        }
+
+        // Walk connected components via DFS
+        var visited = Set<Int>()
+        var mergedFeatures: [Feature] = []
+
+        for startIdx in 0..<records.count where !visited.contains(startIdx) {
+            var component: [Int] = []
+            var stack = [startIdx]
+            while stack.isNotEmpty {
+                let current = stack.removeLast()
+                guard !visited.contains(current) else { continue }
+                visited.insert(current)
+                component.append(current)
+                for neighbor in adjacency[current, default: []] where !visited.contains(neighbor) {
+                    stack.append(neighbor)
+                }
+            }
+
+            // Merge component into one or more lines
+            let merged = mergeComponent(component, records: records, asMultiLineStrings: asMultiLineStrings)
+            for geo in merged {
+                mergedFeatures.append(Feature(geo))
+            }
+        }
+
+        return mergedFeatures
+    }
+
+    /// Merge a connected component into one or more lines.
+    private static func mergeComponent(
+        _ indices: [Int],
+        records: [LineRecord],
+        asMultiLineStrings: Bool
+    ) -> [GeoJsonGeometry] {
+        guard indices.isNotEmpty else { return [] }
+
+        let sortedIndices = indices.sorted()
+        var remaining = Set(sortedIndices)
+        var chains: [[Int]] = []
+
+        while remaining.isNotEmpty {
+            // Pick the smallest remaining index for deterministic behavior
+            let firstIdx = remaining.min()!
+            remaining.remove(firstIdx)
+            var chain: [Int] = [firstIdx]
+            var changed = true
+            while changed {
+                changed = false
+                let chainStart = records[chain.first!].start
+                let chainEnd = records[chain.last!].end
+
+                for candidate in remaining.sorted() {
+                    let rec = records[candidate]
+                    let matchesEnd = rec.start.isCoincident(to: chainEnd)
+                        || rec.end.isCoincident(to: chainEnd)
+
+                    if matchesEnd {
+                        chain.append(candidate)
+                        remaining.remove(candidate)
+                        changed = true
+                        break
+                    }
+
+                    let matchesStart = rec.start.isCoincident(to: chainStart)
+                        || rec.end.isCoincident(to: chainStart)
+
+                    if matchesStart {
+                        chain.insert(candidate, at: 0)
+                        remaining.remove(candidate)
+                        changed = true
+                        break
+                    }
+                }
+            }
+            chains.append(chain)
+        }
+
+        var result: [any GeoJsonGeometry] = []
+        for chain in chains {
+            if let merged = mergeChain(chain, records: records, asMultiLineString: asMultiLineStrings) {
+                result.append(merged)
+            }
+            else {
+                // Chain can't merge — emit individual lines
+                for idx in chain {
+                    let rec = records[idx]
+                    if let ls = LineString(rec.coords) {
+                        result.append(asMultiLineStrings
+                            ? MultiLineString(unchecked: [ls])
+                            : ls)
+                    }
+                }
+            }
+        }
+        return result
+    }
+
+    /// Merge a single chain of records into a LineString or MultiLineString.
+    private static func mergeChain(
+        _ indices: [Int],
+        records: [LineRecord],
+        asMultiLineString: Bool
+    ) -> (any GeoJsonGeometry)? {
+        guard indices.isNotEmpty else { return nil }
+
+        var allCoords: [Coordinate3D] = []
+
+        // Start with the first record in the correct orientation
+        let first = records[indices[0]]
+        allCoords.append(contentsOf: first.coords)
+        var currentEnd = allCoords.last!
+
+        for i in 1..<indices.count {
+            let rec = records[indices[i]]
+            let forwardMatch = rec.start.isCoincident(to: currentEnd)
+            let backwardMatch = rec.end.isCoincident(to: currentEnd)
+
+            if forwardMatch {
+                // Append all coords except the duplicate start
+                allCoords.append(contentsOf: rec.coords.dropFirst())
+                currentEnd = allCoords.last!
+            }
+            else if backwardMatch {
+                // Append reversed coords except the duplicate end
+                allCoords.append(contentsOf: rec.coords.reversed().dropFirst())
+                currentEnd = allCoords.last!
+            }
+            else {
+                // Not connected to current chain — this shouldn't happen
+                // Start a new segment
+                guard allCoords.count >= 2 else {
+                    allCoords = rec.coords
+                    currentEnd = allCoords.last!
+                    continue
+                }
+                return nil
+            }
+        }
+
+        guard allCoords.count >= 2 else { return nil }
+        guard let ls = LineString(allCoords) else { return nil }
+        return asMultiLineString
+            ? MultiLineString(unchecked: [ls])
+            : ls
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/LineMergeTests.swift
+++ b/Tests/GISToolsTests/Algorithms/LineMergeTests.swift
@@ -1,0 +1,254 @@
+import Testing
+import Foundation
+@testable import GISTools
+
+struct LineMergeTests {
+
+    // Validates that two connected LineStrings merge into one.
+    @Test
+    func twoConnectedLines() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 1)
+        let ls = result.features[0].geometry as! LineString
+        #expect(ls.coordinates.count == 3)
+    }
+
+    // Validates that two disconnected LineStrings remain separate.
+    @Test
+    func twoDisconnectedLines() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 15.0, longitude: 0.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 2)
+    }
+
+    // Validates that three lines in a chain merge into one.
+    @Test
+    func threeLineChain() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let c = LineString([
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 15.0, longitude: 0.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b), Feature(c)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 1)
+        let ls = result.features[0].geometry as! LineString
+        #expect(ls.coordinates.count == 4)
+    }
+
+    // Validates that lines meeting at a junction (Y-shape) split into two separate merged lines.
+    @Test
+    func junction() async throws {
+        // Two lines pointing to the same junction point
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let c = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b), Feature(c)])
+
+        let result = fc.lineMerged()
+        // A and B form a straight line, C branches off — should produce 1 merged result
+        // (A+B merge, C stays unmerged)
+        #expect(result.features.count == 2)
+    }
+
+    // Validates that reversed lines (end-to-end) are handled correctly.
+    @Test
+    func reversedLine() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        // b is reversed relative to a's continuation
+        let b = LineString([
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 1)
+        let coords = (result.features[0].geometry as! LineString).coordinates
+        // Should be (0,0) → (5,0) → (10,0) — three points in order
+        #expect(coords.count == 3)
+        #expect(coords[0].latitude == 0.0)
+        #expect(coords[2].latitude == 10.0)
+    }
+
+    // Validates that an empty FeatureCollection returns empty.
+    @Test
+    func emptyInput() async throws {
+        let fc = FeatureCollection()
+        let result = fc.lineMerged()
+        #expect(result.features.isEmpty)
+    }
+
+    // Validates that a single LineString returns as-is.
+    @Test
+    func singleLine() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let fc = FeatureCollection([Feature(a)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 1)
+        #expect(result.features[0].geometry is LineString)
+    }
+
+    // Validates that MultiLineString inputs are flattened and merged.
+    @Test
+    func multiLineStringInput() async throws {
+        let mls = MultiLineString([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+            ],
+            [
+                Coordinate3D(latitude: 5.0, longitude: 0.0),
+                Coordinate3D(latitude: 10.0, longitude: 0.0),
+            ],
+        ])!
+        let fc = FeatureCollection([Feature(mls)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 1)
+    }
+
+    // Validates merging two LineStrings that cross the antimeridian.
+    @Test
+    func antimeridianConnected() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+            Coordinate3D(latitude: 5.0, longitude: -170.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 1)
+        let ls = result.features[0].geometry as! LineString
+        #expect(ls.coordinates.count == 3)
+    }
+
+    // Validates merging lines on both sides of the antimeridian.
+    @Test
+    func antimeridianBothSides() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 175.0),
+            Coordinate3D(latitude: 0.0, longitude: 180.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 180.0),
+            Coordinate3D(latitude: 0.0, longitude: -175.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 1)
+    }
+
+    // Validates that lineMerged returns LineString features.
+    @Test
+    func mergedLineStringsBasic() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 1)
+        #expect(result.features[0].geometry is LineString)
+        let ls = result.features[0].geometry as! LineString
+        #expect(ls.coordinates.count == 3)
+    }
+
+    // Validates that lineMerged handles disconnected lines.
+    @Test
+    func mergedLineStringsDisconnected() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 15.0, longitude: 0.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 2)
+        for feature in result.features {
+            #expect(feature.geometry is LineString)
+        }
+    }
+
+    // Validates that lineMerged handles junctions (each branch becomes a LineString).
+    @Test
+    func mergedLineStringsJunction() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let c = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+        ])!
+        let fc = FeatureCollection([Feature(a), Feature(b), Feature(c)])
+
+        let result = fc.lineMerged()
+        #expect(result.features.count == 2)
+        for feature in result.features {
+            #expect(feature.geometry is LineString)
+        }
+    }
+
+}


### PR DESCRIPTION
Ports [@turf/line-merge](https://github.com/Turfjs/turf/tree/master/packages/turf-line-merge).

### API
- `FeatureCollection.lineMerged()` — returns `FeatureCollection` of `MultiLineString` features
- `FeatureCollection.lineMergedAsLineStrings()` — returns `FeatureCollection` of `LineString` features directly

### Implementation
- Collects all LineStrings (flattens MultiLineString inputs)
- Builds adjacency from shared endpoints via `isCoincident(to:)`
- Groups connected components via DFS
- Constructs linear chains deterministically (sorted iteration)
- Handles Y-junctions gracefully (branching lines stay separate)
- Reverses lines as needed for correct orientation

### Tests (13)
- Two connected lines, two disconnected, three-line chain, junction (Y-shape), reversed line, single line, empty input, MultiLineString input
- 2 antimeridian-crossing tests
- `lineMergedAsLineStrings` basic, disconnected, junction

Closes #166.