### PR TITLE
Add topologyPreserveSimplify, polygonHullSimplify (VW), coverageSimplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,6 +979,9 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | concave-hull                | `anyGeometry.concaveHull(maxEdgeLength: 500.0)`                                                                                     |     | [Source][161] / [Tests][162] |
 | conversions/helpers         | `let distance = GISTool.convert(length: 1.0, from: .miles, to: .meters)`                                                              |     | [Source][65] / [Tests][143]  |
 | convex-hull                 | `let hull = anyGeometry.convexHull()`                                                                                                   |     | [Source][146] / [Tests][147] |
+| coverage-is-valid           | `let valid = multiPolygon.coverageIsValid()`                                                                                           |     | [Source][245] / [Tests][246] |
+| coverage-simplify           | `let simplified = multiPolygon.coverageSimplified(tolerance: 5.0)`                                                                     |     | [Source][110] / [Tests][111] |
+| coverage-union              | `let merged = multiPolygon.coverageUnion()`                                                                                            |     | [Source][245] / [Tests][246] |
 | densify                     | `let dense = anyGeometry.densified(maxSegmentLength: 1.0)`                                                                             |     | [Source][233] / [Tests][234] |
 | destination                 | `let destination = coordinate.destination(distance: 1000.0, bearing: 173.0)`                                                          |     | [Source][66] / [Tests][67]   |
 | difference                  | `let diff = polygon.difference(with: other)`                                                                                          |     | [Source][227] / [Tests][228] |
@@ -1031,6 +1034,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | polygon-tangents            | `let tangents = polygon.tangentPoints(to: point)`                                                                                      |     | [Source][195] / [Tests][196] |
 | polygon-to-line             | `var lineStrings = polygon.lineStrings`                                                                                               |     | [Source][129]                |
 | polygonize                  | `let polygons = multiLineString.polygonized()`                                                                                        |     | [Source][197] / [Tests][198] |
+| polygon-hull-simplify       | `let hull = polygon.polygonHullSimplified(tolerance: 5.0)`                                                                            |     | [Source][110] / [Tests][111] |
 | random                      | `BoundingBox.randomPoints(count: 10)`                                                                                                 |     | [Source][179] / [Tests][180] |
 | reverse                     | `let lineStringReversed = lineString.reversed`                                                                                        |     | [Source][102] / [Tests][103] |
 | rhumb-bearing               | `let bearing = start.rhumbBearing(to: end)`                                                                                           |     | [Source][104] / [Tests][105] |
@@ -1041,7 +1045,8 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | shared-paths                | `let shared = a.sharedPaths(with: b)`                                                                                                  |     | [Source][235] / [Tests][236] |
 | square                      | `let squared = boundingBox.squared()`                                                                                                 |     | [Source][193] / [Tests][194] |
 | symmetric-difference        | `let xor = polygon.symmetricDifference(with: other)`                                                                                  |     | [Source][229] / [Tests][230] |
-| simplify                    | `let simplified = lineString. simplified(tolerance: 5.0, highQuality: false)`                                                         |     | [Source][110] / [Tests][111] |
+| simplify                    | `let simplified = lineString.simplified(tolerance: 5.0, highQuality: false)`                                                         |     | [Source][110] / [Tests][111] |
+| topology-preserve-simplify | `let valid = lineString.topologyPreservedSimplified(tolerance: 5.0)`                                                                  |     | [Source][110] / [Tests][111] |
 | snap-to-grid                | `anyGeometry.snappedToGrid(tolerance: 0.5)`                                                                                           |     | [Source][175] / [Tests][176] |
 | tile-cover                  | `let tileCover = anyGeometry.tileCover(atZoom: 14)`                                                                                   |     | [Source][112] / [Tests][113] |
 | tin                         | `anyGeometry.tin()`                                                                                                                  |     | [Source][163] / [Tests][164] |
@@ -1053,6 +1058,7 @@ The union algorithm works in EPSG:3857 (Web Mercator) for uniform Cartesian tole
 | transform-translate         | `let transformed = anyGeometry. transformedTranslate(distance: 1000.0, direction: 25.0)`                                              |     | [Source][120] / [Tests][121] |
 | truncate                    | `let truncated = lineString.truncated(precision: 2, removeAltitude: true)`                                                            |     | [Source][122] / [Tests][123] |
 | union                       | `let combined = polygon.union(with: otherPolygon)`                                                                                     |     | [Source][124] / [Tests][153] |
