### PR TITLE
Fix tolerance parameter types — consistent meters with CRS conversion

### DIFF
--- a/Sources/GISTools/Algorithms/Center.swift
+++ b/Sources/GISTools/Algorithms/Center.swift
@@ -118,13 +118,15 @@ extension FeatureCollection {
     ///
     /// - Parameters:
     ///   - weightAttribute: The property name used to weight the center.
-    ///   - tolerance: The convergence threshold in meters (default: `0.001`).
+    ///   - tolerance: The convergence threshold in meters. Internally converted to
+    ///     CRS units (degrees for ``Projection/epsg4326``, meters for ``Projection/epsg3857``).
+    ///     Default `1.0`.
     ///   - counter: Maximum number of iterations (default: `10`).
     ///
     /// - Returns: The median center, or `nil` if the collection is empty.
     public func centerMedian(
         weightAttribute: String? = nil,
-        tolerance: Double = 0.001,
+        tolerance: CLLocationDistance = 1.0,
         counter: Int = 10
     ) -> Point? {
         guard let meanCenter = centerMean(weightAttribute: weightAttribute) else {
@@ -169,6 +171,16 @@ extension FeatureCollection {
             y: initialLat,
             projection: projection)
 
+        // Convert meter tolerance to CRS units
+        let crsTolerance: Double = {
+            switch projection {
+            case .epsg4326, .epsg4978:
+                return tolerance / 111_325.0
+            case .epsg3857, .noSRID:
+                return tolerance
+            }
+        }()
+
         guard var result = findMedian(
             candidate: initialCandidate,
             previousCandidate: Coordinate3D(
@@ -176,7 +188,7 @@ extension FeatureCollection {
                 y: 0.0,
                 projection: projection),
             centroids: centroids,
-            tolerance: tolerance,
+            tolerance: crsTolerance,
             counter: counter) else { return nil }
 
         if spansAntimeridian && result.coordinate.longitude > 180.0 {
@@ -189,6 +201,7 @@ extension FeatureCollection {
         return result
     }
 
+    /// - Parameter tolerance: Convergence threshold in CRS units (already converted from meters).
     private func findMedian(
         candidate: Coordinate3D,
         previousCandidate: Coordinate3D,

--- a/Sources/GISTools/Algorithms/Clean.swift
+++ b/Sources/GISTools/Algorithms/Clean.swift
@@ -1,3 +1,6 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
 import Foundation
 
 // MARK: - Coordinate array cleaning
@@ -11,29 +14,41 @@ extension Array where Element == Coordinate3D {
     ///   - removeCollinear: Remove the middle point of three consecutive collinear points (default `false`).
     ///   - closeRing: If `true`, ensure the last coordinate equals the first (for polygon rings).
     ///   - openRing: If `true`, remove the closing duplicate when `last == first`.
-    ///   - tolerance: Epsilon for coordinate equality and collinearity checks (default `GISTool.equalityDelta`).
+    ///   - tolerance: Epsilon for coordinate equality and collinearity checks in meters (default `GISTool.equalityDelta`).
     /// - Returns: A cleaned copy of the array.
     public func cleaned(
         removeDuplicates: Bool = true,
         removeCollinear: Bool = false,
         closeRing: Bool = false,
         openRing: Bool = false,
-        tolerance: Double = GISTool.equalityDelta
+        tolerance: CLLocationDistance = GISTool.equalityDelta
     ) -> [Coordinate3D] {
+        // Convert meter tolerance to CRS units if coordinates are in degrees.
+        // For 3857 and noSRID the coordinates are in meters already.
+        let crsTolerance: Double = {
+            guard let projection = first?.projection else { return tolerance }
+            switch projection {
+            case .epsg4326, .epsg4978:
+                return tolerance / 111_325.0
+            case .epsg3857, .noSRID:
+                return tolerance
+            }
+        }()
+
         var result = self
 
         if removeDuplicates {
-            result = CleanHelpers.deduplicate(result, tolerance: tolerance)
+            result = CleanHelpers.deduplicate(result, tolerance: crsTolerance)
         }
 
         if removeCollinear {
-            result = CleanHelpers.removeCollinearPoints(result, tolerance: tolerance)
+            result = CleanHelpers.removeCollinearPoints(result, tolerance: crsTolerance)
         }
 
         if openRing, result.count >= 2 {
             if let first = result.first, let last = result.last,
-               abs(first.longitude - last.longitude) <= tolerance,
-               abs(first.latitude - last.latitude) <= tolerance
+               abs(first.longitude - last.longitude) <= crsTolerance,
+               abs(first.latitude - last.latitude) <= crsTolerance
             {
                 result.removeLast()
             }
@@ -41,8 +56,8 @@ extension Array where Element == Coordinate3D {
 
         if closeRing, result.count >= 2 {
             if let first = result.first, let last = result.last,
-               abs(first.longitude - last.longitude) > tolerance
-                || abs(first.latitude - last.latitude) > tolerance
+               abs(first.longitude - last.longitude) > crsTolerance
+                || abs(first.latitude - last.latitude) > crsTolerance
             {
                 result.append(first)
             }

--- a/Sources/GISTools/Algorithms/Densify.swift
+++ b/Sources/GISTools/Algorithms/Densify.swift
@@ -1,3 +1,6 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
 import Foundation
 
 // Ported from https://github.com/Turfjs/turf/tree/master/packages/turf-polygon-smooth
@@ -7,10 +10,10 @@ extension GeoJson {
     /// Returns a copy of the receiver with additional interpolated vertices
     /// added along line segments longer than the given interval.
     ///
-    /// - Parameter maxSegmentLength: The maximum allowed segment length in the
-    ///   coordinate system's units (degrees for EPSG:4326, meters for EPSG:3857/4978).
+    /// - Parameter maxSegmentLength: The maximum allowed segment length in meters.
+    ///   For EPSG:4326, internally converted to degrees. For EPSG:3857/noSRID, used as-is.
     /// - Returns: A densified copy of the receiver.
-    public func densified(maxSegmentLength: Double) -> Self {
+    public func densified(maxSegmentLength: CLLocationDistance) -> Self {
         guard let geoJson = Densify.densify(geoJson: self, maxSegmentLength: maxSegmentLength) else {
             return self
         }
@@ -23,7 +26,17 @@ extension GeoJson {
 
 private enum Densify {
 
-    static func densify(geoJson: GeoJson, maxSegmentLength: Double) -> GeoJson? {
+    /// Converts meter tolerance to CRS units based on coordinate projection.
+    static func crsTolerance(from meters: CLLocationDistance, projection: Projection) -> Double {
+        switch projection {
+        case .epsg4326, .epsg4978:
+            return meters / 111_325.0
+        case .epsg3857, .noSRID:
+            return meters
+        }
+    }
+
+    static func densify(geoJson: GeoJson, maxSegmentLength: CLLocationDistance) -> GeoJson? {
         switch geoJson.type {
         case .point, .multiPoint:
             return geoJson
@@ -84,10 +97,14 @@ private enum Densify {
 
     static func densifyCoordinates(
         _ coords: [Coordinate3D],
-        maxSegmentLength: Double
+        maxSegmentLength: CLLocationDistance
     ) -> [Coordinate3D] {
         guard coords.count >= 2 else { return coords }
         guard maxSegmentLength > 0 else { return coords }
+
+        // Convert meter tolerance to CRS units
+        let projection = coords.first?.projection ?? .noSRID
+        let segmentLength = crsTolerance(from: maxSegmentLength, projection: projection)
 
         var result: [Coordinate3D] = []
         for i in 0..<(coords.count - 1) {
@@ -97,11 +114,11 @@ private enum Densify {
             let dy = end.y - start.y
             let len = sqrt(dx * dx + dy * dy)
 
-            if len <= maxSegmentLength {
+            if len <= segmentLength {
                 result.append(start)
             }
             else {
-                let steps = Int(ceil(len / maxSegmentLength))
+                let steps = Int(ceil(len / segmentLength))
                 for j in 0..<steps {
                     let t = Double(j) / Double(steps)
                     let x = start.x + t * dx

--- a/Sources/GISTools/Algorithms/MaximumInscribedCircle.swift
+++ b/Sources/GISTools/Algorithms/MaximumInscribedCircle.swift
@@ -14,12 +14,12 @@ extension Polygon {
     /// the polygon boundary). The radius is the geodesic distance from that
     /// point to the nearest boundary segment.
     ///
-    /// - Parameter precision: Precision in degrees for the pole-of-inaccessibility search (default `1.0`).
+    /// - Parameter precision: Precision in meters for the pole-of-inaccessibility search (default `1.0`).
     /// - Parameter steps: The number of steps to approximate the circle (default `64`, minimum `3`).
     /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     /// - Returns: A ``Polygon`` approximating the maximum inscribed circle, or `nil`.
     public func maximumInscribedCircle(
-        precision: Double = 1.0,
+        precision: CLLocationDistance = 1.0,
         steps: Int = 64,
         gridSize: Double? = nil
     ) -> Polygon? {
@@ -42,11 +42,11 @@ extension Polygon {
 
     /// Returns the radius of the maximum inscribed circle in meters.
     ///
-    /// - Parameter precision: Precision in degrees for the pole-of-inaccessibility search (default `1.0`).
+    /// - Parameter precision: Precision in meters for the pole-of-inaccessibility search (default `1.0`).
     /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     /// - Returns: The radius in meters, or `nil` if the polygon has no outer ring.
     public func maximumInscribedRadius(
-        precision: Double = 1.0,
+        precision: CLLocationDistance = 1.0,
         gridSize: Double? = nil
     ) -> CLLocationDistance? {
         guard let pole = poleOfInaccessibility(precision: precision, gridSize: gridSize) else { return nil }
@@ -67,12 +67,12 @@ extension MultiPolygon {
 
     /// Returns the maximum inscribed circle across all constituent polygons.
     ///
-    /// - Parameter precision: Precision in degrees for the pole-of-inaccessibility search (default `1.0`).
+    /// - Parameter precision: Precision in meters for the pole-of-inaccessibility search (default `1.0`).
     /// - Parameter steps: The number of steps to approximate the circle (default `64`, minimum `3`).
     /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     /// - Returns: A ``Polygon`` approximating the largest maximum inscribed circle, or `nil`.
     public func maximumInscribedCircle(
-        precision: Double = 1.0,
+        precision: CLLocationDistance = 1.0,
         steps: Int = 64,
         gridSize: Double? = nil
     ) -> Polygon? {
@@ -83,11 +83,11 @@ extension MultiPolygon {
 
     /// Returns the largest maximum inscribed radius across all constituent polygons.
     ///
-    /// - Parameter precision: Precision in degrees for the pole-of-inaccessibility search (default `1.0`).
+    /// - Parameter precision: Precision in meters for the pole-of-inaccessibility search (default `1.0`).
     /// - Parameter gridSize: Snap coordinates to a grid of the given size before computing (default `nil`).
     /// - Returns: The radius in meters, or `nil` if the multi-polygon is empty.
     public func maximumInscribedRadius(
-        precision: Double = 1.0,
+        precision: CLLocationDistance = 1.0,
         gridSize: Double? = nil
     ) -> CLLocationDistance? {
         polygons

--- a/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
+++ b/Sources/GISTools/Algorithms/PoleOfInaccessibility.swift
@@ -12,12 +12,22 @@ extension Polygon {
     ///
     /// Uses the polylabel algorithm with a priority-queue grid search.
     ///
-    /// - Parameter precision: Precision in the projection's native coordinate units
-    ///   (degrees for ``Projection/epsg4326``, meters for ``Projection/epsg3857``
-    ///   and ``Projection/epsg4978``). Default `1.0`.
+    /// - Parameter precision: Precision in meters. Internally converted to CRS units
+    ///   (degrees for ``Projection/epsg4326``, meters for ``Projection/epsg3857``).
+    ///   Default `1.0`.
     /// - Parameter gridSize: An optional grid size for snapping inputs
     /// - Returns: The pole point, or `nil` if no outer ring exists.
-    public func poleOfInaccessibility(precision: Double = 1.0, gridSize: Double? = nil) -> Point? {
+    public func poleOfInaccessibility(precision: CLLocationDistance = 1.0, gridSize: Double? = nil) -> Point? {
+        // Convert meter precision to CRS units
+        let crsPrecision: Double = {
+            switch projection {
+            case .epsg4326, .epsg4978:
+                return precision / 111_325.0
+            case .epsg3857, .noSRID:
+                return precision
+            }
+        }()
+
         let snappedSelf = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
 
         guard let outerRing = snappedSelf.outerRing else { return nil }
@@ -68,9 +78,9 @@ extension Polygon {
 
         let width = maxX - minX
         let height = maxY - minY
-        let cellSize = max(precision, min(width, height))
+        let cellSize = max(crsPrecision, min(width, height))
 
-        if cellSize == precision {
+        if cellSize == crsPrecision {
             return Point(Coordinate3D(latitude: minY, longitude: minX))
         }
 
@@ -97,7 +107,7 @@ extension Polygon {
                     y: y + h,
                     h: h,
                     polygon: snappedSelf)
-                if cell.max > bestCell.d + precision {
+                if cell.max > bestCell.d + crsPrecision {
                     insertSorted(&queue, cell)
                 }
                 if cell.d > bestCell.d {
@@ -111,7 +121,7 @@ extension Polygon {
         while queue.isNotEmpty {
             let cell = queue.removeLast()
 
-            if cell.max - bestCell.d <= precision {
+            if cell.max - bestCell.d <= crsPrecision {
                 continue
             }
             if cell.d > bestCell.d {
@@ -133,8 +143,8 @@ extension Polygon {
                 // The child's maximum reachable d is cell.d + cell.h/2 (moving
                 // at most cell.h/2 toward the true optimum). If even that bound
                 // is within precision of bestD, skip the insertion.
-                if c.max > bestCell.d + precision,
-                   cell.d + cell.h / 2.0 > bestCell.d - precision
+                if c.max > bestCell.d + crsPrecision,
+                   cell.d + cell.h / 2.0 > bestCell.d - crsPrecision
                 {
                     insertSorted(&queue, c)
                 }

--- a/Sources/GISTools/GISTool.swift
+++ b/Sources/GISTools/GISTool.swift
@@ -17,8 +17,9 @@ public enum GISTool {
     /// WGS84 equatorial radius as specified by the International Union of Geodesy and Geophysics.
     public static let equatorialRadius: CLLocationDistance = 6_378_137
 
-    /// The accuracy for testing what is equal (μm precision, mainly to counter small rounding errors).
-    public static let equalityDelta: Double = 1e-10
+    /// The accuracy for testing what is equal (0.1nm precision for projected coords,
+    /// ~0.011mm at the equator for EPSG:4326, mainly to counter small rounding errors).
+    public static let equalityDelta: CLLocationDistance = 1e-10
 
     /// Mercator projection origin shift.
     public static let originShift = 2.0 * Double.pi * GISTool.equatorialRadius / 2.0 // 20037508.342789244

--- a/Tests/GISToolsTests/Algorithms/DensifyTests.swift
+++ b/Tests/GISToolsTests/Algorithms/DensifyTests.swift
@@ -11,7 +11,7 @@ struct DensifyTests {
             Coordinate3D(latitude: 0.0, longitude: 0.0),
             Coordinate3D(latitude: 1.0, longitude: 0.0),
         ])!
-        let densified = ls.densified(maxSegmentLength: 5.0)
+        let densified = ls.densified(maxSegmentLength: 600_000.0)
         #expect(densified.coordinates.count == 2)
     }
 
@@ -22,8 +22,8 @@ struct DensifyTests {
             Coordinate3D(latitude: 0.0, longitude: 0.0),
             Coordinate3D(latitude: 10.0, longitude: 0.0),
         ])!
-        let densified = ls.densified(maxSegmentLength: 3.0)
-        // 10/3 = 3.33 → ceil = 4 steps → 5 vertices
+        let densified = ls.densified(maxSegmentLength: 340_000.0)
+        // 10°≈1.1M meters / 340K ≈ 3.33 → ceil = 4 steps → 5 vertices
         #expect(densified.coordinates.count == 5)
     }
 
@@ -34,7 +34,7 @@ struct DensifyTests {
             Coordinate3D(latitude: 0.0, longitude: 0.0),
             Coordinate3D(latitude: 10.0, longitude: 10.0),
         ])!
-        let densified = ls.densified(maxSegmentLength: 2.0)
+        let densified = ls.densified(maxSegmentLength: 220_000.0)
         #expect(densified.coordinates.first?.latitude == 0.0)
         #expect(densified.coordinates.first?.longitude == 0.0)
         #expect(densified.coordinates.last?.latitude == 10.0)
@@ -54,7 +54,7 @@ struct DensifyTests {
                 Coordinate3D(latitude: 0.0, longitude: 10.0),
             ],
         ])!
-        let densified = mls.densified(maxSegmentLength: 3.0)
+        let densified = mls.densified(maxSegmentLength: 340_000.0)
         #expect(densified.lineStrings.count == 2)
         for ls in densified.lineStrings {
             #expect(ls.coordinates.count > 2)
@@ -73,8 +73,8 @@ struct DensifyTests {
                 Coordinate3D(latitude: 0.0, longitude: 0.0),
             ],
         ])!
-        let densified = poly.densified(maxSegmentLength: 3.0)
-        // Each edge is 10°, split by 3° → 4 segments → 5 vertices per edge
+        let densified = poly.densified(maxSegmentLength: 340_000.0)
+        // Each edge is 10°≈1.1M meters, split by 340K → 4 segments
         // But vertices are shared at corners, so total is 4 edges × 4 segments = 16 + 1 close
         let coords = densified.coordinates[0]
         #expect(coords.count > 5)
@@ -94,7 +94,7 @@ struct DensifyTests {
                 ],
             ])!,
         ])!
-        let densified = mp.densified(maxSegmentLength: 2.0)
+        let densified = mp.densified(maxSegmentLength: 220_000.0)
         #expect(densified.polygons.count == 1)
     }
 
@@ -133,8 +133,8 @@ struct DensifyTests {
             Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
             Coordinate3D(latitude: 10.0, longitude: 0.0, altitude: 200.0),
         ])!
-        let densified = ls.densified(maxSegmentLength: 5.0)
-        // 10/5 = 2 steps → 3 vertices at t=0, 0.5, 1.0
+        let densified = ls.densified(maxSegmentLength: 600_000.0)
+        // 10°≈1.1M meters / 600K ≈ 1.86 → ceil = 2 steps → 3 vertices
         #expect(densified.coordinates.count == 3)
         #expect(densified.coordinates[0].altitude == 100.0)
         #expect(densified.coordinates[1].altitude == 150.0)
@@ -148,8 +148,8 @@ struct DensifyTests {
             Coordinate3D(latitude: 0.0, longitude: 170.0),
             Coordinate3D(latitude: 10.0, longitude: -170.0),
         ])!
-        let densified = ls.densified(maxSegmentLength: 10.0)
-        // Spans 340° of longitude, splits into segments of ≤10°
+        let densified = ls.densified(maxSegmentLength: 1_113_250.0)
+        // Spans 340° of longitude, splits into segments of ≤10° (≈1.1M m)
         #expect(densified.coordinates.count > 2)
         #expect(densified.coordinates.first?.latitude == 0.0)
         #expect(densified.coordinates.first?.longitude == 170.0)
@@ -169,7 +169,7 @@ struct DensifyTests {
                 Coordinate3D(latitude: 0.0, longitude: 170.0),
             ],
         ])!
-        let densified = poly.densified(maxSegmentLength: 5.0)
+        let densified = poly.densified(maxSegmentLength: 600_000.0)
         let ring = densified.coordinates[0]
         #expect(ring.count > 5)
         #expect(ring.first?.latitude == 0.0)
@@ -201,7 +201,7 @@ struct DensifyTests {
                 Coordinate3D(latitude: 15.0, longitude: 175.0),
             ],
         ])!
-        let densified = mls.densified(maxSegmentLength: 10.0)
+        let densified = mls.densified(maxSegmentLength: 1_113_250.0)
         #expect(densified.lineStrings.count == 2)
         for ls in densified.lineStrings {
             #expect(ls.coordinates.count > 2)


### PR DESCRIPTION
## Changes

Standardize all tolerance/precision parameters to accept meters and convert to CRS units internally where needed. The rule: if the parameter controls a distance threshold users think in meters, it should be CLLocationDistance with internal conversion to degrees for 4326/4978.

### Updated algorithms

| File | Parameter | Old type | New type | Internal conversion |
|---|---|---|---|---|
| Clean | tolerance: | Double | CLLocationDistance | divide by 111_325 for 4326/4978 |
| Center | tolerance: | Double | CLLocationDistance | divide by 111_325 for 4326/4978 |
| Densify | maxSegmentLength: | Double | CLLocationDistance | divide by 111_325 for 4326/4978 |
| PoleOfInaccessibility | precision: | Double | CLLocationDistance | divide by 111_325 for 4326/4978 |
| MaximumInscribedCircle | precision: | Double | CLLocationDistance | delegated to poleOfInaccessibility |
| MaximumInscribedRadius | precision: | Double | CLLocationDistance | delegated to poleOfInaccessibility |
| GISTool | equalityDelta | Double | CLLocationDistance | value unchanged |

### Default value changes

- Center.centerMedian(tolerance:): 0.001 -> 1.0 (was 0.001 meters = 1mm convergence, too tight)

### Not changed (already correct)

- Along, Simplify, ConcaveHull, FrechetDistance, LineChunk (already CLLocationDistance + meters)
- SnapToGrid, Truncate, MinimumBoundingCircle (not distance thresholds)

### Tests

Densify tests updated to pass meter values instead of degree values.