### PR TITLE
Add hausdorffDistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | grid-rectangle              | `bbox.rectangleGrid(cellWidth: 1000.0, cellHeight: 500.0)`                                                                            |     | [Source][173] / [Tests][174] |
 | grid-square                 | `bbox.squareGrid(cellSide: 1000.0)`                                                                                                   |     | [Source][169] / [Tests][170] |
 | grid-triangle               | `bbox.triangleGrid(cellSide: 1000.0)`                                                                                                 |     | [Source][171] / [Tests][172] |
+| hausdorffDistance           | `let dist = a.hausdorffDistance(from: b)`                                                                                             |     | [Source][239] / [Tests][240] |
 | intersect                   | `let overlap = polygon.intersection(with: other)`                                                                                     |     | [Source][225] / [Tests][226] |
 | isolines                    | `let result = grid.isolines(breaks: [0, 100, 200])`                                                                   |     | [Source][219] / [Tests][220] |
 | kinks                       | `let intersections = anyGeometry.kinks()`                                                                                              |     | [Source][150] / [Tests][151] |
@@ -1302,6 +1303,8 @@ Thomas Rasch, Outdooractive
 [236]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/SharedPathsTests.swift "SharedPathsTests"
 [237]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/LineMerge.swift "LineMerge"
 [238]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/LineMergeTests.swift "LineMergeTests"
+[239]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/HausdorffDistance.swift "HausdorffDistance"
+[240]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/HausdorffDistanceTests.swift "HausdorffDistanceTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/HausdorffDistance.swift
+++ b/Sources/GISTools/Algorithms/HausdorffDistance.swift
@@ -1,0 +1,91 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+
+/// The distance function used for Hausdorff distance calculations.
+public enum HausdorffDistanceFunction {
+
+    /// Use the euclidean distance.
+    case euclidean
+    /// Use the Haversine formula to account for global curvature.
+    case haversine
+    /// Use a rhumb line.
+    case rhumbLine
+    /// Use a custom distance function.
+    case other((Coordinate3D, Coordinate3D) -> CLLocationDistance)
+
+    /// Calculates the distance between two coordinates using the selected method.
+    ///
+    /// - Parameter first: The first coordinate
+    /// - Parameter second: The second coordinate
+    ///
+    /// - Returns: The distance between the two coordinates.
+    public func distance(
+        between first: Coordinate3D,
+        and second: Coordinate3D
+    ) -> CLLocationDistance {
+        switch self {
+        case .euclidean:
+            sqrt(pow(first.longitude - second.longitude, 2.0) + pow(first.latitude - second.latitude, 2.0))
+        case .haversine:
+            first.distance(from: second)
+        case .rhumbLine:
+            first.rhumbDistance(from: second)
+        case let .other(distanceFunction):
+            distanceFunction(first, second)
+        }
+    }
+
+}
+
+extension GeoJson {
+
+    /// Computes the Hausdorff distance between two geometries.
+    ///
+    /// The Hausdorff distance measures how far two subsets of a metric space
+    /// are from each other. Unlike ``frechetDistance(from:distanceFunction:segmentLength:)``,
+    /// Hausdorff only considers the maximum distance from any point in one set
+    /// to the nearest point in the other set, without accounting for point ordering.
+    ///
+    /// - Parameter other: The other geometry.
+    /// - Parameter distanceFunction: The algorithm to use for distance calculations (default `.haversine`).
+    /// - Returns: The Hausdorff distance between the two geometries.
+    public func hausdorffDistance(
+        from other: GeoJson,
+        distanceFunction: HausdorffDistanceFunction = .haversine
+    ) -> Double {
+        let pointsA = allCoordinates
+        let pointsB = other.allCoordinates
+
+        guard pointsA.isNotEmpty, pointsB.isNotEmpty else { return 0.0 }
+
+        // Hausdorff distance: max(min(distance(a, b))) for both directions.
+        func directedHausdorff(
+            from a: [Coordinate3D],
+            to b: [Coordinate3D]
+        ) -> Double {
+            var maxMinDist = 0.0
+            for coordA in a {
+                var minDist = Double.greatestFiniteMagnitude
+                for coordB in b {
+                    let dist = distanceFunction.distance(between: coordA, and: coordB)
+                    if dist < minDist {
+                        minDist = dist
+                        if minDist == 0.0 { break }
+                    }
+                }
+                if minDist > maxMinDist {
+                    maxMinDist = minDist
+                }
+            }
+            return maxMinDist
+        }
+
+        let dAB = directedHausdorff(from: pointsA, to: pointsB)
+        let dBA = directedHausdorff(from: pointsB, to: pointsA)
+
+        return max(dAB, dBA)
+    }
+
+}

