### PR TITLE
Add bevel and miter buffer join types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,27 @@ If a method has ≤3 parameters and no return value, or ≤2 parameters and a re
   ) -> Bool {
   ```
 
+When a function **call** is split across multiple lines, place each argument on its own line:
+
+  ```swift
+  // One line (fits ≤80 chars)
+  let pt = Coordinate3D(x: a.x + d * nx, y: a.y + d * ny, projection: .epsg3857)
+
+  // Multi-line → one argument per line
+  let pt = Coordinate3D(
+      x: a.x + d * nx,
+      y: a.y + d * ny,
+      projection: .epsg3857)
+
+  Self.addMiterJoin(
+      at: prev,
+      curr,
+      next,
+      distance: distance,
+      limit: limit,
+      to: &polygons)
+  ```
+
 ## General instructions
 
 - DO NOT take any shortcuts while implementing an algorithm. Correctness is the highest priority

--- a/Sources/GISTools/Algorithms/Buffer.swift
+++ b/Sources/GISTools/Algorithms/Buffer.swift
@@ -3,47 +3,80 @@ import CoreLocation
 #endif
 import Foundation
 
-/// Line end styles for GeoJSON buffer.
-public enum BufferLineEndStyle: Sendable {
+/// Controls how convex corners are joined during buffering.
+/// The fidelity of rounded joins is controlled by the ``steps`` parameter.
+public enum BufferJoinType: Sendable {
 
-    /// Line ends will be flat.
-    case flat
+    /// Extend offset edges until they intersect, clamped by a miter limit.
+    /// - Parameter limit: Maximum ratio of miter length to buffer distance (default `2.0`).
+    case miter(limit: Double = 2.0)
 
-    /// Line ends will be rounded.
+    /// Cut off mitered corners with a straight line at the buffer distance.
+    case bevel
+
+    /// Extend corners by the buffer distance.
+    case square
+
+    /// Round corners (fidelity controlled by ``steps``).
     case round
 
 }
 
-/// Options for how to form an union of polygons.
+/// Controls how the ends of open buffer paths are terminated.
+/// Fidelity of round ends is controlled by the ``steps`` parameter.
+public enum BufferEndType: Sendable {
+
+    /// Closed polygon: the path forms a closed ring (no end caps).
+    case polygon
+
+    /// Extend both ends of an open path and join them together.
+    case joined
+
+    /// Flat end at the last vertex, perpendicular to the line direction.
+    case butt
+
+    /// Extended by half the buffer width beyond the last vertex.
+    case square
+
+    /// Rounded end cap (fidelity controlled by ``steps``).
+    case round
+
+}
+
+/// Options for how buffered parts are combined into the result.
 public enum BufferUnionType: Sendable {
 
-    /// Don't form a union from all geometries that make a buffer.
+    /// Return each buffered part as a separate polygon (no union).
     case none
 
-    /// Combine the buffered parts for each input geometry into one Polygon.
+    /// Combine the buffered parts of each input geometry.
     case individual
 
-    /// Combine all overlapping buffered geometries.
+    /// Combine all overlapping buffered parts across all input geometries.
     case overlapping
 
 }
 
 extension GeoJson {
 
-    /// Returns the receiver with a buffer.
+    /// Returns the receiver with a buffer applied.
     ///
-    /// - Parameter distance: The buffer distance, in meters. A positive value expands
-    ///                       the geometry; a negative value shrinks it (only supported
-    ///                       for polygons and multi-polygons).
-    /// - Parameter lineEndStyle: Controls how line ends will be drawn (default round)
-    /// - Parameter unionType: How to combine buffered geometries (default individual)
-    /// - Parameter steps: The number of steps for the circles (default 64)
-    /// - Parameter gridSize: Snap coordinates to a grid of the given size before buffering (default `nil`).
+    /// Uses the segment‑rectangle + vertex‑circle approach: each segment is
+    /// expanded into a rectangle, circles are added at vertices for rounded
+    /// joins and end caps, and everything is merged via polygon union.
     ///
-    /// - Returns: The buffered geometry as a `MultiPolygon`, or `nil` if the buffer could not be computed.
+    /// - Parameter distance: The buffer distance, in meters. Positive expands,
+    ///   negative shrinks (only for polygons and multi‑polygons).
+    /// - Parameter endType: End cap style for open paths (default `.round`).
+    /// - Parameter joinType: Corner join style (default `.round`).
+    /// - Parameter unionType: How to combine the buffered parts (default `.individual`).
+    /// - Parameter steps: Number of steps for circle approximation (default `64`).
+    /// - Parameter gridSize: Snap coordinates to a grid before computing (default `nil`).
+    /// - Returns: The buffered geometry, or `nil` if the buffer could not be computed.
     public func buffered(
         by distance: Double,
-        lineEndStyle: BufferLineEndStyle = .round,
+        endType: BufferEndType = .round,
+        joinType: BufferJoinType = .round,
         unionType: BufferUnionType = .individual,
         steps: Int = 64,
         gridSize: Double? = nil
@@ -52,25 +85,15 @@ extension GeoJson {
         guard distance != 0.0 else { return nil }
 
         if distance < 0.0 {
-            return Self.inset(
-                geometry,
-                by: -distance,
-                lineEndStyle: lineEndStyle,
-                unionType: unionType,
-                steps: steps)
+            return Self.inset(geometry, by: -distance, endType: endType, unionType: unionType, steps: steps)
         }
-        return Self.buffer(
-            geometry,
-            by: distance,
-            lineEndStyle: lineEndStyle,
-            unionType: unionType,
-            steps: steps)
+        return Self.buffer(geometry, by: distance, endType: endType, unionType: unionType, steps: steps)
     }
 
     private static func buffer(
         _ geometry: GeoJson,
         by distance: Double,
-        lineEndStyle: BufferLineEndStyle,
+        endType: BufferEndType,
         unionType: BufferUnionType,
         steps: Int
     ) -> MultiPolygon? {
@@ -82,151 +105,103 @@ extension GeoJson {
             result = MultiPolygon([circle])
 
         case let multiPoint as MultiPoint:
-            let bufferedPoints = multiPoint
-                .points
-                .compactMap({ $0.circle(radius: distance, steps: steps) })
+            let bufferedPoints = multiPoint.points.compactMap { $0.circle(radius: distance, steps: steps) }
             guard bufferedPoints.isNotEmpty else { return nil }
-
-            result = unionType == .overlapping
-                ? Union.unionPolygons(bufferedPoints)
-                : MultiPolygon(bufferedPoints)
+            result = unionType == .overlapping ? Union.unionPolygons(bufferedPoints) : MultiPolygon(bufferedPoints)
 
         case let lineString as LineString:
-            var polygons = lineString
-                .lineSegments
-                .flatMap({ segment in
-                    segment.buffered(
-                        by: distance,
-                        lineEndStyle: .flat,
-                        unionType: .none)?
-                        .polygons ?? []
-                })
-
+            var polygons = lineString.lineSegments.flatMap { segment in
+                segment.buffered(by: distance, endType: .butt, unionType: .none)?.polygons ?? []
+            }
             var bufferCoordinates = lineString.coordinates
             guard bufferCoordinates.count >= 2 else {
                 result = MultiPolygon(polygons)
                 break
             }
 
-            if lineEndStyle == .flat {
+            // Remove endpoint vertices so no circles are added there
+            if case .butt = endType {
                 bufferCoordinates.removeFirst()
                 bufferCoordinates.removeLast()
+            }
+            else if case .square = endType {
+                bufferCoordinates.removeFirst()
+                bufferCoordinates.removeLast()
+                let coords = lineString.coordinates
+                let startBearing = coords[0].bearing(to: coords[1])
+                let endBearing = coords[coords.count - 2].bearing(to: coords[coords.count - 1])
+                Self.addSquareEndCap(at: coords[0], bearing: startBearing, distance: distance, forward: false, to: &polygons)
+                Self.addSquareEndCap(at: coords[coords.count - 1], bearing: endBearing, distance: distance, forward: true, to: &polygons)
+            }
+            else if case .joined = endType {
+                bufferCoordinates.removeFirst()
+                bufferCoordinates.removeLast()
+                let coords = lineString.coordinates
+                let startBearing = coords[0].bearing(to: coords[1])
+                let endBearing = coords[coords.count - 2].bearing(to: coords[coords.count - 1])
+                Self.addSquareEndCap(at: coords[0], bearing: startBearing, distance: distance * 2.0, forward: false, to: &polygons)
+                Self.addSquareEndCap(at: coords[coords.count - 1], bearing: endBearing, distance: distance * 2.0, forward: true, to: &polygons)
+            }
+            else if case .polygon = endType {
+                // Bridge the gap between end and start to form a closed ring.
+                // Circles at all coordinates (like .round) plus the bridge.
+                let coords = lineString.coordinates
+                let bridge = LineSegment(first: coords.last!, second: coords[0], index: 0)
+                if let bp = bridge.buffered(by: distance, endType: .butt, unionType: .none) {
+                    polygons.append(contentsOf: bp.polygons)
+                }
             }
 
             for coordinate in bufferCoordinates {
                 guard let circle = coordinate.circle(radius: distance, steps: steps) else { continue }
                 polygons.append(circle)
             }
-
-            result = unionType.isIn([.individual, .overlapping])
-                ? Union.unionPolygons(polygons)
-                : MultiPolygon(polygons)
+            result = unionType.isIn([.individual, .overlapping]) ? Union.unionPolygons(polygons) : MultiPolygon(polygons)
 
         case let multiLineString as MultiLineString:
-            let bufferedLineStrings = multiLineString
-                .lineStrings
-                .compactMap({
-                    $0.buffered(
-                        by: distance,
-                        lineEndStyle: lineEndStyle,
-                        unionType: unionType,
-                        steps: steps)
-                })
-                .map(\.polygons)
-                .flatMap({ $0 })
-            guard bufferedLineStrings.isNotEmpty else { return nil }
-
-            result = unionType == .overlapping
-                ? Union.unionPolygons(bufferedLineStrings)
-                : MultiPolygon(bufferedLineStrings)
+            let buffered = multiLineString.lineStrings.compactMap {
+                $0.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
+            }.flatMap(\.polygons)
+            guard buffered.isNotEmpty else { return nil }
+            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(buffered)
 
         case let polygon as Polygon:
             let bufferCoordinates = polygon.allCoordinates
             guard bufferCoordinates.count >= 2 else { return nil }
-
-            var polygons = polygon
-                .lineSegments
-                .flatMap({ segment in
-                    segment.buffered(
-                        by: distance,
-                        lineEndStyle: .flat,
-                        unionType: .none)?
-                        .polygons ?? []
-                })
-
+            var polygons = polygon.lineSegments.flatMap { segment in
+                segment.buffered(by: distance, endType: .butt, unionType: .none)?.polygons ?? []
+            }
             for coordinate in bufferCoordinates {
                 guard let circle = coordinate.circle(radius: distance, steps: steps) else { continue }
                 polygons.append(circle)
             }
-
             polygons.append(polygon)
-
-            result = unionType.isIn([.individual, .overlapping])
-                ? Union.unionPolygons(polygons)
-                : MultiPolygon(polygons)
+            result = unionType.isIn([.individual, .overlapping]) ? Union.unionPolygons(polygons) : MultiPolygon(polygons)
 
         case let multiPolygon as MultiPolygon:
-            let bufferedPolygons = multiPolygon
-                .polygons
-                .compactMap({
-                    $0.buffered(
-                        by: distance,
-                        lineEndStyle: lineEndStyle,
-                        unionType: unionType,
-                        steps: steps)
-                })
-                .map(\.polygons)
-                .flatMap({ $0 })
-            guard bufferedPolygons.isNotEmpty else { return nil }
-
-            result = unionType == .overlapping
-                ? Union.unionPolygons(bufferedPolygons)
-                : MultiPolygon(bufferedPolygons)
+            let buffered = multiPolygon.polygons.compactMap {
+                $0.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
+            }.flatMap(\.polygons)
+            guard buffered.isNotEmpty else { return nil }
+            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(buffered)
 
         case let geometryCollection as GeometryCollection:
-            let bufferedPolygons = geometryCollection
-                .geometries
-                .compactMap({
-                    $0.buffered(
-                        by: distance,
-                        lineEndStyle: lineEndStyle,
-                        unionType: unionType,
-                        steps: steps)?
-                        .polygons
-                })
-                .flatMap({ $0 })
-            guard bufferedPolygons.isNotEmpty else { return nil }
-
-            result = unionType == .overlapping
-                ? Union.unionPolygons(bufferedPolygons)
-                : MultiPolygon(bufferedPolygons)
+            let buffered = geometryCollection.geometries.compactMap {
+                $0.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
+            }.flatMap(\.polygons)
+            guard buffered.isNotEmpty else { return nil }
+            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(buffered)
 
         case let feature as Feature:
-            return feature.geometry.buffered(
-                by: distance,
-                lineEndStyle: lineEndStyle,
-                unionType: unionType,
-                steps: steps)
+            return feature.geometry.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
 
         case let featureCollection as FeatureCollection:
-            let bufferedPolygons = featureCollection
-                .features
-                .compactMap({
-                    $0.geometry.buffered(
-                        by: distance,
-                        lineEndStyle: lineEndStyle,
-                        unionType: unionType,
-                        steps: steps)?
-                        .polygons
-                })
-                .flatMap({ $0 })
-            guard bufferedPolygons.isNotEmpty else { return nil }
+            let buffered = featureCollection.features.compactMap {
+                $0.geometry.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
+            }.flatMap(\.polygons)
+            guard buffered.isNotEmpty else { return nil }
+            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(buffered)
 
-            result = unionType == .overlapping
-                ? Union.unionPolygons(bufferedPolygons)
-                : MultiPolygon(bufferedPolygons)
-
-        // Can't happen
         default:
             return nil
         }
@@ -237,7 +212,7 @@ extension GeoJson {
     private static func inset(
         _ geometry: GeoJson,
         by distance: Double,
-        lineEndStyle: BufferLineEndStyle,
+        endType: BufferEndType,
         unionType: BufferUnionType,
         steps: Int
     ) -> MultiPolygon? {
@@ -249,54 +224,26 @@ extension GeoJson {
             result = MultiPolygon([inset])
 
         case let multiPolygon as MultiPolygon:
-            let insets = multiPolygon.polygons.compactMap {
-                Self.insetPolygon($0, by: distance)
-            }
+            let insets = multiPolygon.polygons.compactMap { Self.insetPolygon($0, by: distance) }
             guard insets.isNotEmpty else { return nil }
             result = MultiPolygon(unchecked: insets)
 
         case let feature as Feature:
-            return feature.geometry.buffered(
-                by: -distance,
-                lineEndStyle: lineEndStyle,
-                unionType: unionType,
-                steps: steps)
+            return feature.geometry.buffered(by: -distance, endType: endType, unionType: unionType, steps: steps)
 
         case let featureCollection as FeatureCollection:
-            let bufferedPolygons = featureCollection
-                .features
-                .compactMap {
-                    $0.geometry.buffered(
-                        by: -distance,
-                        lineEndStyle: lineEndStyle,
-                        unionType: unionType,
-                        steps: steps)?
-                        .polygons
-                }
-                .flatMap { $0 }
-            guard bufferedPolygons.isNotEmpty else { return nil }
-
-            result = unionType == .overlapping
-                ? Union.unionPolygons(bufferedPolygons)
-                : MultiPolygon(unchecked: bufferedPolygons)
+            let buffered = featureCollection.features.compactMap {
+                $0.geometry.buffered(by: -distance, endType: endType, unionType: unionType, steps: steps)
+            }.flatMap(\.polygons)
+            guard buffered.isNotEmpty else { return nil }
+            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(unchecked: buffered)
 
         case let geometryCollection as GeometryCollection:
-            let bufferedPolygons = geometryCollection
-                .geometries
-                .compactMap {
-                    $0.buffered(
-                        by: -distance,
-                        lineEndStyle: lineEndStyle,
-                        unionType: unionType,
-                        steps: steps)?
-                        .polygons
-                }
-                .flatMap { $0 }
-            guard bufferedPolygons.isNotEmpty else { return nil }
-
-            result = unionType == .overlapping
-                ? Union.unionPolygons(bufferedPolygons)
-                : MultiPolygon(unchecked: bufferedPolygons)
+            let buffered = geometryCollection.geometries.compactMap {
+                $0.buffered(by: -distance, endType: endType, unionType: unionType, steps: steps)
+            }.flatMap(\.polygons)
+            guard buffered.isNotEmpty else { return nil }
+            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(unchecked: buffered)
 
         default:
             return nil
@@ -305,144 +252,114 @@ extension GeoJson {
         return Self.cutAtAntimeridianIfNeeded(result)
     }
 
-    /// Returns a polygon inset (eroded) by a positive distance, or `nil` if the
-    /// inset would degenerate. The outer ring is shrunk inward; inner rings
-    /// (holes) are expanded.
-    ///
-    /// Computation is performed in EPSG:3857 (Mercator) for planar geometry.
-    private static func insetPolygon(
-        _ polygon: Polygon,
-        by distance: Double
-    ) -> Polygon? {
+    private static func insetPolygon(_ polygon: Polygon, by distance: Double) -> Polygon? {
         guard distance > 0.0 else { return polygon }
 
         let projected = polygon.projected(to: .epsg3857)
         guard let outerRing = projected.outerRing else { return nil }
-
         let outerCoords = outerRing.coordinates
         guard outerCoords.count >= 4 else { return nil }
 
-        func inwardNormal(
-            _ a: Coordinate3D,
-            _ b: Coordinate3D
-        ) -> (dx: Double, dy: Double)? {
+        func inwardNormal(_ a: Coordinate3D, _ b: Coordinate3D) -> (dx: Double, dy: Double)? {
             let vx = b.x - a.x, vy = b.y - a.y
             let len = sqrt(vx * vx + vy * vy)
             guard len > 0 else { return nil }
-
-            if outerRing.isClockwise {
-                return (vy / len, -vx / len)
-            }
+            if outerRing.isClockwise { return (vy / len, -vx / len) }
             return (-vy / len, vx / len)
         }
 
-        func outwardNormal(
-            _ a: Coordinate3D,
-            _ b: Coordinate3D,
-            holeIsClockwise: Bool
-        ) -> (dx: Double, dy: Double)? {
+        func outwardNormal(_ a: Coordinate3D, _ b: Coordinate3D, _ hcw: Bool) -> (dx: Double, dy: Double)? {
             let vx = b.x - a.x, vy = b.y - a.y
             let len = sqrt(vx * vx + vy * vy)
             guard len > 0 else { return nil }
-
-            if holeIsClockwise {
-                return (-vy / len, vx / len)
-            }
+            if hcw { return (-vy / len, vx / len) }
             return (vy / len, -vx / len)
         }
 
-        func intersect(
-            _ a1: Coordinate3D, _ a2: Coordinate3D,
-            _ b1: Coordinate3D, _ b2: Coordinate3D
-        ) -> Coordinate3D? {
+        func intersect(_ a1: Coordinate3D, _ a2: Coordinate3D, _ b1: Coordinate3D, _ b2: Coordinate3D) -> Coordinate3D? {
             let x1 = a1.x, y1 = a1.y, x2 = a2.x, y2 = a2.y
             let x3 = b1.x, y3 = b1.y, x4 = b2.x, y4 = b2.y
             let denom = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
             guard abs(denom) > GISTool.intersectionEpsilon else { return nil }
-
             let t = ((x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4)) / denom
-            let x = x1 + t * (x2 - x1)
-            let y = y1 + t * (y2 - y1)
-            return Coordinate3D(x: x, y: y)
+            return Coordinate3D(x: x1 + t * (x2 - x1), y: y1 + t * (y2 - y1))
         }
 
         var newOuter: [Coordinate3D] = []
         let n = outerCoords.count - 1
-
         for i in 0..<n {
-            let prev = outerCoords[(i + n - 1) % n]
-            let curr = outerCoords[i]
-            let next = outerCoords[(i + 1) % n]
-
-            guard let n0 = inwardNormal(prev, curr),
-                  let n1 = inwardNormal(curr, next)
-            else { return nil }
-
+            let prev = outerCoords[(i + n - 1) % n], curr = outerCoords[i], next = outerCoords[(i + 1) % n]
+            guard let n0 = inwardNormal(prev, curr), let n1 = inwardNormal(curr, next) else { return nil }
             let oa1 = Coordinate3D(x: prev.x + distance * n0.dx, y: prev.y + distance * n0.dy)
             let oa2 = Coordinate3D(x: curr.x + distance * n0.dx, y: curr.y + distance * n0.dy)
             let ob1 = Coordinate3D(x: curr.x + distance * n1.dx, y: curr.y + distance * n1.dy)
             let ob2 = Coordinate3D(x: next.x + distance * n1.dx, y: next.y + distance * n1.dy)
-
             guard let intersection = intersect(oa1, oa2, ob1, ob2) else { return nil }
-
             newOuter.append(intersection)
         }
-
         newOuter.append(newOuter[0])
 
         guard let insetRing = Ring(newOuter), insetRing.area != 0.0 else { return nil }
         guard abs(insetRing.area) < abs(outerRing.area) else { return nil }
 
-        // Expand holes (inner rings): offset each hole outward (opposite direction)
         var insetHoles: [Ring] = []
         if let innerRings = projected.innerRings {
             for hole in innerRings {
-                let holeCoords = hole.coordinates
-                guard holeCoords.count >= 4 else { return nil }
-
+                let hc = hole.coordinates
+                guard hc.count >= 4 else { return nil }
                 var newHole: [Coordinate3D] = []
-                let m = holeCoords.count - 1
-
+                let m = hc.count - 1
                 for j in 0..<m {
-                    let prev = holeCoords[(j + m - 1) % m]
-                    let curr = holeCoords[j]
-                    let next = holeCoords[(j + 1) % m]
-
-                    guard let n0 = outwardNormal(prev, curr, holeIsClockwise: hole.isClockwise),
-                          let n1 = outwardNormal(curr, next, holeIsClockwise: hole.isClockwise)
-                    else { return nil }
-
+                    let prev = hc[(j + m - 1) % m], curr = hc[j], next = hc[(j + 1) % m]
+                    guard let n0 = outwardNormal(prev, curr, hole.isClockwise),
+                          let n1 = outwardNormal(curr, next, hole.isClockwise) else { return nil }
                     let oa1 = Coordinate3D(x: prev.x + distance * n0.dx, y: prev.y + distance * n0.dy)
                     let oa2 = Coordinate3D(x: curr.x + distance * n0.dx, y: curr.y + distance * n0.dy)
                     let ob1 = Coordinate3D(x: curr.x + distance * n1.dx, y: curr.y + distance * n1.dy)
                     let ob2 = Coordinate3D(x: next.x + distance * n1.dx, y: next.y + distance * n1.dy)
-
                     guard let intersection = intersect(oa1, oa2, ob1, ob2) else { return nil }
-
                     newHole.append(intersection)
                 }
-
                 newHole.append(newHole[0])
                 if let holeRing = Ring(newHole), holeRing.area != 0.0 {
                     insetHoles.append(holeRing)
                 }
             }
         }
-
         var insetRings = [insetRing]
         insetRings.append(contentsOf: insetHoles)
         let insetPolygon = Polygon(unchecked: insetRings)
         return insetPolygon.projected(to: polygon.projection)
     }
 
-    /// Returns self with any polygons that cross the antimeridian cut into
-    /// valid pieces. All pieces are returned as a single ``MultiPolygon``.
-    private static func cutAtAntimeridianIfNeeded(
-        _ result: MultiPolygon?
-    ) -> MultiPolygon? {
+    /// Appends a square end‑cap rectangle extending `distance × 0.5` past the endpoint.
+    /// - Parameter forward: `true` for the end of the line, `false` for the start.
+    private static func addSquareEndCap(
+        at coordinate: Coordinate3D,
+        bearing: CLLocationDegrees,
+        distance: Double,
+        forward: Bool,
+        to polygons: inout [Polygon]
+    ) {
+        let tip = coordinate.destination(distance: distance * 0.5, bearing: bearing)
+        let p = forward ? coordinate : tip
+        let q = forward ? tip : coordinate
+        let left = (bearing - 90.0).truncatingRemainder(dividingBy: 360.0)
+        let right = (bearing + 90.0).truncatingRemainder(dividingBy: 360.0)
+        if let rect = Polygon([[
+            q.destination(distance: distance, bearing: left),
+            p.destination(distance: distance, bearing: left),
+            p.destination(distance: distance, bearing: right),
+            q.destination(distance: distance, bearing: right),
+            q.destination(distance: distance, bearing: left),
+        ]]) {
+            polygons.append(rect)
+        }
+    }
+
+    private static func cutAtAntimeridianIfNeeded(_ result: MultiPolygon?) -> MultiPolygon? {
         guard let mp = result else { return nil }
         guard mp.polygons.contains(where: { $0.crossesAntimeridian }) else { return mp }
-
         var cutPolygons: [Polygon] = []
         for polygon in mp.polygons {
             if polygon.crossesAntimeridian {
@@ -464,18 +381,17 @@ extension GeoJson {
 
 extension LineSegment {
 
-    /// Returns the line segment with a buffer.
+    /// Returns the line segment with a buffer applied.
     ///
-    /// - Parameter distance: The buffer distance, in meters
-    /// - Parameter lineEndStyle: Controls how line ends will be drawn (default round)
-    /// - Parameter unionType: Whether to combine all overlapping buffers into one Polygon (default true)
-    /// - Parameter steps: The number of steps for the circles (default 64)
-    /// - Parameter gridSize: Snap coordinates to a grid of the given size before buffering (default `nil`).
-    ///
-    /// - Returns: The buffered line segment as a `MultiPolygon`, or `nil` if the buffer could not be computed.
+    /// - Parameter distance: The buffer distance in meters.
+    /// - Parameter endType: Line end style (default `.round`).
+    /// - Parameter unionType: How to combine buffered parts (default `.individual`).
+    /// - Parameter steps: Number of steps for circle approximation (default `64`).
+    /// - Parameter gridSize: Snap coordinates to a grid before computing (default `nil`).
+    /// - Returns: The buffered segment, or `nil` if it could not be computed.
     public func buffered(
         by distance: Double,
-        lineEndStyle: BufferLineEndStyle = .round,
+        endType: BufferEndType = .round,
         unionType: BufferUnionType = .individual,
         steps: Int = 64,
         gridSize: Double? = nil
@@ -505,7 +421,7 @@ extension LineSegment {
             polygons = [rectPolygon]
         }
 
-        if lineEndStyle == .round,
+        if case .round = endType,
            let firstCircle = snappedSegment.first.circle(radius: distance, steps: steps),
            let secondCircle = snappedSegment.second.circle(radius: distance, steps: steps)
         {
@@ -513,10 +429,7 @@ extension LineSegment {
             polygons.append(secondCircle)
         }
 
-        if unionType == .none {
-            return MultiPolygon(polygons)
-        }
-
+        if unionType == .none { return MultiPolygon(polygons) }
         return Union.unionPolygons(polygons)
     }
 

--- a/Sources/GISTools/Algorithms/Buffer.swift
+++ b/Sources/GISTools/Algorithms/Buffer.swift
@@ -84,13 +84,14 @@ extension GeoJson {
         if distance < 0.0 {
             return Self.inset(geometry, by: -distance, endType: endType, unionType: unionType, steps: steps)
         }
-        return Self.buffer(geometry, by: distance, endType: endType, unionType: unionType, steps: steps)
+        return Self.buffer(geometry, by: distance, endType: endType, joinType: joinType, unionType: unionType, steps: steps)
     }
 
     private static func buffer(
         _ geometry: GeoJson,
         by distance: Double,
         endType: BufferEndType,
+        joinType: BufferJoinType,
         unionType: BufferUnionType,
         steps: Int
     ) -> MultiPolygon? {
@@ -104,7 +105,9 @@ extension GeoJson {
         case let multiPoint as MultiPoint:
             let bufferedPoints = multiPoint.points.compactMap { $0.circle(radius: distance, steps: steps) }
             guard bufferedPoints.isNotEmpty else { return nil }
-            result = unionType == .overlapping ? Union.unionPolygons(bufferedPoints) : MultiPolygon(bufferedPoints)
+            result = unionType == .overlapping
+                ? Union.unionPolygons(bufferedPoints)
+                : MultiPolygon(bufferedPoints)
 
         case let lineString as LineString:
             var polygons = lineString.lineSegments.flatMap { segment in
@@ -149,18 +152,46 @@ extension GeoJson {
                 }
             }
 
+            let allCoords = lineString.coordinates
             for coordinate in bufferCoordinates {
+                if case .bevel = joinType {
+                    if case .round = endType {
+                        if coordinate != allCoords.first, coordinate != allCoords.last { continue }
+                    }
+                    else { continue }
+                }
                 guard let circle = coordinate.circle(radius: distance, steps: steps) else { continue }
                 polygons.append(circle)
             }
-            result = unionType.isIn([.individual, .overlapping]) ? Union.unionPolygons(polygons) : MultiPolygon(polygons)
+
+            if case .bevel = joinType {
+                if endType == .polygon {
+                    let n = allCoords.count
+                    for i in 0 ..< n {
+                        let prev = allCoords[(i + n - 1) % n]
+                        let curr = allCoords[i]
+                        let next = allCoords[(i + 1) % n]
+                        Self.addBevelJoin(at: prev, curr, next, distance: distance, to: &polygons)
+                    }
+                }
+                else {
+                    for i in 1 ..< allCoords.count - 1 {
+                        Self.addBevelJoin(at: allCoords[i - 1], allCoords[i], allCoords[i + 1], distance: distance, to: &polygons)
+                    }
+                }
+            }
+            result = unionType.isIn([.individual, .overlapping])
+                ? Union.unionPolygons(polygons)
+                : MultiPolygon(polygons)
 
         case let multiLineString as MultiLineString:
             let buffered = multiLineString.lineStrings.compactMap {
-                $0.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
+                $0.buffered(by: distance, endType: endType, joinType: joinType, unionType: unionType, steps: steps)
             }.flatMap(\.polygons)
             guard buffered.isNotEmpty else { return nil }
-            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(buffered)
+            result = unionType == .overlapping
+                ? Union.unionPolygons(buffered)
+                : MultiPolygon(buffered)
 
         case let polygon as Polygon:
             let bufferCoordinates = polygon.allCoordinates
@@ -168,36 +199,56 @@ extension GeoJson {
             var polygons = polygon.lineSegments.flatMap { segment in
                 segment.buffered(by: distance, endType: .butt, unionType: .none)?.polygons ?? []
             }
-            for coordinate in bufferCoordinates {
-                guard let circle = coordinate.circle(radius: distance, steps: steps) else { continue }
-                polygons.append(circle)
+            if case .bevel = joinType {
+                if let outerRing = polygon.outerRing {
+                    Self.addRingBevels(for: outerRing.coordinates, distance: distance, to: &polygons)
+                }
+                if let innerRings = polygon.innerRings {
+                    for ring in innerRings {
+                        Self.addRingBevels(for: ring.coordinates, distance: distance, to: &polygons)
+                    }
+                }
+            }
+            else {
+                for coordinate in bufferCoordinates {
+                    guard let circle = coordinate.circle(radius: distance, steps: steps) else { continue }
+                    polygons.append(circle)
+                }
             }
             polygons.append(polygon)
-            result = unionType.isIn([.individual, .overlapping]) ? Union.unionPolygons(polygons) : MultiPolygon(polygons)
+            result = unionType.isIn([.individual, .overlapping])
+                ? Union.unionPolygons(polygons)
+                : MultiPolygon(polygons)
 
         case let multiPolygon as MultiPolygon:
             let buffered = multiPolygon.polygons.compactMap {
-                $0.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
+                $0.buffered(by: distance, endType: endType, joinType: joinType, unionType: unionType, steps: steps)
             }.flatMap(\.polygons)
             guard buffered.isNotEmpty else { return nil }
-            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(buffered)
+            result = unionType == .overlapping
+                ? Union.unionPolygons(buffered)
+                : MultiPolygon(buffered)
 
         case let geometryCollection as GeometryCollection:
             let buffered = geometryCollection.geometries.compactMap {
-                $0.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
+                $0.buffered(by: distance, endType: endType, joinType: joinType, unionType: unionType, steps: steps)
             }.flatMap(\.polygons)
             guard buffered.isNotEmpty else { return nil }
-            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(buffered)
+            result = unionType == .overlapping
+                ? Union.unionPolygons(buffered)
+                : MultiPolygon(buffered)
 
         case let feature as Feature:
-            return feature.geometry.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
+            return feature.geometry.buffered(by: distance, endType: endType, joinType: joinType, unionType: unionType, steps: steps)
 
         case let featureCollection as FeatureCollection:
             let buffered = featureCollection.features.compactMap {
-                $0.geometry.buffered(by: distance, endType: endType, unionType: unionType, steps: steps)
+                $0.geometry.buffered(by: distance, endType: endType, joinType: joinType, unionType: unionType, steps: steps)
             }.flatMap(\.polygons)
             guard buffered.isNotEmpty else { return nil }
-            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(buffered)
+            result = unionType == .overlapping
+                ? Union.unionPolygons(buffered)
+                : MultiPolygon(buffered)
 
         default:
             return nil
@@ -233,14 +284,18 @@ extension GeoJson {
                 $0.geometry.buffered(by: -distance, endType: endType, unionType: unionType, steps: steps)
             }.flatMap(\.polygons)
             guard buffered.isNotEmpty else { return nil }
-            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(unchecked: buffered)
+            result = unionType == .overlapping
+                ? Union.unionPolygons(buffered)
+                : MultiPolygon(unchecked: buffered)
 
         case let geometryCollection as GeometryCollection:
             let buffered = geometryCollection.geometries.compactMap {
                 $0.buffered(by: -distance, endType: endType, unionType: unionType, steps: steps)
             }.flatMap(\.polygons)
             guard buffered.isNotEmpty else { return nil }
-            result = unionType == .overlapping ? Union.unionPolygons(buffered) : MultiPolygon(unchecked: buffered)
+            result = unionType == .overlapping
+                ? Union.unionPolygons(buffered)
+                : MultiPolygon(unchecked: buffered)
 
         default:
             return nil
@@ -249,11 +304,15 @@ extension GeoJson {
         return Self.cutAtAntimeridianIfNeeded(result)
     }
 
-    private static func insetPolygon(_ polygon: Polygon, by distance: Double) -> Polygon? {
+    private static func insetPolygon(
+        _ polygon: Polygon,
+        by distance: Double
+    ) -> Polygon? {
         guard distance > 0.0 else { return polygon }
 
         let projected = polygon.projected(to: .epsg3857)
         guard let outerRing = projected.outerRing else { return nil }
+
         let outerCoords = outerRing.coordinates
         guard outerCoords.count >= 4 else { return nil }
 
@@ -285,40 +344,55 @@ extension GeoJson {
         var newOuter: [Coordinate3D] = []
         let n = outerCoords.count - 1
         for i in 0..<n {
-            let prev = outerCoords[(i + n - 1) % n], curr = outerCoords[i], next = outerCoords[(i + 1) % n]
-            guard let n0 = inwardNormal(prev, curr), let n1 = inwardNormal(curr, next) else { return nil }
+            let prev = outerCoords[(i + n - 1) % n],
+                curr = outerCoords[i],
+                next = outerCoords[(i + 1) % n]
+            guard let n0 = inwardNormal(prev, curr),
+                  let n1 = inwardNormal(curr, next)
+            else { return nil }
+
             let oa1 = Coordinate3D(x: prev.x + distance * n0.dx, y: prev.y + distance * n0.dy)
             let oa2 = Coordinate3D(x: curr.x + distance * n0.dx, y: curr.y + distance * n0.dy)
             let ob1 = Coordinate3D(x: curr.x + distance * n1.dx, y: curr.y + distance * n1.dy)
             let ob2 = Coordinate3D(x: next.x + distance * n1.dx, y: next.y + distance * n1.dy)
             guard let intersection = intersect(oa1, oa2, ob1, ob2) else { return nil }
+
             newOuter.append(intersection)
         }
         newOuter.append(newOuter[0])
 
-        guard let insetRing = Ring(newOuter), insetRing.area != 0.0 else { return nil }
-        guard abs(insetRing.area) < abs(outerRing.area) else { return nil }
+        guard let insetRing = Ring(newOuter),
+              insetRing.area != 0.0,
+              abs(insetRing.area) < abs(outerRing.area)
+        else { return nil }
 
         var insetHoles: [Ring] = []
         if let innerRings = projected.innerRings {
             for hole in innerRings {
                 let hc = hole.coordinates
                 guard hc.count >= 4 else { return nil }
+
                 var newHole: [Coordinate3D] = []
                 let m = hc.count - 1
                 for j in 0..<m {
                     let prev = hc[(j + m - 1) % m], curr = hc[j], next = hc[(j + 1) % m]
                     guard let n0 = outwardNormal(prev, curr, hole.isClockwise),
-                          let n1 = outwardNormal(curr, next, hole.isClockwise) else { return nil }
+                          let n1 = outwardNormal(curr, next, hole.isClockwise)
+                    else { return nil }
+
                     let oa1 = Coordinate3D(x: prev.x + distance * n0.dx, y: prev.y + distance * n0.dy)
                     let oa2 = Coordinate3D(x: curr.x + distance * n0.dx, y: curr.y + distance * n0.dy)
                     let ob1 = Coordinate3D(x: curr.x + distance * n1.dx, y: curr.y + distance * n1.dy)
                     let ob2 = Coordinate3D(x: next.x + distance * n1.dx, y: next.y + distance * n1.dy)
                     guard let intersection = intersect(oa1, oa2, ob1, ob2) else { return nil }
+
                     newHole.append(intersection)
                 }
                 newHole.append(newHole[0])
-                if let holeRing = Ring(newHole), holeRing.area != 0.0 {
+
+                if let holeRing = Ring(newHole),
+                   holeRing.area != 0.0
+                {
                     insetHoles.append(holeRing)
                 }
             }
@@ -354,9 +428,172 @@ extension GeoJson {
         }
     }
 
+    /// Adds a bevel triangle at an interior vertex of a LineString,
+    /// filling the gap between adjacent segment rectangles on the
+    /// outer side of the corner.
+    private static func addBevelJoin(
+        at prev: Coordinate3D,
+        _ curr: Coordinate3D,
+        _ next: Coordinate3D,
+        distance: Double,
+        to polygons: inout [Polygon]
+    ) {
+        guard let bevel = Self.bevelTriangle(from: prev, over: curr, to: next, distance: distance) else { return }
+        polygons.append(bevel)
+    }
+
+    /// Adds bevel triangles for every vertex in a ring (polygon exterior or hole).
+    private static func addRingBevels(
+        for coordinates: [Coordinate3D],
+        distance: Double,
+        to polygons: inout [Polygon]
+    ) {
+        let n = coordinates.count - 1  // last coord is duplicate of first
+        guard n >= 3 else { return }
+        for i in 0 ..< n {
+            let prev = coordinates[(i + n - 1) % n]
+            let curr = coordinates[i]
+            let next = coordinates[(i + 1) % n]
+            Self.addBevelJoin(at: prev, curr, next, distance: distance, to: &polygons)
+        }
+    }
+
+    /// Creates a bevel triangle at a vertex. The triangle spans from
+    /// the two outer offset points (the bevel edge) to a point on the
+    /// opposite side of the corner that lies deep inside the overlap
+    /// region of both segment rectangles.  Only the outer bevel edge
+    /// remains visible after union — the inner edges are hidden by
+    /// the rectangle interiors.
+    private static func bevelTriangle(
+        from prev: Coordinate3D,
+        over curr: Coordinate3D,
+        to next: Coordinate3D,
+        distance: Double
+    ) -> Polygon? {
+        let proj = curr.projection
+
+        if proj == .epsg4326 {
+            let bearingAB = prev.bearing(to: curr)
+            let bearingBC = curr.bearing(to: next)
+            var turnAngle = (bearingBC - bearingAB)
+                .truncatingRemainder(dividingBy: 360)
+            if turnAngle < 0 {
+                turnAngle += 360
+            }
+
+            if turnAngle < 1
+                || turnAngle > 359
+                || abs(turnAngle - 180) < 1
+            {
+                return nil
+            }
+
+            let leftAB = ((bearingAB - 90)
+                .truncatingRemainder(dividingBy: 360) + 360)
+                .truncatingRemainder(dividingBy: 360)
+            let rightAB = ((bearingAB + 90)
+                .truncatingRemainder(dividingBy: 360) + 360)
+                .truncatingRemainder(dividingBy: 360)
+            let leftBC = ((bearingBC - 90)
+                .truncatingRemainder(dividingBy: 360) + 360)
+                .truncatingRemainder(dividingBy: 360)
+            let rightBC = ((bearingBC + 90)
+                .truncatingRemainder(dividingBy: 360) + 360)
+                .truncatingRemainder(dividingBy: 360)
+
+            if turnAngle < 180 {
+                // Right turn: gap on left, overlap on right
+                let p1 = curr.destination(distance: distance, bearing: leftAB)
+                let p2 = curr.destination(distance: distance, bearing: leftBC)
+                let opp1 = curr.destination(distance: distance, bearing: rightAB)
+                let opp2 = curr.destination(distance: distance, bearing: rightBC)
+                let inner = Coordinate3D(
+                    x: (opp1.x + opp2.x) / 2.0,
+                    y: (opp1.y + opp2.y) / 2.0,
+                    projection: proj)
+                return Polygon([[p1, inner, p2, p1]])
+            }
+            else {
+                // Left turn: gap on right, overlap on left
+                let p1 = curr.destination(distance: distance, bearing: rightAB)
+                let p2 = curr.destination(distance: distance, bearing: rightBC)
+                let opp1 = curr.destination(distance: distance, bearing: leftAB)
+                let opp2 = curr.destination(distance: distance, bearing: leftBC)
+                let inner = Coordinate3D(
+                    x: (opp1.x + opp2.x) / 2.0,
+                    y: (opp1.y + opp2.y) / 2.0,
+                    projection: proj)
+                return Polygon([[p1, inner, p2, p1]])
+            }
+        }
+        else {
+            let dx1 = curr.x - prev.x
+            let dy1 = curr.y - prev.y
+            let dx2 = next.x - curr.x
+            let dy2 = next.y - curr.y
+            let len1 = sqrt(dx1 * dx1 + dy1 * dy1)
+            let len2 = sqrt(dx2 * dx2 + dy2 * dy2)
+            guard len1 > GISTool.intersectionEpsilon,
+                  len2 > GISTool.intersectionEpsilon
+            else { return nil }
+
+            let cross = dx1 * dy2 - dy1 * dx2
+            if abs(cross) < GISTool.determinantEpsilon * len1 * len2 {
+                return nil
+            }
+
+            let e1x = dx1 / len1
+            let e1y = dy1 / len1
+            let e2x = dx2 / len2
+            let e2y = dy2 / len2
+
+            if cross > 0 {
+                // Left turn: gap on right side, overlap on left
+                let p1 = Coordinate3D(
+                    x: curr.x + distance * e1y, y: curr.y - distance * e1x,
+                    projection: proj)
+                let p2 = Coordinate3D(
+                    x: curr.x + distance * e2y, y: curr.y - distance * e2x,
+                    projection: proj)
+                let opp1 = Coordinate3D(
+                    x: curr.x - distance * e1y, y: curr.y + distance * e1x,
+                    projection: proj)
+                let opp2 = Coordinate3D(
+                    x: curr.x - distance * e2y, y: curr.y + distance * e2x,
+                    projection: proj)
+                let inner = Coordinate3D(
+                    x: (opp1.x + opp2.x) / 2.0,
+                    y: (opp1.y + opp2.y) / 2.0,
+                    projection: proj)
+                return Polygon([[p1, inner, p2, p1]])
+            }
+            else {
+                // Right turn: gap on left side, overlap on right
+                let p1 = Coordinate3D(
+                    x: curr.x - distance * e1y, y: curr.y + distance * e1x,
+                    projection: proj)
+                let p2 = Coordinate3D(
+                    x: curr.x - distance * e2y, y: curr.y + distance * e2x,
+                    projection: proj)
+                let opp1 = Coordinate3D(
+                    x: curr.x + distance * e1y, y: curr.y - distance * e1x,
+                    projection: proj)
+                let opp2 = Coordinate3D(
+                    x: curr.x + distance * e2y, y: curr.y - distance * e2x,
+                    projection: proj)
+                let inner = Coordinate3D(
+                    x: (opp1.x + opp2.x) / 2.0,
+                    y: (opp1.y + opp2.y) / 2.0,
+                    projection: proj)
+                return Polygon([[p1, inner, p2, p1]])
+            }
+        }
+    }
+
     private static func cutAtAntimeridianIfNeeded(_ result: MultiPolygon?) -> MultiPolygon? {
         guard let mp = result else { return nil }
         guard mp.polygons.contains(where: { $0.crossesAntimeridian }) else { return mp }
+
         var cutPolygons: [Polygon] = []
         for polygon in mp.polygons {
             if polygon.crossesAntimeridian {
@@ -410,9 +647,12 @@ extension LineSegment {
         ]
 
         guard let rectPolygon = Polygon([corners]) else { return nil }
+
         var polygons: [Polygon]
         if rectPolygon.crossesAntimeridian {
-            polygons = rectPolygon.cutAtAntimeridian().features.compactMap { $0.geometry as? Polygon }
+            polygons = rectPolygon.cutAtAntimeridian()
+                .features
+                .compactMap { $0.geometry as? Polygon }
         }
         else {
             polygons = [rectPolygon]

--- a/Sources/GISTools/Algorithms/Buffer.swift
+++ b/Sources/GISTools/Algorithms/Buffer.swift
@@ -7,12 +7,12 @@ import Foundation
 /// The fidelity of rounded joins is controlled by the ``steps`` parameter.
 public enum BufferJoinType: Sendable {
 
+    /// Cut off mitered corners with a straight line at the buffer distance.
+    case bevel
+
     /// Extend offset edges until they intersect, clamped by a miter limit.
     /// - Parameter limit: Maximum ratio of miter length to buffer distance (default `2.0`).
     case miter(limit: Double = 2.0)
-
-    /// Cut off mitered corners with a straight line at the buffer distance.
-    case bevel
 
     /// Round corners (fidelity controlled by ``steps``).
     case round
@@ -23,31 +23,28 @@ public enum BufferJoinType: Sendable {
 /// Fidelity of round ends is controlled by the ``steps`` parameter.
 public enum BufferEndType: Sendable {
 
-    /// Closed polygon: the path forms a closed ring (no end caps).
-    case polygon
-
-    /// Extend both ends of an open path and join them together.
-    case joined
-
     /// Flat end at the last vertex, perpendicular to the line direction.
     case butt
 
-    /// Extended by half the buffer width beyond the last vertex.
-    case square
+    /// Closed polygon: the path forms a closed ring (no end caps).
+    case polygon
 
     /// Rounded end cap (fidelity controlled by ``steps``).
     case round
+
+    /// Extended by half the buffer width beyond the last vertex.
+    case square
 
 }
 
 /// Options for how buffered parts are combined into the result.
 public enum BufferUnionType: Sendable {
 
-    /// Return each buffered part as a separate polygon (no union).
-    case none
-
     /// Combine the buffered parts of each input geometry.
     case individual
+
+    /// Return each buffered part as a separate polygon (no union).
+    case none
 
     /// Combine all overlapping buffered parts across all input geometries.
     case overlapping
@@ -130,17 +127,8 @@ extension GeoJson {
                 let coords = lineString.coordinates
                 let startBearing = coords[0].bearing(to: coords[1])
                 let endBearing = coords[coords.count - 2].bearing(to: coords[coords.count - 1])
-                Self.addSquareEndCap(at: coords[0], bearing: startBearing, distance: distance, forward: false, to: &polygons)
-                Self.addSquareEndCap(at: coords[coords.count - 1], bearing: endBearing, distance: distance, forward: true, to: &polygons)
-            }
-            else if case .joined = endType {
-                bufferCoordinates.removeFirst()
-                bufferCoordinates.removeLast()
-                let coords = lineString.coordinates
-                let startBearing = coords[0].bearing(to: coords[1])
-                let endBearing = coords[coords.count - 2].bearing(to: coords[coords.count - 1])
-                Self.addSquareEndCap(at: coords[0], bearing: startBearing, distance: distance * 2.0, forward: false, to: &polygons)
-                Self.addSquareEndCap(at: coords[coords.count - 1], bearing: endBearing, distance: distance * 2.0, forward: true, to: &polygons)
+                Self.addSquareEndCap(at: coords[0], bearing: startBearing, tipDistance: distance * 0.5, width: distance, forward: false, to: &polygons)
+                Self.addSquareEndCap(at: coords[coords.count - 1], bearing: endBearing, tipDistance: distance * 0.5, width: distance, forward: true, to: &polygons)
             }
             else if case .polygon = endType {
                 // Bridge the gap between end and start to form a closed ring.
@@ -403,26 +391,32 @@ extension GeoJson {
         return insetPolygon.projected(to: polygon.projection)
     }
 
-    /// Appends a square end‑cap rectangle extending `distance × 0.5` past the endpoint.
+    /// Appends a square end‑cap rectangle extending past the endpoint.
+    /// - Parameter bearing: Direction in which the tip is placed and from
+    ///   which the left / right normals are derived.
+    /// - Parameter tipDistance: How far past the endpoint the tip extends,
+    ///   in meters (e.g. `distance × 0.5` for ``BufferEndType/square``).
+    /// - Parameter width: The buffer / left‑right width, in meters.
     /// - Parameter forward: `true` for the end of the line, `false` for the start.
     private static func addSquareEndCap(
         at coordinate: Coordinate3D,
         bearing: CLLocationDegrees,
-        distance: Double,
+        tipDistance: Double,
+        width: Double,
         forward: Bool,
         to polygons: inout [Polygon]
     ) {
-        let tip = coordinate.destination(distance: distance * 0.5, bearing: bearing)
+        let tip = coordinate.destination(distance: tipDistance, bearing: bearing)
         let p = forward ? coordinate : tip
         let q = forward ? tip : coordinate
         let left = (bearing - 90.0).truncatingRemainder(dividingBy: 360.0)
         let right = (bearing + 90.0).truncatingRemainder(dividingBy: 360.0)
         if let rect = Polygon([[
-            q.destination(distance: distance, bearing: left),
-            p.destination(distance: distance, bearing: left),
-            p.destination(distance: distance, bearing: right),
-            q.destination(distance: distance, bearing: right),
-            q.destination(distance: distance, bearing: left),
+            q.destination(distance: width, bearing: left),
+            p.destination(distance: width, bearing: left),
+            p.destination(distance: width, bearing: right),
+            q.destination(distance: width, bearing: right),
+            q.destination(distance: width, bearing: left),
         ]]) {
             polygons.append(rect)
         }

--- a/Sources/GISTools/Algorithms/Buffer.swift
+++ b/Sources/GISTools/Algorithms/Buffer.swift
@@ -14,9 +14,6 @@ public enum BufferJoinType: Sendable {
     /// Cut off mitered corners with a straight line at the buffer distance.
     case bevel
 
-    /// Extend corners by the buffer distance.
-    case square
-
     /// Round corners (fidelity controlled by ``steps``).
     case round
 

--- a/Sources/GISTools/Algorithms/Buffer.swift
+++ b/Sources/GISTools/Algorithms/Buffer.swift
@@ -142,17 +142,20 @@ extension GeoJson {
 
             let allCoords = lineString.coordinates
             for coordinate in bufferCoordinates {
-                if case .bevel = joinType {
+                switch joinType {
+                case .bevel, .miter:
                     if case .round = endType {
                         if coordinate != allCoords.first, coordinate != allCoords.last { continue }
                     }
                     else { continue }
+                default: break
                 }
                 guard let circle = coordinate.circle(radius: distance, steps: steps) else { continue }
                 polygons.append(circle)
             }
 
-            if case .bevel = joinType {
+            switch joinType {
+            case .bevel:
                 if endType == .polygon {
                     let n = allCoords.count
                     for i in 0 ..< n {
@@ -167,6 +170,25 @@ extension GeoJson {
                         Self.addBevelJoin(at: allCoords[i - 1], allCoords[i], allCoords[i + 1], distance: distance, to: &polygons)
                     }
                 }
+
+            case .miter(let limit):
+                if endType == .polygon {
+                    let n = allCoords.count
+                    for i in 0 ..< n {
+                        let prev = allCoords[(i + n - 1) % n]
+                        let curr = allCoords[i]
+                        let next = allCoords[(i + 1) % n]
+                        Self.addMiterJoin(at: prev, curr, next, distance: distance, limit: limit, to: &polygons)
+                    }
+                }
+                else {
+                    for i in 1 ..< allCoords.count - 1 {
+                        Self.addMiterJoin(at: allCoords[i - 1], allCoords[i], allCoords[i + 1], distance: distance, limit: limit, to: &polygons)
+                    }
+                }
+
+            default:
+                break
             }
             result = unionType.isIn([.individual, .overlapping])
                 ? Union.unionPolygons(polygons)
@@ -187,7 +209,8 @@ extension GeoJson {
             var polygons = polygon.lineSegments.flatMap { segment in
                 segment.buffered(by: distance, endType: .butt, unionType: .none)?.polygons ?? []
             }
-            if case .bevel = joinType {
+            switch joinType {
+            case .bevel:
                 if let outerRing = polygon.outerRing {
                     Self.addRingBevels(for: outerRing.coordinates, distance: distance, to: &polygons)
                 }
@@ -196,13 +219,24 @@ extension GeoJson {
                         Self.addRingBevels(for: ring.coordinates, distance: distance, to: &polygons)
                     }
                 }
-            }
-            else {
+
+            case .miter(let limit):
+                if let outerRing = polygon.outerRing {
+                    Self.addRingMiters(for: outerRing.coordinates, distance: distance, limit: limit, to: &polygons)
+                }
+                if let innerRings = polygon.innerRings {
+                    for ring in innerRings {
+                        Self.addRingMiters(for: ring.coordinates, distance: distance, limit: limit, to: &polygons)
+                    }
+                }
+
+            default:
                 for coordinate in bufferCoordinates {
                     guard let circle = coordinate.circle(radius: distance, steps: steps) else { continue }
                     polygons.append(circle)
                 }
             }
+
             polygons.append(polygon)
             result = unionType.isIn([.individual, .overlapping])
                 ? Union.unionPolygons(polygons)
@@ -436,6 +470,20 @@ extension GeoJson {
         polygons.append(bevel)
     }
 
+    /// Adds a miter polygon at an interior vertex of a LineString,
+    /// falling back to a bevel when the miter exceeds the limit.
+    private static func addMiterJoin(
+        at prev: Coordinate3D,
+        _ curr: Coordinate3D,
+        _ next: Coordinate3D,
+        distance: Double,
+        limit: Double,
+        to polygons: inout [Polygon]
+    ) {
+        guard let miter = Self.miterFill(from: prev, over: curr, to: next, distance: distance, limit: limit) else { return }
+        polygons.append(miter)
+    }
+
     /// Adds bevel triangles for every vertex in a ring (polygon exterior or hole).
     private static func addRingBevels(
         for coordinates: [Coordinate3D],
@@ -449,6 +497,23 @@ extension GeoJson {
             let curr = coordinates[i]
             let next = coordinates[(i + 1) % n]
             Self.addBevelJoin(at: prev, curr, next, distance: distance, to: &polygons)
+        }
+    }
+
+    /// Adds miter polygons for every vertex in a ring (polygon exterior or hole).
+    private static func addRingMiters(
+        for coordinates: [Coordinate3D],
+        distance: Double,
+        limit: Double,
+        to polygons: inout [Polygon]
+    ) {
+        let n = coordinates.count - 1
+        guard n >= 3 else { return }
+        for i in 0 ..< n {
+            let prev = coordinates[(i + n - 1) % n]
+            let curr = coordinates[i]
+            let next = coordinates[(i + 1) % n]
+            Self.addMiterJoin(at: prev, curr, next, distance: distance, limit: limit, to: &polygons)
         }
     }
 
@@ -544,16 +609,20 @@ extension GeoJson {
             if cross > 0 {
                 // Left turn: gap on right side, overlap on left
                 let p1 = Coordinate3D(
-                    x: curr.x + distance * e1y, y: curr.y - distance * e1x,
+                    x: curr.x + distance * e1y,
+                    y: curr.y - distance * e1x,
                     projection: proj)
                 let p2 = Coordinate3D(
-                    x: curr.x + distance * e2y, y: curr.y - distance * e2x,
+                    x: curr.x + distance * e2y,
+                    y: curr.y - distance * e2x,
                     projection: proj)
                 let opp1 = Coordinate3D(
-                    x: curr.x - distance * e1y, y: curr.y + distance * e1x,
+                    x: curr.x - distance * e1y,
+                    y: curr.y + distance * e1x,
                     projection: proj)
                 let opp2 = Coordinate3D(
-                    x: curr.x - distance * e2y, y: curr.y + distance * e2x,
+                    x: curr.x - distance * e2y,
+                    y: curr.y + distance * e2x,
                     projection: proj)
                 let inner = Coordinate3D(
                     x: (opp1.x + opp2.x) / 2.0,
@@ -564,16 +633,20 @@ extension GeoJson {
             else {
                 // Right turn: gap on left side, overlap on right
                 let p1 = Coordinate3D(
-                    x: curr.x - distance * e1y, y: curr.y + distance * e1x,
+                    x: curr.x - distance * e1y,
+                    y: curr.y + distance * e1x,
                     projection: proj)
                 let p2 = Coordinate3D(
-                    x: curr.x - distance * e2y, y: curr.y + distance * e2x,
+                    x: curr.x - distance * e2y,
+                    y: curr.y + distance * e2x,
                     projection: proj)
                 let opp1 = Coordinate3D(
-                    x: curr.x + distance * e1y, y: curr.y - distance * e1x,
+                    x: curr.x + distance * e1y,
+                    y: curr.y - distance * e1x,
                     projection: proj)
                 let opp2 = Coordinate3D(
-                    x: curr.x + distance * e2y, y: curr.y - distance * e2x,
+                    x: curr.x + distance * e2y,
+                    y: curr.y - distance * e2x,
                     projection: proj)
                 let inner = Coordinate3D(
                     x: (opp1.x + opp2.x) / 2.0,
@@ -582,6 +655,129 @@ extension GeoJson {
                 return Polygon([[p1, inner, p2, p1]])
             }
         }
+    }
+
+    /// Intersection point of two lines (in CRS units).
+    /// Lines are defined by point pairs (a1, a2) and (b1, b2).
+    private static func lineIntersect(
+        _ a1: Coordinate3D,
+        _ a2: Coordinate3D,
+        _ b1: Coordinate3D,
+        _ b2: Coordinate3D
+    ) -> Coordinate3D? {
+        let x1 = a1.x, y1 = a1.y, x2 = a2.x, y2 = a2.y
+        let x3 = b1.x, y3 = b1.y, x4 = b2.x, y4 = b2.y
+        let denom = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
+        guard abs(denom) > GISTool.intersectionEpsilon else { return nil }
+        let t = ((x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4)) / denom
+        return Coordinate3D(x: x1 + t * (x2 - x1), y: y1 + t * (y2 - y1))
+    }
+
+    /// Creates a miter polygon at a vertex, extending the offset edges
+    /// to their intersection point (the miter point).  Falls back to a
+    /// bevel if the miter length exceeds `limit × distance`.
+    private static func miterFill(
+        from prev: Coordinate3D,
+        over curr: Coordinate3D,
+        to next: Coordinate3D,
+        distance: Double,
+        limit: Double
+    ) -> Polygon? {
+        let proj = curr.projection
+
+        // Project to 3857 for Euclidean offset‑edge intersection
+        let p = prev.projected(to: .epsg3857)
+        let c = curr.projected(to: .epsg3857)
+        let n = next.projected(to: .epsg3857)
+
+        let dx1 = c.x - p.x; let dy1 = c.y - p.y
+        let dx2 = n.x - c.x; let dy2 = n.y - c.y
+        let len1 = sqrt(dx1 * dx1 + dy1 * dy1)
+        let len2 = sqrt(dx2 * dx2 + dy2 * dy2)
+        guard len1 > GISTool.intersectionEpsilon,
+              len2 > GISTool.intersectionEpsilon else { return nil }
+
+        let e1x = dx1 / len1; let e1y = dy1 / len1
+        let e2x = dx2 / len2; let e2y = dy2 / len2
+
+        let cross = dx1 * dy2 - dy1 * dx2
+        guard abs(cross) > GISTool.determinantEpsilon * len1 * len2
+        else { return nil }
+
+        let d = distance
+
+        // Outer side normals and opposite (inner) normals
+        let onx1: Double, ony1: Double, onx2: Double, ony2: Double
+        let inx1: Double, iny1: Double, inx2: Double, iny2: Double
+
+        if cross > 0 {
+            onx1 = e1y;  ony1 = -e1x
+            onx2 = e2y;  ony2 = -e2x
+            inx1 = -e1y; iny1 = e1x
+            inx2 = -e2y; iny2 = e2x
+        }
+        else {
+            onx1 = -e1y; ony1 = e1x
+            onx2 = -e2y; ony2 = e2x
+            inx1 = e1y;  iny1 = -e1x
+            inx2 = e2y;  iny2 = -e2x
+        }
+
+        // Miter point = intersection of the two offset‑edge lines
+        let oa1 = Coordinate3D(
+            x: p.x + d * onx1,
+            y: p.y + d * ony1,
+            projection: .epsg3857)
+        let oa2 = Coordinate3D(
+            x: c.x + d * onx1,
+            y: c.y + d * ony1,
+            projection: .epsg3857)
+        let ob1 = Coordinate3D(
+            x: c.x + d * onx2,
+            y: c.y + d * ony2,
+            projection: .epsg3857)
+        let ob2 = Coordinate3D(
+            x: n.x + d * onx2,
+            y: n.y + d * ony2,
+            projection: .epsg3857)
+
+        guard let miter3857 = Self.lineIntersect(oa1, oa2, ob1, ob2)
+        else {
+            return Self.bevelTriangle(
+                from: prev,
+                over: curr,
+                to: next,
+                distance: distance)
+        }
+
+        let mdx = miter3857.x - c.x
+        let mdy = miter3857.y - c.y
+        let miterLen = sqrt(mdx * mdx + mdy * mdy)
+
+        if miterLen > limit * d {
+            return Self.bevelTriangle(
+                from: prev,
+                over: curr,
+                to: next,
+                distance: distance)
+        }
+
+        let miterPt = miter3857.projected(to: proj)
+
+        let p1 = Coordinate3D(
+            x: c.x + d * onx1,
+            y: c.y + d * ony1,
+            projection: .epsg3857).projected(to: proj)
+        let p2 = Coordinate3D(
+            x: c.x + d * onx2,
+            y: c.y + d * ony2,
+            projection: .epsg3857).projected(to: proj)
+        let inner = Coordinate3D(
+            x: (c.x + d * inx1 + c.x + d * inx2) / 2.0,
+            y: (c.y + d * iny1 + c.y + d * iny2) / 2.0,
+            projection: .epsg3857).projected(to: proj)
+
+        return Polygon([[p1, miterPt, p2, inner, p1]])
     }
 
     private static func cutAtAntimeridianIfNeeded(_ result: MultiPolygon?) -> MultiPolygon? {

--- a/Tests/GISToolsTests/Algorithms/BufferTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BufferTests.swift
@@ -838,6 +838,93 @@ struct BufferTests {
                 "bevel=\(bevelArea), round=\(roundArea)")
     }
 
+    // MARK: - Miter join tests
+
+    @Test
+    func miterJoinBasic() throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+        ]))
+        let miter = try #require(line.buffered(
+            by: 10_000.0, endType: .butt, joinType: .miter()))
+        let bevel = try #require(line.buffered(
+            by: 10_000.0, endType: .butt, joinType: .bevel))
+
+        let miterArea = miter.polygons.reduce(0) { $0 + $1.area }
+        let bevelArea = bevel.polygons.reduce(0) { $0 + $1.area }
+
+        #expect(miter.isValid)
+        #expect(miterArea > bevelArea,
+                "miter=\(miterArea), bevel=\(bevelArea)")
+    }
+
+    @Test
+    func miterJoinLimitClamp() throws {
+        // Sharp turn forces miter to exceed the limit; should fall back to bevel
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.2, longitude: 0.0),
+            Coordinate3D(latitude: 0.1, longitude: 0.05),
+        ]))
+        let miter = try #require(line.buffered(
+            by: 10_000.0, endType: .butt, joinType: .miter(limit: 1.5)))
+        let bevel = try #require(line.buffered(
+            by: 10_000.0, endType: .butt, joinType: .bevel))
+
+        let miterArea = miter.polygons.reduce(0) { $0 + $1.area }
+        let bevelArea = bevel.polygons.reduce(0) { $0 + $1.area }
+
+        #expect(miter.isValid)
+        // With a tight limit the miter falls back to bevel — areas should match
+        let ratio = miterArea / bevelArea
+        #expect(ratio > 0.95 && ratio < 1.05,
+                "miter=\(miterArea), bevel=\(bevelArea), ratio=\(ratio)")
+    }
+
+    @Test
+    func miterJoin3857() throws {
+        let line = try #require(LineString([
+            Coordinate3D(x: 0.0, y: 0.0),
+            Coordinate3D(x: 10.0, y: 0.0),
+            Coordinate3D(x: 10.0, y: 10.0),
+        ]))
+        let miter = try #require(line.buffered(
+            by: 1.0, endType: .butt, joinType: .miter()))
+        let bevel = try #require(line.buffered(
+            by: 1.0, endType: .butt, joinType: .bevel))
+
+        let miterArea = miter.polygons.reduce(0) { $0 + $1.area }
+        let bevelArea = bevel.polygons.reduce(0) { $0 + $1.area }
+
+        #expect(miter.isValid)
+        #expect(miterArea > bevelArea,
+                "miter=\(miterArea), bevel=\(bevelArea)")
+    }
+
+    @Test
+    func miterJoinOnPolygon() throws {
+        let poly = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let miter = try #require(poly.buffered(
+            by: 10_000.0, joinType: .miter()))
+        let bevel = try #require(poly.buffered(
+            by: 10_000.0, joinType: .bevel))
+
+        let miterArea = miter.polygons.reduce(0) { $0 + $1.area }
+        let bevelArea = bevel.polygons.reduce(0) { $0 + $1.area }
+
+        #expect(miter.isValid)
+        #expect(miterArea > bevelArea,
+                "miter=\(miterArea), bevel=\(bevelArea)")
+    }
+
     // MARK: - Showcase (disabled)
 
     // Dumps a GeoJSON FeatureCollection to the console showing all buffer
@@ -925,7 +1012,7 @@ struct BufferTests {
         // ════════════════════════════════════════════════════════════════
         // Bevel stress‑test section (separated spatially from above)
         // ════════════════════════════════════════════════════════════════
-        let bevelLat = 44.0
+        let bevelLat = 47.5
 
         /// Helper: buffer a line with bevel at the given longitude offset
         /// and also emit the original input line.
@@ -1078,6 +1165,94 @@ struct BufferTests {
             Coordinate3D(latitude: polyLat, longitude: 0.3),
             Coordinate3D(latitude: polyLat, longitude: 0.0),
         ], offset: 0.8, label: "concave poly")
+
+        // ════════════════════════════════════════════════════════════════
+        // Miter stress‑test section
+        // ════════════════════════════════════════════════════════════════
+        let miterLat = polyLat - 0.8
+
+        func addMiterLine(
+            _ coords: [Coordinate3D],
+            offset: Double,
+            limit: Double = 2.0,
+            label: String
+        ) throws {
+            let line = try #require(LineString(coords))
+            let shifted = line.translated(
+                distance: offset * 111_325.0 * cos(miterLat * .pi / 180.0),
+                direction: 90.0)
+            let mp = try #require(shifted.buffered(
+                by: distance, endType: .butt, joinType: .miter(limit: limit)))
+            for poly in mp.polygons {
+                addFeature(poly, [
+                    "miterTest": label,
+                    "section": "miter stress",
+                ])
+            }
+            addFeature(shifted, [
+                "miterTest": label,
+                "section": "miter stress",
+                "kind": "input",
+            ])
+        }
+
+        var miterOffset = 0.0
+
+        // 90° right turn — limit 2.0 shows clear miter
+        try addMiterLine([
+            Coordinate3D(latitude: miterLat, longitude: 0.0),
+            Coordinate3D(latitude: miterLat + 0.3, longitude: 0.0),
+            Coordinate3D(latitude: miterLat + 0.3, longitude: 0.3),
+        ], offset: miterOffset, label: "90° miter limit 2.0")
+        miterOffset += 0.8
+
+        // Same turn, limit 1.2 falls back to bevel
+        try addMiterLine([
+            Coordinate3D(latitude: miterLat, longitude: 0.0),
+            Coordinate3D(latitude: miterLat + 0.3, longitude: 0.0),
+            Coordinate3D(latitude: miterLat + 0.3, longitude: 0.3),
+        ], offset: miterOffset, limit: 1.2, label: "90° limit 1.2 → bevel")
+        miterOffset += 0.8
+
+        // Same turn, limit 5.0 allows long miter
+        try addMiterLine([
+            Coordinate3D(latitude: miterLat, longitude: 0.0),
+            Coordinate3D(latitude: miterLat + 0.3, longitude: 0.0),
+            Coordinate3D(latitude: miterLat + 0.3, longitude: 0.3),
+        ], offset: miterOffset, limit: 5.0, label: "90° miter limit 5.0")
+        miterOffset += 0.8
+
+        // Sharp acute (~30°) — miter vs bevel side‑by‑side
+        try addMiterLine([
+            Coordinate3D(latitude: miterLat, longitude: 0.0),
+            Coordinate3D(latitude: miterLat + 0.3, longitude: 0.0),
+            Coordinate3D(latitude: miterLat + 0.1, longitude: -0.15),
+        ], offset: miterOffset, limit: 5.0, label: "sharp ~30° miter")
+        miterOffset += 0.8
+
+        // Next row: miter polygon
+        miterOffset = 0.0
+        let miterPolyLat = miterLat - 0.8
+        let miterPoly = try #require(Polygon([[
+            Coordinate3D(latitude: miterPolyLat, longitude: 0.0),
+            Coordinate3D(latitude: miterPolyLat + 0.25, longitude: 0.0),
+            Coordinate3D(latitude: miterPolyLat + 0.25, longitude: 0.25),
+            Coordinate3D(latitude: miterPolyLat, longitude: 0.25),
+            Coordinate3D(latitude: miterPolyLat, longitude: 0.0),
+        ]]))
+        if let mp = miterPoly.buffered(by: distance, joinType: .miter()) {
+            for poly in mp.polygons {
+                addFeature(poly, [
+                    "miterTest": "rect poly miter",
+                    "section": "miter stress",
+                ])
+            }
+            addFeature(miterPoly, [
+                "miterTest": "rect poly miter",
+                "section": "miter stress",
+                "kind": "input",
+            ])
+        }
 
         let fc = FeatureCollection(allFeatures)
         fc.dump()

--- a/Tests/GISToolsTests/Algorithms/BufferTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BufferTests.swift
@@ -1,3 +1,6 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
 import Foundation
 @testable import GISTools
 import Testing
@@ -107,7 +110,7 @@ struct BufferTests {
             Coordinate3D(latitude: 47.56, longitude: 10.2),
             Coordinate3D(latitude: 47.56, longitude: 10.25),
         ]))
-        let result = try #require(lineString.buffered(by: GISTool.convertToMeters(1000, .meters)))
+        let result = try #require(lineString.buffered(by: GISTool.convertToMeters(1000, .meters), endType: .round))
         checkArea(result, try loadExpected("LineRoundResult"))
     }
 
@@ -118,7 +121,7 @@ struct BufferTests {
             Coordinate3D(latitude: 47.56, longitude: 10.2),
             Coordinate3D(latitude: 47.56, longitude: 10.25),
         ]))
-        let result = try #require(lineString.buffered(by: GISTool.convertToMeters(1000, .meters), lineEndStyle: .flat))
+        let result = try #require(lineString.buffered(by: GISTool.convertToMeters(1000, .meters), endType: .butt))
         checkArea(result, try loadExpected("LineFlatResult"))
     }
 
@@ -132,7 +135,7 @@ struct BufferTests {
             Coordinate3D(latitude: 47.65, longitude: 10.25),
             Coordinate3D(latitude: 47.70, longitude: 10.2),
         ]))
-        let result = try #require(lineString.buffered(by: GISTool.convertToMeters(1000, .meters)))
+        let result = try #require(lineString.buffered(by: GISTool.convertToMeters(1000, .meters), endType: .round))
         checkArea(result, try loadExpected("LongLineRoundResult"), tolerance: 0.15)
     }
 
@@ -146,7 +149,7 @@ struct BufferTests {
             Coordinate3D(latitude: 47.65, longitude: 10.25),
             Coordinate3D(latitude: 47.70, longitude: 10.2),
         ]))
-        let result = try #require(lineString.buffered(by: GISTool.convertToMeters(1000, .meters), lineEndStyle: .flat))
+        let result = try #require(lineString.buffered(by: GISTool.convertToMeters(1000, .meters), endType: .butt))
         checkArea(result, try loadExpected("LongLineFlatResult"), tolerance: 0.25)
     }
 
@@ -164,7 +167,7 @@ struct BufferTests {
                 Coordinate3D(latitude: 47.70, longitude: 10.2),
             ],
         ]))
-        let result = try #require(multiLineString.buffered(by: GISTool.convertToMeters(1000, .meters)))
+        let result = try #require(multiLineString.buffered(by: GISTool.convertToMeters(1000, .meters), endType: .round))
         checkArea(result, try loadExpected("MultiLineRoundResult"), tolerance: 0.25)
     }
 
@@ -182,7 +185,7 @@ struct BufferTests {
                 Coordinate3D(latitude: 47.70, longitude: 10.2),
             ],
         ]))
-        let result = try #require(multiLineString.buffered(by: GISTool.convertToMeters(1000, .meters), lineEndStyle: .flat))
+        let result = try #require(multiLineString.buffered(by: GISTool.convertToMeters(1000, .meters), endType: .butt))
         checkArea(result, try loadExpected("MultiLineFlatResult"))
     }
 
@@ -319,6 +322,7 @@ struct BufferTests {
             name: fixture.name,
             result: try #require(geoJson.buffered(
                 by: params.distance,
+                endType: .round,
                 unionType: fixture.unionType,
                 steps: params.steps)))
     }
@@ -335,6 +339,7 @@ struct BufferTests {
                 name: "issue-#900")
                 .buffered(
                     by: params.distance,
+                    endType: .round,
                     steps: params.steps)))
     }
 
@@ -388,7 +393,7 @@ struct BufferTests {
             Coordinate3D(latitude: 0.0, longitude: 170.0),
             Coordinate3D(latitude: 0.0, longitude: -170.0),
         ]))
-        let result = try #require(lineString.buffered(by: 100_000.0))
+        let result = try #require(lineString.buffered(by: 100_000.0, endType: .round))
         #expect(!result.polygons.contains(where: { $0.crossesAntimeridian }))
         #expect(result.polygons.count >= 2)
     }
@@ -400,7 +405,7 @@ struct BufferTests {
             Coordinate3D(latitude: 0.0, longitude: 178.0),
             Coordinate3D(latitude: 1.0, longitude: 179.0),
         ]))
-        let result = try #require(lineString.buffered(by: 50_000.0))
+        let result = try #require(lineString.buffered(by: 50_000.0, endType: .round))
         #expect(!result.polygons.contains(where: { $0.crossesAntimeridian }))
     }
 
@@ -651,6 +656,158 @@ struct BufferTests {
                 #expect(coord.latitude >= -90.0 && coord.latitude <= 90.0)
             }
         }
+    }
+
+    // MARK: - Square end type
+
+    // Validates that square end buffer produces a larger area than flat end.
+    @Test
+    func squareEndLargerThanButt() throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 48.0, longitude: 2.0),
+            Coordinate3D(latitude: 48.0, longitude: 2.1),
+        ]))
+        let butt = try #require(line.buffered(by: 5_000.0, endType: .butt))
+        let square = try #require(line.buffered(by: 5_000.0, endType: .square))
+        let buttArea = butt.polygons.reduce(0) { $0 + $1.area }
+        let squareArea = square.polygons.reduce(0) { $0 + $1.area }
+        #expect(squareArea > buttArea)
+        #expect(square.isValid)
+    }
+
+    // Validates that square end buffer on a polygon falls back to polygon behavior.
+    @Test
+    func squareEndPolygon() throws {
+        let poly = try #require(Polygon([[
+            Coordinate3D(latitude: 48.0, longitude: 2.0),
+            Coordinate3D(latitude: 48.0, longitude: 2.1),
+            Coordinate3D(latitude: 48.1, longitude: 2.1),
+            Coordinate3D(latitude: 48.1, longitude: 2.0),
+            Coordinate3D(latitude: 48.0, longitude: 2.0),
+        ]]))
+        let result = try #require(poly.buffered(by: 1_000.0, endType: .square))
+        #expect(result.polygons.isNotEmpty)
+        #expect(result.polygons[0].isValid)
+    }
+
+    // Validates square end on a multi-line string.
+    @Test
+    func squareEndMultiLine() throws {
+        let mls = MultiLineString([
+            [
+                Coordinate3D(latitude: 48.0, longitude: 2.0),
+                Coordinate3D(latitude: 48.0, longitude: 2.1),
+            ],
+            [
+                Coordinate3D(latitude: 48.1, longitude: 2.0),
+                Coordinate3D(latitude: 48.1, longitude: 2.1),
+            ],
+        ])!
+        let result = try #require(mls.buffered(by: 2_000.0, endType: .square))
+        #expect(result.polygons.isNotEmpty)
+    }
+
+    // MARK: - Joined end type
+
+    @Test
+    func joinedEndBasic() throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 48.0, longitude: 2.0),
+            Coordinate3D(latitude: 48.0, longitude: 2.1),
+        ]))
+        let joined = try #require(line.buffered(by: 5_000.0, endType: .joined))
+        let square = try #require(line.buffered(by: 5_000.0, endType: .square))
+        let joinedArea = joined.polygons.reduce(0) { $0 + $1.area }
+        let squareArea = square.polygons.reduce(0) { $0 + $1.area }
+        #expect(joinedArea > squareArea)
+        #expect(joined.isValid)
+    }
+
+    // MARK: - Polygon end type
+
+    @Test
+    func polygonEndBasic() throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 48.0, longitude: 2.0),
+            Coordinate3D(latitude: 48.0, longitude: 2.1),
+        ]))
+        let polygon = try #require(line.buffered(by: 5_000.0, endType: .polygon))
+        let butt = try #require(line.buffered(by: 5_000.0, endType: .butt))
+        let polyArea = polygon.polygons.reduce(0) { $0 + $1.area }
+        let buttArea = butt.polygons.reduce(0) { $0 + $1.area }
+        // Polygon end should bridge the gap, making area visibly larger
+        #expect(polyArea > buttArea)
+        #expect(polygon.isValid)
+    }
+
+    // MARK: - Showcase (disabled)
+
+    // Dumps a GeoJSON FeatureCollection to the console showing all buffer
+    // join and end type combinations. Run locally to visually inspect the
+    // results at https://geojson.io.
+    @Test//(.disabled("Enable locally to dump GeoJSON to console"))
+    func bufferShowcase() async throws {
+        let baseLine = try #require(LineString([
+            Coordinate3D(latitude: 48.0, longitude: 2.0),
+            Coordinate3D(latitude: 48.0, longitude: 2.5),
+            Coordinate3D(latitude: 48.3, longitude: 2.0),
+            Coordinate3D(latitude: 48.3, longitude: 2.5),
+        ]))
+        let distance: CLLocationDistance = 5_000.0
+        var allFeatures: [Feature] = []
+
+        let joinTypes: [(label: String, join: BufferJoinType)] = [
+            ("miter", .miter()),
+            ("bevel", .bevel),
+            ("square_join", .square),
+            ("round_join", .round),
+        ]
+
+        let endTypes: [(label: String, end: BufferEndType)] = [
+            ("butt", .butt),
+            ("square_end", .square),
+            ("round_end", .round),
+            ("polygon", .polygon),
+            ("joined", .joined),
+        ]
+
+        // Row: different join types on the same line
+        var lonOffset = 0.0
+        for (joinLabel, joinType) in joinTypes {
+            let line = baseLine.translated(
+                distance: lonOffset * 111_325.0 * cos(48.0 * .pi / 180.0),
+                direction: 90.0)
+            let mp = try #require(line.buffered(by: distance, endType: .butt, joinType: joinType))
+            for poly in mp.polygons {
+                var feature = Feature(poly)
+                feature.setProperty(joinLabel, for: "joinType")
+                feature.setProperty("butt", for: "endType")
+                allFeatures.append(feature)
+            }
+            lonOffset += 1.0
+        }
+
+        // Next row: different end types
+        lonOffset = 0.0
+        for (endLabel, endType) in endTypes {
+            let line = baseLine.translated(
+                distance: -0.5 * 111_325.0,
+                direction: 0.0)
+            let line2 = line.translated(
+                distance: lonOffset * 111_325.0 * cos(48.0 * .pi / 180.0),
+                direction: 90.0)
+            let mp = try #require(line2.buffered(by: distance, endType: endType, joinType: .miter()))
+            for poly in mp.polygons {
+                var feature = Feature(poly)
+                feature.setProperty("miter", for: "joinType")
+                feature.setProperty(endLabel, for: "endType")
+                allFeatures.append(feature)
+            }
+            lonOffset += 1.0
+        }
+
+        let fc = FeatureCollection(allFeatures)
+        fc.dump()
     }
 
 }

--- a/Tests/GISToolsTests/Algorithms/BufferTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BufferTests.swift
@@ -707,22 +707,6 @@ struct BufferTests {
         #expect(result.polygons.isNotEmpty)
     }
 
-    // MARK: - Joined end type
-
-    @Test
-    func joinedEndBasic() throws {
-        let line = try #require(LineString([
-            Coordinate3D(latitude: 48.0, longitude: 2.0),
-            Coordinate3D(latitude: 48.0, longitude: 2.1),
-        ]))
-        let joined = try #require(line.buffered(by: 5_000.0, endType: .joined))
-        let square = try #require(line.buffered(by: 5_000.0, endType: .square))
-        let joinedArea = joined.polygons.reduce(0) { $0 + $1.area }
-        let squareArea = square.polygons.reduce(0) { $0 + $1.area }
-        #expect(joinedArea > squareArea)
-        #expect(joined.isValid)
-    }
-
     // MARK: - Polygon end type
 
     @Test
@@ -912,7 +896,6 @@ struct BufferTests {
             ("square_end", .square),
             ("round_end", .round),
             ("polygon", .polygon),
-            ("joined", .joined),
         ]
         for (endLabel, endType) in endTypes {
             let line = baseLine.translated(

--- a/Tests/GISToolsTests/Algorithms/BufferTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BufferTests.swift
@@ -740,28 +740,173 @@ struct BufferTests {
         #expect(polygon.isValid)
     }
 
+    // MARK: - Bevel join tests
+
+    @Test
+    func bevelJoinBasic() throws {
+        let line = try #require(LineString([
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+        ]))
+        let bevel = try #require(line.buffered(
+            by: 10_000.0, endType: .butt, joinType: .bevel))
+        let round = try #require(line.buffered(
+            by: 10_000.0, endType: .butt, joinType: .round))
+
+        let bevelArea = bevel.polygons.reduce(0) { $0 + $1.area }
+        let roundArea = round.polygons.reduce(0) { $0 + $1.area }
+
+        #expect(bevel.isValid)
+        #expect(round.isValid)
+        // Bevel should have less area than round (no arc filling the corner)
+        #expect(bevelArea < roundArea,
+                "bevel=\(bevelArea), round=\(roundArea)")
+    }
+
+    @Test
+    func bevelJoin3857() throws {
+        let line = try #require(LineString([
+            Coordinate3D(x: 0.0, y: 0.0),
+            Coordinate3D(x: 10.0, y: 0.0),
+            Coordinate3D(x: 0.0, y: 10.0),
+        ]))
+        let bevel = try #require(line.buffered(
+            by: 1.0, endType: .butt, joinType: .bevel))
+        let round = try #require(line.buffered(
+            by: 1.0, endType: .butt, joinType: .round))
+
+        let bevelArea = bevel.polygons.reduce(0) { $0 + $1.area }
+        let roundArea = round.polygons.reduce(0) { $0 + $1.area }
+
+        #expect(bevel.isValid)
+        #expect(round.isValid)
+        #expect(bevelArea < roundArea,
+                "bevel=\(bevelArea), round=\(roundArea)")
+    }
+
+    @Test
+    func bevelJoinOnPolygon() throws {
+        let poly = try #require(Polygon([[
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 0.0),
+            Coordinate3D(latitude: 1.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 1.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]]))
+        let bevel = try #require(poly.buffered(
+            by: 10_000.0, joinType: .bevel))
+        let round = try #require(poly.buffered(
+            by: 10_000.0, joinType: .round))
+
+        let bevelArea = bevel.polygons.reduce(0) { $0 + $1.area }
+        let roundArea = round.polygons.reduce(0) { $0 + $1.area }
+
+        #expect(bevel.isValid)
+        #expect(round.isValid)
+        #expect(bevelArea < roundArea,
+                "bevel=\(bevelArea), round=\(roundArea)")
+    }
+
+    @Test
+    func bevelJoinOnPolygon3857() throws {
+        let poly = Polygon([[
+            Coordinate3D(x: 0.0, y: 0.0),
+            Coordinate3D(x: 10.0, y: 0.0),
+            Coordinate3D(x: 10.0, y: 10.0),
+            Coordinate3D(x: 0.0, y: 10.0),
+            Coordinate3D(x: 0.0, y: 0.0),
+        ]])!
+        let bevel = try #require(poly.buffered(
+            by: 1.0, joinType: .bevel))
+        let round = try #require(poly.buffered(
+            by: 1.0, joinType: .round))
+
+        let bevelArea = bevel.polygons.reduce(0) { $0 + $1.area }
+        let roundArea = round.polygons.reduce(0) { $0 + $1.area }
+
+        #expect(bevel.isValid)
+        #expect(round.isValid)
+        #expect(bevelArea < roundArea,
+                "bevel=\(bevelArea), round=\(roundArea)")
+    }
+
+    @Test
+    func bevelJoinMultiLine() throws {
+        let mls = MultiLineString([
+            [
+                Coordinate3D(latitude: 0.0, longitude: 0.0),
+                Coordinate3D(latitude: 1.0, longitude: 0.0),
+                Coordinate3D(latitude: 0.0, longitude: 1.0),
+            ],
+        ])!
+        let bevel = try #require(mls.buffered(
+            by: 10_000.0, endType: .butt, joinType: .bevel))
+        let round = try #require(mls.buffered(
+            by: 10_000.0, endType: .butt, joinType: .round))
+
+        let bevelArea = bevel.polygons.reduce(0) { $0 + $1.area }
+        let roundArea = round.polygons.reduce(0) { $0 + $1.area }
+
+        #expect(bevel.isValid)
+        #expect(round.isValid)
+        #expect(bevelArea < roundArea,
+                "bevel=\(bevelArea), round=\(roundArea)")
+    }
+
     // MARK: - Showcase (disabled)
 
     // Dumps a GeoJSON FeatureCollection to the console showing all buffer
     // join and end type combinations. Run locally to visually inspect the
     // results at https://geojson.io.
-    @Test(.disabled("Enable locally to dump GeoJSON to console"))
+    @Test//(.disabled("Enable locally to dump GeoJSON to console"))
     func bufferShowcase() async throws {
-        let baseLine = try #require(LineString([
-            Coordinate3D(latitude: 48.0, longitude: 2.0),
-            Coordinate3D(latitude: 48.0, longitude: 2.5),
-            Coordinate3D(latitude: 48.3, longitude: 2.0),
-            Coordinate3D(latitude: 48.3, longitude: 2.5),
-        ]))
         let distance: CLLocationDistance = 5_000.0
         var allFeatures: [Feature] = []
 
+        func addFeature<T: GeoJsonGeometry>(_ geometry: T, _ props: [String: String]) {
+            var f = Feature(geometry)
+            for (k, v) in props { f.setProperty(v, for: k) }
+            allFeatures.append(f)
+        }
+
+        // ── Row 1: join types (miter / bevel / round) ──
+        let baseLine = try #require(LineString([
+            Coordinate3D(latitude: 49.0, longitude: 2.0),
+            Coordinate3D(latitude: 49.0, longitude: 2.5),
+            Coordinate3D(latitude: 49.3, longitude: 2.0),
+            Coordinate3D(latitude: 49.3, longitude: 2.5),
+        ]))
         let joinTypes: [(label: String, join: BufferJoinType)] = [
             ("miter", .miter()),
             ("bevel", .bevel),
             ("round_join", .round),
         ]
+        var lonOffset = 0.0
+        for (joinLabel, joinType) in joinTypes {
+            let line = baseLine.translated(
+                distance: lonOffset * 111_325.0 * cos(49.0 * .pi / 180.0),
+                direction: 90.0)
+            let mp = try #require(line.buffered(
+                by: distance, endType: .butt, joinType: joinType))
+            for poly in mp.polygons {
+                addFeature(poly, [
+                    "joinType": joinLabel,
+                    "endType": "butt",
+                    "section": "join types",
+                ])
+            }
+            addFeature(line, [
+                "joinType": joinLabel,
+                "endType": "butt",
+                "section": "join types",
+                "kind": "input",
+            ])
+            lonOffset += 1.0
+        }
 
+        // ── Row 2: end types (butt / square / round / polygon / joined) ──
+        lonOffset = 0.0
         let endTypes: [(label: String, end: BufferEndType)] = [
             ("butt", .butt),
             ("square_end", .square),
@@ -769,41 +914,187 @@ struct BufferTests {
             ("polygon", .polygon),
             ("joined", .joined),
         ]
-
-        // Row: different join types on the same line
-        var lonOffset = 0.0
-        for (joinLabel, joinType) in joinTypes {
-            let line = baseLine.translated(
-                distance: lonOffset * 111_325.0 * cos(48.0 * .pi / 180.0),
-                direction: 90.0)
-            let mp = try #require(line.buffered(by: distance, endType: .butt, joinType: joinType))
-            for poly in mp.polygons {
-                var feature = Feature(poly)
-                feature.setProperty(joinLabel, for: "joinType")
-                feature.setProperty("butt", for: "endType")
-                allFeatures.append(feature)
-            }
-            lonOffset += 1.0
-        }
-
-        // Next row: different end types
-        lonOffset = 0.0
         for (endLabel, endType) in endTypes {
             let line = baseLine.translated(
                 distance: -0.5 * 111_325.0,
                 direction: 0.0)
             let line2 = line.translated(
-                distance: lonOffset * 111_325.0 * cos(48.0 * .pi / 180.0),
+                distance: lonOffset * 111_325.0 * cos(48.5 * .pi / 180.0),
                 direction: 90.0)
-            let mp = try #require(line2.buffered(by: distance, endType: endType, joinType: .miter()))
+            let mp = try #require(line2.buffered(
+                by: distance, endType: endType, joinType: .miter()))
             for poly in mp.polygons {
-                var feature = Feature(poly)
-                feature.setProperty("miter", for: "joinType")
-                feature.setProperty(endLabel, for: "endType")
-                allFeatures.append(feature)
+                addFeature(poly, [
+                    "joinType": "miter",
+                    "endType": endLabel,
+                    "section": "end types",
+                ])
             }
+            addFeature(line2, [
+                "joinType": "miter",
+                "endType": endLabel,
+                "section": "end types",
+                "kind": "input",
+            ])
             lonOffset += 1.0
         }
+
+        // ════════════════════════════════════════════════════════════════
+        // Bevel stress‑test section (separated spatially from above)
+        // ════════════════════════════════════════════════════════════════
+        let bevelLat = 44.0
+
+        /// Helper: buffer a line with bevel at the given longitude offset
+        /// and also emit the original input line.
+        func addBevelLine(
+            _ coords: [Coordinate3D],
+            offset: Double,
+            label: String
+        ) throws {
+            let line = try #require(LineString(coords))
+            let shifted = line.translated(
+                distance: offset * 111_325.0 * cos(bevelLat * .pi / 180.0),
+                direction: 90.0)
+            let mp = try #require(shifted.buffered(
+                by: distance, endType: .butt, joinType: .bevel))
+            for poly in mp.polygons {
+                addFeature(poly, [
+                    "bevelTest": label,
+                    "section": "bevel stress",
+                ])
+            }
+            addFeature(shifted, [
+                "bevelTest": label,
+                "section": "bevel stress",
+                "kind": "input",
+            ])
+        }
+
+        var bevelOffset = 0.0
+
+        // Sharp left turn (~30°)
+        try addBevelLine([
+            Coordinate3D(latitude: bevelLat, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.5, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.3, longitude: -0.15),
+        ], offset: bevelOffset, label: "sharp left ~30°")
+        bevelOffset += 0.8
+
+        // Sharp right turn (~30°)
+        try addBevelLine([
+            Coordinate3D(latitude: bevelLat, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.5, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.3, longitude: 0.15),
+        ], offset: bevelOffset, label: "sharp right ~30°")
+        bevelOffset += 0.8
+
+        // Obtuse turn (~135°)
+        try addBevelLine([
+            Coordinate3D(latitude: bevelLat, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.5, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.8, longitude: -0.15),
+        ], offset: bevelOffset, label: "obtuse ~135°")
+        bevelOffset += 0.8
+
+        // Near‑collinear (~175°)
+        try addBevelLine([
+            Coordinate3D(latitude: bevelLat, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.5, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.98, longitude: 0.02),
+        ], offset: bevelOffset, label: "near-collinear ~175°")
+        bevelOffset += 0.8
+
+        // V‑shape (left then right turn)
+        try addBevelLine([
+            Coordinate3D(latitude: bevelLat, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.3, longitude: 0.3),
+            Coordinate3D(latitude: bevelLat + 0.6, longitude: 0.0),
+        ], offset: bevelOffset, label: "V-shape L→R")
+        bevelOffset += 0.8
+
+        // Zigzag (right then left)
+        try addBevelLine([
+            Coordinate3D(latitude: bevelLat, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.3, longitude: -0.15),
+            Coordinate3D(latitude: bevelLat + 0.6, longitude: 0.0),
+            Coordinate3D(latitude: bevelLat + 0.9, longitude: -0.15),
+        ], offset: bevelOffset, label: "zigzag R→L→R")
+        bevelOffset += 1.0
+
+        // Next row: 90°‑turn square (4 vertices)
+        bevelOffset = 0.0
+        let row2Lat = bevelLat - 0.8
+        try addBevelLine([
+            Coordinate3D(latitude: row2Lat, longitude: 0.0),
+            Coordinate3D(latitude: row2Lat + 0.3, longitude: 0.0),
+            Coordinate3D(latitude: row2Lat + 0.3, longitude: 0.3),
+            Coordinate3D(latitude: row2Lat, longitude: 0.3),
+        ], offset: 0.0, label: "90°-turn path")
+        bevelOffset += 0.8
+
+        // Very short middle segment
+        try addBevelLine([
+            Coordinate3D(latitude: row2Lat, longitude: 0.0),
+            Coordinate3D(latitude: row2Lat + 0.01, longitude: 0.2),
+            Coordinate3D(latitude: row2Lat + 0.4, longitude: 0.0),
+        ], offset: bevelOffset, label: "short middle seg")
+        bevelOffset += 0.8
+
+        // Sharp spike (back‑and‑forth)
+        try addBevelLine([
+            Coordinate3D(latitude: row2Lat, longitude: 0.0),
+            Coordinate3D(latitude: row2Lat + 0.3, longitude: 0.0),
+            Coordinate3D(latitude: row2Lat + 0.15, longitude: -0.15),
+            Coordinate3D(latitude: row2Lat + 0.5, longitude: 0.0),
+        ], offset: bevelOffset, label: "spike")
+        bevelOffset += 0.8
+
+        // Next row: polygons with bevel
+        let polyLat = row2Lat - 0.8
+
+        /// Helper: buffer a polygon with bevel, emitting both the buffer
+        /// and the original polygon boundary.
+        func addBevelPolygon(
+            _ ring: [Coordinate3D],
+            offset: Double,
+            label: String
+        ) {
+            guard let poly = Polygon([ring]) else { return }
+            let shifted = poly.translated(
+                distance: offset * 111_325.0 * cos(polyLat * .pi / 180.0),
+                direction: 90.0)
+            guard let mp = shifted.buffered(by: distance, joinType: .bevel) else { return }
+            for p in mp.polygons {
+                addFeature(p, [
+                    "bevelTest": label,
+                    "section": "bevel polys",
+                ])
+            }
+            addFeature(shifted, [
+                "bevelTest": label,
+                "section": "bevel polys",
+                "kind": "input",
+            ])
+        }
+
+        // Simple rectangle polygon
+        addBevelPolygon([
+            Coordinate3D(latitude: polyLat, longitude: 0.0),
+            Coordinate3D(latitude: polyLat + 0.3, longitude: 0.0),
+            Coordinate3D(latitude: polyLat + 0.3, longitude: 0.3),
+            Coordinate3D(latitude: polyLat, longitude: 0.3),
+            Coordinate3D(latitude: polyLat, longitude: 0.0),
+        ], offset: 0.0, label: "rect poly")
+
+        // Concave polygon (arrow‑head shape)
+        addBevelPolygon([
+            Coordinate3D(latitude: polyLat, longitude: 0.0),
+            Coordinate3D(latitude: polyLat + 0.3, longitude: 0.0),
+            Coordinate3D(latitude: polyLat + 0.15, longitude: 0.15),
+            Coordinate3D(latitude: polyLat + 0.3, longitude: 0.3),
+            Coordinate3D(latitude: polyLat, longitude: 0.3),
+            Coordinate3D(latitude: polyLat, longitude: 0.0),
+        ], offset: 0.8, label: "concave poly")
 
         let fc = FeatureCollection(allFeatures)
         fc.dump()

--- a/Tests/GISToolsTests/Algorithms/BufferTests.swift
+++ b/Tests/GISToolsTests/Algorithms/BufferTests.swift
@@ -745,7 +745,7 @@ struct BufferTests {
     // Dumps a GeoJSON FeatureCollection to the console showing all buffer
     // join and end type combinations. Run locally to visually inspect the
     // results at https://geojson.io.
-    @Test//(.disabled("Enable locally to dump GeoJSON to console"))
+    @Test(.disabled("Enable locally to dump GeoJSON to console"))
     func bufferShowcase() async throws {
         let baseLine = try #require(LineString([
             Coordinate3D(latitude: 48.0, longitude: 2.0),
@@ -759,7 +759,6 @@ struct BufferTests {
         let joinTypes: [(label: String, join: BufferJoinType)] = [
             ("miter", .miter()),
             ("bevel", .bevel),
-            ("square_join", .square),
             ("round_join", .round),
         ]
 


### PR DESCRIPTION
## Summary

Implements `.bevel` and `.miter(limit:)` buffer join types for LineString and Polygon buffering, matching the join styles offered by turf.js.

## Changes

### Bevel join
- At interior vertices, replaces circles with a triangle that fills the gap between adjacent segment rectangles on the outer corner side
- Turn direction determines which side gets the bevel (right turn → left gap, left turn → right gap)
- Inner point placed at midpoint of opposite-side offsets, deep inside both rectangle overlap regions so only the outer bevel edge remains visible after union

### Miter join
- Extends offset edges to their intersection point (the miter point)
- Falls back to bevel when miter length exceeds `limit × distance`
- Computes offset-edge intersection in EPSG:3857 Euclidean space for correctness across all projections
- Shared `lineIntersect` helper extracted for reuse

### Other
- Removed `.square` join type (not offered by turf.js)
- Removed `.joined` end type (incorrect implementation)
- Sorted all three enums alphabetically
- Enforced one-argument-per-line for multi-line function calls
- Updated AGENTS.md with call-site style convention

### Tests
- 9 new tests: 5 bevel + 4 miter across EPSG:4326, EPSG:3857, polygons, and edge cases
- Extended showcase with bevel and miter stress-test sections

Closes #154