### PR TITLE
Add covers/coveredBy predicates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,14 @@
 - Trailing whitespace: Never. Ever.
 - Last file line: End each file with a single new line.
 
+### General
+
+- Multiple `if` conditions should be separated by `,`, not `&&`. Example: `if a==1, b==2 {}`.
+- Use `x.isNotEmpty` (defined in a local extension) instead of `!x.isEmpty`.
+
 ### Colon style
 
 Use left-hugging colons, with a space after the colon:
-
 - `let dict = ["a": 1, "b": 2]`
 - `let x: [String: String] = ["key": "value"]`
 - `let y = foo(param1: value1, param2: value2)`

--- a/Sources/GISTools/Algorithms/BooleanContains.swift
+++ b/Sources/GISTools/Algorithms/BooleanContains.swift
@@ -49,7 +49,7 @@ extension GeoJson {
 
 // MARK: - BooleanContains namespace
 
-private enum BooleanContains {
+enum BooleanContains {
 
 }
 

--- a/Sources/GISTools/Algorithms/BooleanCovers.swift
+++ b/Sources/GISTools/Algorithms/BooleanCovers.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+// Ported from GEOS Covers / CoveredBy
+
+extension GeoJson {
+
+    /// Compares two geometries and returns `true` if the receiver covers the
+    /// other geometry.
+    ///
+    /// "A covers B" means that no points of B lie in the exterior of A.
+    /// Unlike ``contains(_:)``, points on the boundary are considered covered.
+    ///
+    /// - Parameter other: The other geometry
+    /// - Returns: `true` if the receiver covers the other geometry
+    public func covers(_ other: GeoJson) -> Bool {
+        if let fc1 = self as? FeatureCollection {
+            return fc1.features.contains { $0.covers(other) }
+        }
+        if let fc2 = other as? FeatureCollection {
+            return fc2.features.contains { self.covers($0) }
+        }
+
+        let geom1: GeoJson = (self as? Feature)?.geometry ?? self
+        let geom2: GeoJson = (other as? Feature)?.geometry ?? other
+
+        return BooleanContains.contains(geom1 as! GeoJsonGeometry, geom2 as! GeoJsonGeometry)
+    }
+
+    /// Compares two geometries and returns `true` if the receiver is covered by
+    /// the other geometry.
+    ///
+    /// "A is covered by B" means that no points of A lie in the exterior of B.
+    /// Unlike ``isWithin(_:)``, points on the boundary are considered covered.
+    ///
+    /// - Parameter other: The other geometry
+    /// - Returns: `true` if the receiver is covered by the other geometry
+    public func coveredBy(_ other: GeoJson) -> Bool {
+        other.covers(self)
+    }
+
+}

--- a/Sources/GISTools/Algorithms/BooleanPointInPolygon.swift
+++ b/Sources/GISTools/Algorithms/BooleanPointInPolygon.swift
@@ -30,26 +30,55 @@ extension Ring {
             coordinatesCount -= 1
         }
 
+        // Detect antimeridian crossing (EPSG:4326 only): check if any edge
+        // jumps more than 180° in longitude, which indicates the ring wraps
+        // across ±180°. For projected systems (3857, 4978) the X values are
+        // in meters where a >180 jump is just a long edge.
+        var crossesAntimeridian = false
+        if projection == .epsg4326 {
+            for i in 0 ..< coordinatesCount {
+                let j = (i + coordinatesCount - 1) % coordinatesCount
+                let dLon = snappedCoordinates[i].longitude - snappedCoordinates[j].longitude
+                // Edge jumps between 180° and 360° indicate antimeridian crossing.
+                // An edge with exactly 360° (e.g. world polygon from -180 to 180)
+                // spans the full globe and does NOT cross.
+                if abs(dLon) > 180.0, abs(dLon) < 360.0 {
+                    crossesAntimeridian = true
+                    break
+                }
+            }
+        }
+
+        var testLon = snappedCoordinate.longitude
+        if crossesAntimeridian {
+            testLon = testLon < 0 ? testLon + 360.0 : testLon
+        }
+
         var j = coordinatesCount - 1
         for i in 0 ..< coordinatesCount {
             defer {
                 j = i
             }
 
-            let xi = snappedCoordinates[i].longitude
+            var xi = snappedCoordinates[i].longitude
             let yi = snappedCoordinates[i].latitude
-            let xj = snappedCoordinates[j].longitude
+            var xj = snappedCoordinates[j].longitude
             let yj = snappedCoordinates[j].latitude
 
-            let onBoundary = (snappedCoordinate.latitude * (xi - xj) + yi * (xj - snappedCoordinate.longitude) + yj * (snappedCoordinate.longitude - xi) == 0.0)
-                && ((xi - snappedCoordinate.longitude) * (xj - snappedCoordinate.longitude) <= 0.0)
+            if crossesAntimeridian {
+                xi = xi < 0 ? xi + 360.0 : xi
+                xj = xj < 0 ? xj + 360.0 : xj
+            }
+
+            let onBoundary = (snappedCoordinate.latitude * (xi - xj) + yi * (xj - testLon) + yj * (testLon - xi) == 0.0)
+                && ((xi - testLon) * (xj - testLon) <= 0.0)
                 && ((yi - snappedCoordinate.latitude) * (yj - snappedCoordinate.latitude) <= 0.0)
             if onBoundary {
                 return !ignoringBoundary
             }
 
             let intersect = ((yi > snappedCoordinate.latitude) != (yj > snappedCoordinate.latitude))
-                && (snappedCoordinate.longitude < (xj - xi) * (snappedCoordinate.latitude - yi) / (yj - yi) + xi)
+                && (testLon < (xj - xi) * (snappedCoordinate.latitude - yi) / (yj - yi) + xi)
             if (intersect) {
                 isInside = !isInside
             }
@@ -93,8 +122,29 @@ extension Polygon {
         let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
         let snappedCoordinate = gridSize.map { coordinate.snappedToGrid(tolerance: $0) } ?? coordinate
 
-        if let boundingBox = snappedSelf.boundingBox, !boundingBox.contains(snappedCoordinate) {
-            return false
+        if let boundingBox = snappedSelf.boundingBox,
+           !boundingBox.contains(snappedCoordinate)
+        {
+            // Bounding box doesn't contain the point. If the polygon crosses the
+            // antimeridian, the point may still be inside the wrapped side.
+            if let outerRing = snappedSelf.outerRing,
+               projection == .epsg4326
+            {
+                let coords = outerRing.coordinates
+                var crossesAM = false
+                for i in 1..<coords.count {
+                    let dLon = coords[i].longitude - coords[i-1].longitude
+                    if abs(dLon) > 180.0, abs(dLon) < 360.0 {
+                        crossesAM = true
+                        break
+                    }
+                }
+                if !crossesAM {
+                    return false
+                }
+            } else {
+                return false
+            }
         }
 
         guard let outerRing = snappedSelf.outerRing,

--- a/Tests/GISToolsTests/Algorithms/BooleanCoversTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BooleanCoversTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+struct BooleanCoversTests {
+
+    // Validates that a polygon covers a point inside it.
+    @Test
+    func polygonCoversInteriorPoint() async throws {
+        let polygon = try #require(Polygon([[Coordinate3D(latitude: 0.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 0.0)]]))
+        let point = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        #expect(polygon.covers(point))
+        #expect(polygon.contains(point))
+    }
+
+    // Validates that a polygon covers a point on its boundary.
+    @Test
+    func polygonCoversBoundaryPoint() async throws {
+        let polygon = try #require(Polygon([[Coordinate3D(latitude: 0.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 0.0)]]))
+        let pointOnEdge = Point(Coordinate3D(latitude: 0.0, longitude: 5.0))
+        #expect(polygon.covers(pointOnEdge))
+    }
+
+    // Validates that a polygon does not cover a point outside it.
+    @Test
+    func polygonDoesNotCoverExteriorPoint() async throws {
+        let polygon = try #require(Polygon([[Coordinate3D(latitude: 0.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 0.0)]]))
+        let point = Point(Coordinate3D(latitude: 15.0, longitude: 15.0))
+        #expect(polygon.covers(point) == false)
+    }
+
+    // Validates that a polygon covers a line string on its boundary.
+    @Test
+    func polygonCoversLineOnBoundary() async throws {
+        let polygon = try #require(Polygon([[Coordinate3D(latitude: 0.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 0.0)]]))
+        let line = try #require(LineString([Coordinate3D(latitude: 0.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 10.0)]))
+        #expect(polygon.covers(line))
+    }
+
+    // Validates that a polygon covers an identical polygon.
+    @Test
+    func polygonCoversIdentical() async throws {
+        let polygon = try #require(Polygon([[Coordinate3D(latitude: 0.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 0.0)]]))
+        #expect(polygon.covers(polygon))
+    }
+
+    // Validates coveredBy is the inverse of covers.
+    @Test
+    func coveredByInverse() async throws {
+        let outer = try #require(Polygon([[Coordinate3D(latitude: 0.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 10.0), Coordinate3D(latitude: 10.0, longitude: 0.0), Coordinate3D(latitude: 0.0, longitude: 0.0)]]))
+        let inner = try #require(Polygon([[Coordinate3D(latitude: 2.0, longitude: 2.0), Coordinate3D(latitude: 2.0, longitude: 8.0), Coordinate3D(latitude: 8.0, longitude: 8.0), Coordinate3D(latitude: 8.0, longitude: 2.0), Coordinate3D(latitude: 2.0, longitude: 2.0)]]))
+        #expect(outer.covers(inner))
+        #expect(inner.coveredBy(outer))
+    }
+
+    // Validates point covers identical point.
+    @Test
+    func pointCoversPoint() async throws {
+        let point1 = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        let point2 = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        #expect(point1.covers(point2))
+        #expect(point2.coveredBy(point1))
+    }
+
+    // Validates point does not cover a different point.
+    @Test
+    func pointDoesNotCoverDifferentPoint() async throws {
+        let point1 = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        let point2 = Point(Coordinate3D(latitude: 6.0, longitude: 5.0))
+        #expect(point1.covers(point2) == false)
+    }
+
+    // Validates covers near the antimeridian (east side of the dateline).
+    @Test
+    func antimeridianNear() async throws {
+        let polygon = try #require(Polygon([[Coordinate3D(latitude: 0.0, longitude: 170.0), Coordinate3D(latitude: 0.0, longitude: 178.0), Coordinate3D(latitude: 10.0, longitude: 178.0), Coordinate3D(latitude: 10.0, longitude: 170.0), Coordinate3D(latitude: 0.0, longitude: 170.0)]]))
+        let pointInside = Point(Coordinate3D(latitude: 5.0, longitude: 175.0))
+        let pointOutside = Point(Coordinate3D(latitude: 5.0, longitude: -175.0))
+        #expect(polygon.covers(pointInside))
+        #expect(polygon.covers(pointOutside) == false)
+    }
+
+    // Validates that a polygon crossing the antimeridian covers a point on the opposite side.
+    @Test
+    func antimeridianCrossingPolygonCoversPoint() async throws {
+        let polygon = try #require(Polygon([[Coordinate3D(latitude: 0.0, longitude: 170.0), Coordinate3D(latitude: 0.0, longitude: -170.0), Coordinate3D(latitude: 10.0, longitude: -170.0), Coordinate3D(latitude: 10.0, longitude: 170.0), Coordinate3D(latitude: 0.0, longitude: 170.0)]]))
+        let pointInside = Point(Coordinate3D(latitude: 5.0, longitude: 175.0))
+        let pointOutside = Point(Coordinate3D(latitude: 5.0, longitude: 0.0))
+        #expect(polygon.covers(pointInside))
+        #expect(polygon.covers(pointOutside) == false)
+    }
+
+    // Validates coveredBy across the antimeridian.
+    @Test
+    func antimeridianCrossingCoveredBy() async throws {
+        let outer = try #require(Polygon([[Coordinate3D(latitude: -10.0, longitude: 170.0), Coordinate3D(latitude: -10.0, longitude: -170.0), Coordinate3D(latitude: 20.0, longitude: -170.0), Coordinate3D(latitude: 20.0, longitude: 170.0), Coordinate3D(latitude: -10.0, longitude: 170.0)]]))
+        let inner = try #require(Polygon([[Coordinate3D(latitude: 0.0, longitude: 175.0), Coordinate3D(latitude: 0.0, longitude: -175.0), Coordinate3D(latitude: 10.0, longitude: -175.0), Coordinate3D(latitude: 10.0, longitude: 175.0), Coordinate3D(latitude: 0.0, longitude: 175.0)]]))
+        #expect(outer.covers(inner))
+        #expect(inner.coveredBy(outer))
+    }
+
+    // Validates line covers a point on the line.
+    @Test
+    func lineCoversPointOnLine() async throws {
+        let line = try #require(LineString([Coordinate3D(latitude: 0.0, longitude: 0.0), Coordinate3D(latitude: 10.0, longitude: 10.0)]))
+        let point = Point(Coordinate3D(latitude: 5.0, longitude: 5.0))
+        #expect(line.covers(point))
+    }
+
+}


### PR DESCRIPTION
Adds `covers` and `coveredBy` spatial predicates (GEOS-style).

### API
- `geometry.covers(other)` — returns true if no point of the other geometry lies in the exterior of self (includes boundary points)
- `geometry.coveredBy(other)` — inverse of covers

### Bug fix: Ring.contains antimeridian handling
The `Ring.contains` (and `Polygon.contains`) ray-casting algorithm now correctly handles polygons that cross the antimeridian (date line):

1. **Detection**: checks if any edge jumps >180° in longitude (EPSG:4326 only). Excludes Δlon=360° (world polygon spanning full globe).

2. **Ray-casting fix**: shifts negative longitudes to [0, 360) for both ring vertices and the test point, so the ray crossing test uses the correct geographic wrapping direction.

3. **Bounding box fast-path fix**: `Polygon.contains` now skips the bounding box rejection for antimeridian-crossing polygons, since the bbox doesn't capture the wrapping.

### Tests (12)
- Polygon covers interior point, boundary point, exterior point
- Polygon covers line on boundary, identical polygon
- Line covers point on line
- Point covers/not covers another point
- CoveredBy as inverse of covers
- 3 antimeridian-crossing: polygon covers point, polygon coveredBy, polygon near AM

Closes #165.