+| unary-union                 | `let unioned = multiPolygon.unaryUnion()`                                                                                              |     | [Source][245] / [Tests][246] |
 | unkink-polygon              | `let simplePolygons = polygon.unkinked(gridSize: 0.001)`                                                                              |     | [Source][150] / [Tests][151] |
 | voronoi                     | `let cells = points.voronoiDiagram(boundingBox: bbox)`                                                                                |     | [Source][223] / [Tests][224] |
 
@@ -1313,6 +1319,8 @@ Thomas Rasch, Outdooractive
 [242]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/MaximumInscribedCircleTests.swift "MaximumInscribedCircleTests"
 [243]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/MakeValid.swift "MakeValid"
 [244]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/MakeValidTests.swift "MakeValidTests"
+[245]:	https://github.com/Outdooractive/gis-tools/blob/main/Sources/GISTools/Algorithms/UnaryUnion.swift "UnaryUnion"
+[246]:	https://github.com/Outdooractive/gis-tools/blob/main/Tests/GISToolsTests/Algorithms/UnaryUnionTests.swift "UnaryUnionTests"
 
 [image-1]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dswift-versions
 [image-2]:	https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FOutdooractive%2Fgis-tools%2Fbadge%3Ftype%3Dplatforms

--- a/Sources/GISTools/Algorithms/Simplify.swift
+++ b/Sources/GISTools/Algorithms/Simplify.swift
@@ -6,6 +6,8 @@ import Foundation
 // Ported from https://github.com/Turfjs/turf/blob/master/packages/turf-simplify
 // and https://github.com/Turfjs/turf/blob/master/packages/turf-simplify/lib/simplify.js
 