--- a/Tests/GISToolsTests/Algorithms/FrechetDistanceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/FrechetDistanceTests.swift
@@ -118,6 +118,26 @@ struct FrechetDistanceTests {
 
     // MARK: - Antimeridian
 
+    // Validates Frechet distance for lines 1° apart across the dateline.
+    @Test
+    func antimeridianOneDegreeApart() async throws {
+        // Line A: lon 179.5°E (just east of the dateline)
+        let a = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 179.5),
+            Coordinate3D(latitude: 10.0, longitude: 179.5),
+        ]))
+        // Line B: lon 179.5°W (just west of the dateline, 1° away)
+        let b = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: -179.5),
+            Coordinate3D(latitude: 10.0, longitude: -179.5),
+        ]))
+
+        let dist = a.frechetDistance(from: b, distanceFunction: .haversine)
+        // 1° of longitude at the equator ≈ 111 km
+        #expect(dist > 100_000.0)
+        #expect(dist < 120_000.0)
+    }
+
     @Test
     func antimeridian() async throws {
         let line1 = try #require(LineString([

--- a/Tests/GISToolsTests/Algorithms/HausdorffDistanceTests.swift
+++ b/Tests/GISToolsTests/Algorithms/HausdorffDistanceTests.swift
@@ -1,0 +1,167 @@
+import Testing
+import Foundation
+@testable import GISTools
+
+struct HausdorffDistanceTests {
+
+    // Validates that identical geometries have zero Hausdorff distance.
+    @Test
+    func identicalLines() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+
+        let dist = a.hausdorffDistance(from: b)
+        #expect(dist == 0.0)
+    }
+
+    // Validates that a line and its shifted version have the expected distance.
+    @Test
+    func parallelShifted() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 20.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 1.0, longitude: 10.0),
+            Coordinate3D(latitude: 1.0, longitude: 20.0),
+        ])!
+
+        let dist = a.hausdorffDistance(from: b)
+        // Approx 111 km per degree of latitude at the equator
+        #expect(dist > 100_000.0)
+        #expect(dist < 120_000.0)
+    }
+
+    // Validates that far apart geometries have a large Hausdorff distance.
+    @Test
+    func farApart() async throws {
+        let a = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let b = Point(Coordinate3D(latitude: 0.0, longitude: 10.0))
+
+        let dist = a.hausdorffDistance(from: b)
+        // Approx 111 km per degree of longitude at the equator
+        #expect(dist > 1_100_000.0)
+        #expect(dist < 1_200_000.0)
+    }
+
+    // Validates Hausdorff distance for lines 1° apart across the dateline.
+    @Test
+    func antimeridianOneDegreeApart() async throws {
+        // Line A: lon 179.5°E (just east of the dateline)
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 179.5),
+            Coordinate3D(latitude: 10.0, longitude: 179.5),
+        ])!
+        // Line B: lon 179.5°W (just west of the dateline, 1° away)
+        let b = LineString([
+            Coordinate3D(latitude: 0.0, longitude: -179.5),
+            Coordinate3D(latitude: 10.0, longitude: -179.5),
+        ])!
+
+        let dist = a.hausdorffDistance(from: b)
+        // 1° of longitude at the equator ≈ 111 km
+        #expect(dist > 100_000.0)
+        #expect(dist < 120_000.0)
+    }
+
+    // Validates that two identical points have zero distance.
+    @Test
+    func identicalPoints() async throws {
+        let a = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let b = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        #expect(a.hausdorffDistance(from: b) == 0.0)
+    }
+
+    // Validates that the Hausdorff distance works with MultiPoint.
+    @Test
+    func multiPoints() async throws {
+        let a = MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+        ])!
+        let b = MultiPoint([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+        ])!
+
+        let dist = a.hausdorffDistance(from: b)
+        // The farthest point in A from B is (0,10) at ~5° from (0,5) ≈ 555 km
+        #expect(dist > 500_000.0)
+        #expect(dist < 600_000.0)
+    }
+
+    // Validates Euclidean distance mode.
+    @Test
+    func euclideanDistance() async throws {
+        let a = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let b = Point(Coordinate3D(latitude: 3.0, longitude: 4.0))
+
+        let dist = a.hausdorffDistance(from: b, distanceFunction: .euclidean)
+        #expect(abs(dist - 5.0) < 0.001)
+    }
+
+    // Validates that empty geometries return zero.
+    @Test
+    func emptyGeometries() async throws {
+        let a = Point(Coordinate3D(latitude: 0.0, longitude: 0.0))
+        let b = FeatureCollection()
+        #expect(a.hausdorffDistance(from: b) == 0.0)
+    }
+
+    // Validates Hausdorff distance across the antimeridian.
+    @Test
+    func antimeridianLineStrings() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 1.0, longitude: 170.0),
+            Coordinate3D(latitude: 1.0, longitude: -170.0),
+        ])!
+
+        let dist = a.hausdorffDistance(from: b)
+        // 1° of latitude ≈ 111 km
+        #expect(dist > 100_000.0)
+        #expect(dist < 120_000.0)
+    }
+
+    // Validates Hausdorff distance with points on both sides of the antimeridian.
+    @Test
+    func antimeridianPoints() async throws {
+        let a = Point(Coordinate3D(latitude: 0.0, longitude: 175.0))
+        let b = Point(Coordinate3D(latitude: 0.0, longitude: -175.0))
+
+        let dist = a.hausdorffDistance(from: b)
+        // 10° of longitude at the equator ≈ 1113 km, but going the short way across
+        // the dateline (175° to -175° = 10° of actual separation)
+        #expect(dist > 1_000_000.0)
+        #expect(dist < 1_200_000.0)
+    }
+
+    // Validates that the Hausdorff distance is symmetric.
+    @Test
+    func symmetric() async throws {
+        let a = LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+        ])!
+        let b = LineString([
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 15.0, longitude: 0.0),
+        ])!
+
+        let dAB = a.hausdorffDistance(from: b)
+        let dBA = b.hausdorffDistance(from: a)
+        #expect(abs(dAB - dBA) < 0.001)
+    }
+
+}


### PR DESCRIPTION
Adds `hausdorffDistance(from:distanceFunction:)` on `GeoJson`, computing the Hausdorff distance between two geometries.

### API
- `geoJson.hausdorffDistance(from: other, distanceFunction: .haversine)`
- Supports `.euclidean`, `.haversine`, `.rhumbLine`, and `.other(...)` distance functions
- Returns `Double` in meters (for haversine/rhumb) or coordinate units (for euclidean)
- O(n·m) implementation, works on any `GeoJson` type

### Tests (11)
- Identical lines, parallel shifted, far apart points, identical points, MultiPoint, Euclidean distance, empty geometries, symmetric
- 3 antimeridian tests: lines across dateline, points across dateline, and 1°-apart across dateline
- Also adds a 1°-apart-across-dateline antimeridian test to `FrechetDistance`

Closes #169.