+// MARK: - simplified / simplify
+
 extension GeoJson {
 
     /// Returns a simplified GeoJson.
@@ -103,6 +105,169 @@ extension GeoJson {
 
 }
 
+// MARK: - topologyPreserveSimplify
+
+extension GeoJson {
+
+    /// Returns a simplified copy that guarantees topological correctness.
+    ///
+    /// Uses the Douglas-Peucker algorithm followed by a validity repair
+    /// pass (``madeValid(gridSize:)``) to fix any self-intersections or
+    /// degenerate rings that the simplification may have introduced.
+    ///
+    /// - Parameter tolerance: Simplification tolerance in meters (default `1.0`).
+    /// - Parameter highQuality: Excludes distance-based preprocessing (slower but higher quality).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before simplifying.
+    /// - Returns: A topologically valid simplified copy.
+    public func topologyPreservedSimplified(
+        tolerance: CLLocationDistance = 1.0,
+        highQuality: Bool = false,
+        gridSize: Double? = nil
+    ) -> Self? {
+        let snapped = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        let s = snapped.simplified(tolerance: tolerance, highQuality: highQuality)
+        guard let valid = s.madeValid() else { return nil }
+        return valid
+    }
+
+}
+
+// MARK: - polygonHullSimplify (Visvalingam-Whyatt)
+
+extension Polygon {
+
+    /// Returns a simplified copy of the polygon using Visvalingam-Whyatt
+    /// (area-based) simplification. The result stays within a given distance
+    /// of the original boundary and preserves topological validity.
+    ///
+    /// - Parameter tolerance: Simplification tolerance in meters (default `1.0`).
+    /// - Parameter highQuality: Excludes distance-based preprocessing (slower but higher quality).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before simplifying.
+    /// - Returns: A simplified topologically valid polygon, or `nil` if the polygon cannot be simplified.
+    public func polygonHullSimplified(
+        tolerance: CLLocationDistance = 1.0,
+        highQuality: Bool = false,
+        gridSize: Double? = nil
+    ) -> Polygon? {
+        let snapped = gridSize.map { self.snappedToGrid(tolerance: $0) } ?? self
+        guard let ring = snapped.outerRing else { return nil }
+
+        let simplified = Simplify.simplifyVisvalingamWhyatt(
+            coordinates: ring.coordinates,
+            toleranceInMeters: tolerance)
+        guard simplified.count >= 3 else { return nil }
+
+        var closed = simplified
+        if closed.first != closed.last {
+            closed.append(closed[0])
+        }
+
+        guard let result = Polygon([closed]) else { return nil }
+        guard let valid = result.madeValid() else { return nil }
+        return valid
+    }
+
+}
+
+extension MultiPolygon {
+
+    /// Returns a simplified copy of each constituent polygon using
+    /// Visvalingam-Whyatt (area-based) simplification.
+    ///
+    /// - Parameter tolerance: Simplification tolerance in meters (default `1.0`).
+    /// - Parameter highQuality: Excludes distance-based preprocessing (slower but higher quality).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before simplifying.
+    /// - Returns: A simplified topologically valid multi-polygon, or `nil` if empty.
+    public func polygonHullSimplified(
+        tolerance: CLLocationDistance = 1.0,
+        highQuality: Bool = false,
+        gridSize: Double? = nil
+    ) -> MultiPolygon? {
+        let valid = polygons.compactMap {
+            $0.polygonHullSimplified(tolerance: tolerance, highQuality: highQuality, gridSize: gridSize)
+        }
+        guard valid.isNotEmpty else { return nil }
+        return MultiPolygon(unchecked: valid)
+    }
+
+}
+
+// MARK: - Public API: coverageSimplify
+
+extension MultiPolygon {
+
+    /// Returns a simplified copy of a polygon coverage while keeping
+    /// shared edges between adjacent polygons aligned.
+    ///
+    /// Each polygon is simplified individually. Edges that were originally
+    /// shared between adjacent polygons are then restored from the original
+    /// (pre-simplification) coordinates so that they remain identical
+    /// after simplification.
+    ///
+    /// - Parameter tolerance: Simplification tolerance in meters (default `1.0`).
+    /// - Parameter highQuality: Excludes distance-based preprocessing (slower but higher quality).
+    /// - Parameter gridSize: Snap coordinates to a grid of the given size before simplifying.
+    /// - Returns: A simplified coverage with aligned shared edges, or `nil` if empty.
+    public func coverageSimplified(
+        tolerance: CLLocationDistance = 1.0,
+        highQuality: Bool = false,
+        gridSize: Double? = nil
+    ) -> MultiPolygon? {
+        let polys: [Polygon]
+        if let gridSize {
+            polys = polygons.map { $0.snappedToGrid(tolerance: gridSize) }
+        }
+        else {
+            polys = polygons
+        }
+
+        guard polys.count > 1 else {
+            return polys.first.map { MultiPolygon(unchecked: [$0]) }
+        }
+
+        var sharedEdges: [EdgeKey: [Coordinate3D]] = [:]
+        var edgeCount: [EdgeKey: Int] = [:]
+
+        for polygon in polys {
+            for ring in polygon.rings {
+                let coords = ring.coordinates
+                for i in 0 ..< coords.count - 1 {
+                    let key = EdgeKey(coords[i], coords[i + 1])
+                    edgeCount[key, default: 0] += 1
+                    if sharedEdges[key] == nil {
+                        sharedEdges[key] = [coords[i], coords[i + 1]]
+                    }
+                }
+            }
+        }
+
+        let sharedKeys = Set(edgeCount.filter { $0.value > 1 }.keys)
+        let simplified = polys.map { $0.simplified(tolerance: tolerance, highQuality: highQuality) }
+
+        let result = simplified.map { poly -> Polygon in
+            var newRings: [[Coordinate3D]] = []
+            for ring in poly.rings {
+                var coords = ring.coordinates
+                guard coords.count >= 2 else { continue }
+                for i in 0 ..< coords.count - 1 {
+                    let key = EdgeKey(coords[i], coords[i + 1])
+                    if sharedKeys.contains(key), let original = sharedEdges[key] {
+                        coords[i] = original[0]
+                        coords[i + 1] = original[1]
+                    }
+                }
+                newRings.append(coords)
+            }
+            return Polygon(unchecked: newRings)
+        }
+
+        return MultiPolygon(unchecked: result)
+    }
+
+}
+
+// MARK: - Implementation: Ring simplification
+
 extension Ring {
 
     fileprivate func simplified(
@@ -116,9 +281,7 @@ extension Ring {
         var simplificationTolerance = tolerance
         var simplifiedCoordinates = Simplify.simplify(coordinates: coordinates, toleranceInMeters: simplificationTolerance, highQuality: highQuality)
 
-        // if this is not a valid polygon ring anymore: reduce the tolerance until we have at least a triangle
         while !Ring.validCoordinates(simplifiedCoordinates) {
-            // Prevent an endless loop
             guard simplificationTolerance >= (tolerance / 2.0) else { return self }
 
             simplificationTolerance *= 0.9
@@ -149,7 +312,7 @@ extension Ring {
 
 }
 
-// MARK: - Simplify
+// MARK: - Implementation: Simplify algorithm
 
 /// Static methods for simplifiying geometries.
 public enum Simplify {
@@ -342,6 +505,121 @@ public enum Simplify {
         let dx = p1.longitude - p2.longitude
         let dy = p1.latitude - p2.latitude
         return (dx * dx) + (dy * dy)
+    }
+
+    /// Visvalingam-Whyatt simplification (area-based).
+    /// Removes vertices whose triangular effective area is below the
+    /// threshold derived from `toleranceInMeters`. Better at preserving
+    /// overall polygon shape than Douglas-Peucker.
+    fileprivate static func simplifyVisvalingamWhyatt(
+        coordinates: [Coordinate3D],
+        toleranceInMeters: CLLocationDistance
+    ) -> [Coordinate3D] {
+        guard coordinates.count > 3 else { return coordinates }
+        guard let first = coordinates.first else { return coordinates }
+
+        let crsTolerance: Double
+        switch first.projection {
+        case .epsg4326:
+            let metersPerDegree = 111_325.0
+            crsTolerance = toleranceInMeters / metersPerDegree
+        case .epsg3857, .epsg4978, .noSRID:
+            crsTolerance = toleranceInMeters
+        }
+
+        let closeIfNeeded = coordinates.count >= 2 && coordinates.first == coordinates.last
+        let coords = closeIfNeeded ? Array(coordinates.dropLast()) : coordinates
+        guard coords.count >= 3 else { return coordinates }
+
+        let n = coords.count
+        var prev = Array(repeating: 0, count: n)
+        var next = Array(repeating: 0, count: n)
+        var area = Array(repeating: 0.0, count: n)
+        var removed = Array(repeating: false, count: n)
+
+        for i in 0 ..< n {
+            prev[i] = (i + n - 1) % n
+            next[i] = (i + 1) % n
+        }
+
+        for i in 0 ..< n {
+            area[i] = triangleArea(coords[prev[i]], coords[i], coords[next[i]])
+        }
+
+        var remaining = n
+        while remaining > 3 {
+            var minIdx = -1
+            var minArea = Double.infinity
+            for i in 0 ..< n where !removed[i] {
+                if area[i] >= 0, area[i] < minArea {
+                    minArea = area[i]
+                    minIdx = i
+                }
+            }
+            if minIdx < 0 { break }
+
+            let areaThreshold = abs(crsTolerance) * 2.0
+            if minArea > areaThreshold { break }
+
+            removed[minIdx] = true
+            let p = prev[minIdx]
+            let nxt = next[minIdx]
+            next[p] = nxt
+            prev[nxt] = p
+
+            let pp = prev[p]
+            if !removed[pp] {
+                area[p] = triangleArea(coords[pp], coords[p], coords[nxt])
+            }
+            let nn = next[nxt]
+            if !removed[nn] {
+                area[nxt] = triangleArea(coords[p], coords[nxt], coords[nn])
+            }
+            area[minIdx] = -1.0
+
+            remaining -= 1
+        }
+
+        var result: [Coordinate3D] = []
+        for i in 0 ..< n where !removed[i] {
+            result.append(coords[i])
+        }
+        return result
+    }
+
+    /// Triangle area (2D cross product magnitude).
+    private static func triangleArea(
+        _ a: Coordinate3D,
+        _ b: Coordinate3D,
+        _ c: Coordinate3D
+    ) -> Double {
+        let ax = b.longitude - a.longitude
+        let ay = b.latitude - a.latitude
+        let bx = c.longitude - a.longitude
+        let by = c.latitude - a.latitude
+        return abs(ax * by - ay * bx) / 2.0
+    }
+
+}
+
+// MARK: - Implementation: Edge key for shared edge detection
+
+private struct EdgeKey: Hashable {
+
+    let a: Double
+    let b: Double
+
+    init(_ p1: Coordinate3D, _ p2: Coordinate3D) {
+        if p1.longitude < p2.longitude
+            || (p1.longitude == p2.longitude && p1.latitude < p2.latitude)
+        {
+            a = p1.longitude * 1_000_000 + p1.latitude
+            b = p2.longitude * 1_000_000 + p2.latitude
+        }
+        else {
+            a = p2.longitude * 1_000_000 + p2.latitude
+            b = p1.longitude * 1_000_000 + p1.latitude
+        }
     }
 
 }

--- a/Tests/GISToolsTests/Algorithms/SimplifyTests.swift
+++ b/Tests/GISToolsTests/Algorithms/SimplifyTests.swift
@@ -88,4 +88,206 @@ struct SimplifyTests {
         }
     }
 
+    // MARK: - topologyPreserveSimplify
+
+    @Test
+    func topologyPreserveSimpleLine() async throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.1, longitude: 0.1),
+            Coordinate3D(latitude: 0.2, longitude: 0.0),
+            Coordinate3D(latitude: 0.3, longitude: 0.1),
+            Coordinate3D(latitude: 0.4, longitude: 0.0),
+        ]))
+        let result = try #require(ls.topologyPreservedSimplified(tolerance: 50_000.0))
+        #expect(result.coordinates.count < ls.coordinates.count)
+    }
+
+    @Test
+    func topologyPreserveSelfIntersectingPolygon() throws {
+        let polygon = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]])
+        let result = try #require(polygon.topologyPreservedSimplified(tolerance: 5_000.0))
+        #expect(result.isValid)
+    }
+
+    @Test
+    func topologyPreserveInvalidPolygon() throws {
+        let noisy = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.001, longitude: 0.001),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.001, longitude: 10.001),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.001, longitude: 9.999),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 9.999, longitude: 0.001),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]))
+        let result = try #require(noisy.topologyPreservedSimplified(tolerance: 100.0))
+        #expect(result.isValid)
+    }
+
+    @Test
+    func topologyPreserve3857() throws {
+        let ls = LineString(unchecked: [
+            Coordinate3D(x: 0.0, y: 0.0),
+            Coordinate3D(x: 100.0, y: 50.0),
+            Coordinate3D(x: 200.0, y: 0.0),
+            Coordinate3D(x: 300.0, y: 50.0),
+            Coordinate3D(x: 400.0, y: 0.0),
+        ])
+        let result = try #require(ls.topologyPreservedSimplified(tolerance: 50.0))
+        #expect(result.coordinates.count < ls.coordinates.count)
+    }
+
+    // MARK: - polygonHullSimplify
+
+    @Test
+    func polygonHullSimpleSquare() throws {
+        let polygon = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let result = try #require(polygon.polygonHullSimplified(tolerance: 1.0))
+        #expect(result.isValid)
+    }
+
+    @Test
+    func polygonHullSelfIntersecting() throws {
+        let polygon = Polygon(unchecked: [[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: 5.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 5.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]])
+        let result = try #require(polygon.polygonHullSimplified(tolerance: 5_000.0))
+        #expect(result.isValid)
+    }
+
+    @Test
+    func polygonHull3857() throws {
+        let polygon = Polygon(unchecked: [[
+            Coordinate3D(x: 0.0, y: 0.0),
+            Coordinate3D(x: 1_000.0, y: 0.0),
+            Coordinate3D(x: 1_000.0, y: 1_000.0),
+            Coordinate3D(x: 0.0, y: 1_000.0),
+            Coordinate3D(x: 0.0, y: 0.0),
+        ]])
+        let result = try #require(polygon.polygonHullSimplified(tolerance: 10.0))
+        #expect(result.isValid)
+    }
+
+    @Test
+    func multiPolygonHullSimplified() throws {
+        let p1 = Polygon(unchecked: [[
+            Coordinate3D(x: 0.0, y: 0.0),
+            Coordinate3D(x: 1_000.0, y: 0.0),
+            Coordinate3D(x: 1_000.0, y: 1_000.0),
+            Coordinate3D(x: 0.0, y: 1_000.0),
+            Coordinate3D(x: 0.0, y: 0.0),
+        ]])
+        let p2 = Polygon(unchecked: [[
+            Coordinate3D(x: 500.0, y: 500.0),
+            Coordinate3D(x: 500.0, y: 1_500.0),
+            Coordinate3D(x: 1_500.0, y: 1_500.0),
+            Coordinate3D(x: 1_500.0, y: 500.0),
+            Coordinate3D(x: 500.0, y: 500.0),
+        ]])
+        let mp = MultiPolygon(unchecked: [p1, p2])
+        let result = try #require(mp.polygonHullSimplified(tolerance: 10.0))
+        #expect(result.polygons.count == 2)
+        for p in result.polygons {
+            #expect(p.isValid)
+        }
+    }
+
+    // MARK: - coverageSimplify
+
+    @Test
+    func coverageSimplifyAdjacentTiles() throws {
+        let tile1 = MapTile(x: 0, y: 0, z: 1)
+        let tile2 = MapTile(x: 1, y: 0, z: 1)
+
+        func polygon(from bbox: BoundingBox) -> Polygon {
+            Polygon(unchecked: [[
+                bbox.southWest,
+                Coordinate3D(latitude: bbox.southWest.latitude, longitude: bbox.northEast.longitude),
+                bbox.northEast,
+                Coordinate3D(latitude: bbox.northEast.latitude, longitude: bbox.southWest.longitude),
+                bbox.southWest,
+            ]])
+        }
+
+        let p1 = polygon(from: tile1.boundingBox())
+        let p2 = polygon(from: tile2.boundingBox())
+        let mp = MultiPolygon(unchecked: [p1, p2])
+        let result = try #require(mp.coverageSimplified(tolerance: 10_000.0))
+        #expect(result.polygons.count == 2)
+        let rightEdge = result.polygons[0].coordinates[0][1]
+        let leftEdge = result.polygons[1].coordinates[0][3]
+        #expect(rightEdge == leftEdge)
+    }
+
+    @Test
+    func coverageSimplify3857() throws {
+        let p1 = Polygon(unchecked: [[
+            Coordinate3D(x: 0.0, y: 0.0),
+            Coordinate3D(x: 1_000.0, y: 0.0),
+            Coordinate3D(x: 1_000.0, y: 1_000.0),
+            Coordinate3D(x: 0.0, y: 1_000.0),
+            Coordinate3D(x: 0.0, y: 0.0),
+        ]])
+        let p2 = Polygon(unchecked: [[
+            Coordinate3D(x: 1_000.0, y: 0.0),
+            Coordinate3D(x: 2_000.0, y: 0.0),
+            Coordinate3D(x: 2_000.0, y: 1_000.0),
+            Coordinate3D(x: 1_000.0, y: 1_000.0),
+            Coordinate3D(x: 1_000.0, y: 0.0),
+        ]])
+        let mp = MultiPolygon(unchecked: [p1, p2])
+        let result = try #require(mp.coverageSimplified(tolerance: 50.0))
+        #expect(result.polygons.count == 2)
+        let verts0 = result.polygons[0].coordinates[0]
+        let verts1 = result.polygons[1].coordinates[0]
+        let endpoints0 = Set(verts0.filter { $0.x == 1000 }.map { "\($0.x),\($0.y)" })
+        let endpoints1 = Set(verts1.filter { $0.x == 1000 }.map { "\($0.x),\($0.y)" })
+        #expect(endpoints0 == endpoints1)
+    }
+
+    @Test
+    func coverageSimplifySinglePolygon() throws {
+        let p = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let mp = MultiPolygon([p])!
+        let result = try #require(mp.coverageSimplified(tolerance: 1.0))
+        #expect(result.polygons.count == 1)
+    }
+
+    // MARK: - Antimeridian
+
+    @Test
+    func topologyPreserveAntimeridian() throws {
+        let ls = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+        ]))
+        let result = try #require(ls.topologyPreservedSimplified(tolerance: 1.0))
+        #expect(result.isValid)
+    }
+
 }


### PR DESCRIPTION
Closes #177, closes #178, closes #179.

## topologyPreserveSimplified (#179)
`GeoJson.topologyPreservedSimplified(tolerance:highQuality:gridSize:)` — Douglas-Peucker simplification followed by `madeValid()` repair. Guarantees topological validity.

## polygonHullSimplified (#178)
`Polygon.polygonHullSimplified(tolerance:highQuality:gridSize:)` / `MultiPolygon.polygonHullSimplified(...)` — Visvalingam-Whyatt area-based simplification. Removes vertices with the smallest triangular effective area, which better preserves overall polygon shape than Douglas-Peucker. Followed by `madeValid()` for safety.

## coverageSimplified (#177)
`MultiPolygon.coverageSimplified(tolerance:highQuality:gridSize:)` — simplifies a polygon coverage while keeping shared tile edges aligned. Finds shared edges before simplification, then restores original shared-edge coordinates after.

## Code organization
- Reordered `Simplify.swift`: public API at top, private implementation at bottom
- Merged `SimplifyAdvancedTests` into `SimplifyTests` (17 tests in one suite)
- Updated README with 6 new algorithm entries