### PR TITLE
Add GeoPackage spatial index (gpkg_rtree_index) support

### DIFF
--- a/Sources/GISTools/Extensions/StringExtensions.swift
+++ b/Sources/GISTools/Extensions/StringExtensions.swift
@@ -39,4 +39,10 @@ extension String {
         self.data(using: .utf8)
     }
 
+    /// Returns `true` when the string is not empty.
+    @inlinable
+    var isNotEmpty: Bool {
+        !isEmpty
+    }
+
 }

--- a/Sources/GISToolsGeoPackage/GeoPackage.swift
+++ b/Sources/GISToolsGeoPackage/GeoPackage.swift
@@ -313,4 +313,48 @@ enum GeoPackage {
         return try GeoPackage.readContents(from: db)
     }
 
+    // MARK: - Spatial index helpers
+
+    /// Returns the SQL identifier of the rtree virtual table for a given
+    /// feature table and geometry column.
+    static func rTreeTableName(for table: String, column: String) -> String {
+        GeoPackage.sanitizeIdentifier("rtree_\(table)_\(column)")
+    }
+
+    /// Checks whether a spatial (rtree) index exists for the given feature
+    /// table and geometry column.
+    ///
+    /// Returns `true` if either `gpkg_extensions` registers a
+    /// `gpkg_rtree_index` extension for the table/column pair, or the
+    /// rtree virtual table exists in `sqlite_master`.
+    static func hasRTreeIndex(
+        for table: String,
+        column: String,
+        in db: SQLiteDB
+    ) throws -> Bool {
+        // Check gpkg_extensions
+        let escapedTable = GeoPackage.sanitizeStringLiteral(table)
+        let escapedCol = GeoPackage.sanitizeStringLiteral(column)
+        let extRows = try db.query("""
+            SELECT 1 FROM gpkg_extensions
+            WHERE table_name = \(escapedTable)
+              AND column_name = \(escapedCol)
+              AND extension_name = 'gpkg_rtree_index'
+            LIMIT 1;
+            """)
+        if !extRows.isEmpty {
+            return true
+        }
+
+        // Fallback: check if the rtree virtual table exists
+        let rtreeName = GeoPackage.sanitizeStringLiteral("rtree_\(table)_\(column)")
+        let tableRows = try db.query("""
+            SELECT 1 FROM sqlite_master
+            WHERE type = 'table'
+              AND name = \(rtreeName)
+            LIMIT 1;
+            """)
+        return tableRows.isEmpty == false
+    }
+
 }

--- a/Sources/GISToolsGeoPackage/GeoPackageReader.swift
+++ b/Sources/GISToolsGeoPackage/GeoPackageReader.swift
@@ -8,14 +8,21 @@ extension FeatureCollection {
     /// - Parameters:
     ///   - url: The file URL of the GeoPackage database.
     ///   - table: The name of the feature table to read (default `"features"`).
+    ///   - boundingBox: An optional bounding box to filter features. When
+    ///     set and the GeoPackage has a spatial (rtree) index, only
+    ///     features within or intersecting the bounding box are returned.
     /// - Throws: A ``GeoPackageError`` if the file cannot be read or is invalid.
     public init(
         geopackage url: URL,
-        table: String = "features"
+        table: String = "features",
+        boundingBox: BoundingBox? = nil
     ) throws {
         let db = try SQLiteDB(path: url.path)
         try GeoPackage.validateMetadata(in: db)
-        let features = try GeoPackageReader.readFeatures(from: db, table: table)
+        let features = try GeoPackageReader.readFeatures(
+            from: db,
+            table: table,
+            boundingBox: boundingBox)
         self.init(features)
     }
 
@@ -27,7 +34,8 @@ private enum GeoPackageReader {
 
     static func readFeatures(
         from db: SQLiteDB,
-        table: String
+        table: String,
+        boundingBox: BoundingBox? = nil
     ) throws -> [Feature] {
         // Get geometry column metadata
         let escapedTable = GeoPackage.sanitizeStringLiteral(table)
@@ -54,8 +62,37 @@ private enum GeoPackageReader {
             throw GeoPackageError.invalidGeoPackage("Table '\(table)' has no columns")
         }
 
-        // Read all rows
-        let rows: [[String: Sendable]] = try db.query("SELECT * FROM \(quotedTable);")
+        // Resolve row IDs — use rtree index when available
+        let rowIds: [Int]?
+        if let bbox = boundingBox {
+            if try GeoPackage.hasRTreeIndex(for: table, column: geomColumnName, in: db) {
+                rowIds = try Self.readRowIdsFromRTree(
+                    db: db,
+                    table: table,
+                    column: geomColumnName,
+                    boundingBox: bbox)
+            }
+            else {
+                // No rtree — nil signals in-memory filter below
+                rowIds = nil
+            }
+        }
+        else {
+            rowIds = nil
+        }
+
+        // Build the SQL query
+        let rows: [[String: Sendable]]
+        if let rowIds,
+           !rowIds.isEmpty,
+           boundingBox != nil
+        {
+            let idList = rowIds.map(String.init).joined(separator: ", ")
+            rows = try db.query("SELECT * FROM \(quotedTable) WHERE rowid IN (\(idList));")
+        }
+        else {
+            rows = try db.query("SELECT * FROM \(quotedTable);")
+        }
 
         var features: [Feature] = []
         for row in rows {
@@ -63,16 +100,13 @@ private enum GeoPackageReader {
                 continue
             }
 
-            // Parse the geometry
             let header = try WKBHeader.parse(wkbData)
             let geoJson = try WKBCoder.decode(wkb: header.wkbData, sourceSrid: header.srid)
 
-            // Determine target projection from the table's SRS
             let projection = GeoPackage.projection(for: srsId)
             let projectedGeoJson = geoJson.projected(to: projection)
             let geometry = projectedGeoJson
 
-            // Build properties
             var properties: [String: Sendable] = [:]
             for col in columnNames where col != geomColumnName {
                 guard let value = row[col] else { continue }
@@ -88,7 +122,38 @@ private enum GeoPackageReader {
             features.append(feature)
         }
 
+        // If we couldn't use rtree but a bounding box was requested,
+        // filter in memory as a fallback
+        if let bbox = boundingBox,
+           rowIds == nil
+        {
+            features = features.filter { $0.intersects(bbox) }
+        }
+
         return features
+    }
+
+    /// Queries the rtree virtual table for rowids intersecting a bounding box.
+    private static func readRowIdsFromRTree(
+        db: SQLiteDB,
+        table: String,
+        column: String,
+        boundingBox: BoundingBox
+    ) throws -> [Int]? {
+        let rtreeName = GeoPackage.rTreeTableName(for: table, column: column)
+        let minX = boundingBox.southWest.longitude
+        let minY = boundingBox.southWest.latitude
+        let maxX = boundingBox.northEast.longitude
+        let maxY = boundingBox.northEast.latitude
+
+        let rows = try db.query("""
+            SELECT id FROM \(rtreeName)
+            WHERE minx <= \(maxX)
+              AND maxx >= \(minX)
+              AND miny <= \(maxY)
+              AND maxy >= \(minY);
+            """)
+        return rows.compactMap { $0["id"] as? Int }
     }
 
     private static func extractGeometryBlob(

--- a/Sources/GISToolsGeoPackage/GeoPackageWriter.swift
+++ b/Sources/GISToolsGeoPackage/GeoPackageWriter.swift
@@ -9,10 +9,13 @@ extension FeatureCollection {
     /// - Parameters:
     ///   - url: The file URL to write to.
     ///   - table: The name of the feature table to create (default `"features"`).
+    ///   - createSpatialIndex: If `true`, creates a `gpkg_rtree_index` spatial
+    ///     index for faster bounding-box queries (default `false`).
     /// - Throws: A ``GeoPackageError`` if the file cannot be written.
     public func writeGeopackage(
         to url: URL,
-        table: String = "features"
+        table: String = "features",
+        createSpatialIndex: Bool = false
     ) throws {
         // Remove existing file to start fresh
         if FileManager.default.fileExists(atPath: url.path) {
@@ -20,7 +23,11 @@ extension FeatureCollection {
         }
         let db = try SQLiteDB(path: url.path)
         try GeoPackage.createMetadata(in: db)
-        try GeoPackageWriter.writeFeatures(self, to: db, table: table)
+        try GeoPackageWriter.writeFeatures(
+            self,
+            to: db,
+            table: table,
+            createSpatialIndex: createSpatialIndex)
     }
 
 }
@@ -32,7 +39,8 @@ private enum GeoPackageWriter {
     static func writeFeatures(
         _ fc: FeatureCollection,
         to db: SQLiteDB,
-        table: String
+        table: String,
+        createSpatialIndex: Bool = false
     ) throws {
         let features = fc.features
         guard !features.isEmpty else {
@@ -80,7 +88,9 @@ private enum GeoPackageWriter {
         var maxY = -Double.infinity
 
         // Insert features
-        let colNamesQuoted = columnDefs.map { GeoPackage.sanitizeIdentifier($0.name) }.joined(separator: ", ")
+        let colNamesQuoted = columnDefs
+            .map { GeoPackage.sanitizeIdentifier($0.name) }
+            .joined(separator: ", ")
         let placeholders = columnDefs.map { _ in "?" }.joined(separator: ", ")
         let insertSQL = "INSERT INTO \(quotedTable) (\(colNamesQuoted)) VALUES (\(placeholders));"
 
@@ -132,6 +142,64 @@ private enum GeoPackageWriter {
             geomColumnName: geomColumnName,
             geoTypeName: geoTypeName,
             srsId: srsId)
+
+        // Create spatial index (rtree) if requested
+        if createSpatialIndex {
+            try createSpatialIndexOnTable(
+                table: table,
+                geomColumnName: geomColumnName,
+                srsId: srsId,
+                for: features,
+                db: db)
+        }
+    }
+
+    // MARK: - Spatial index
+
+    /// Creates a `gpkg_rtree_index` spatial index on the feature table.
+    private static func createSpatialIndexOnTable(
+        table: String,
+        geomColumnName: String,
+        srsId: Int,
+        for features: [Feature],
+        db: SQLiteDB
+    ) throws {
+        let rtreeName = GeoPackage.rTreeTableName(for: table, column: geomColumnName)
+
+        // Create rtree virtual table
+        try db.execute("""
+            CREATE VIRTUAL TABLE \(rtreeName)
+            USING rtree("id", "minx", "maxx", "miny", "maxy");
+            """)
+
+        // Insert bounding boxes for each feature
+        var rowId: Int64 = 1
+        for feature in features {
+            if let envelope = feature.boundingBox ?? feature.calculateBoundingBox() {
+                let minX = envelope.southWest.longitude
+                let minY = envelope.southWest.latitude
+                let maxX = envelope.northEast.longitude
+                let maxY = envelope.northEast.latitude
+                let sql = """
+                    INSERT INTO \(rtreeName) (id, minx, maxx, miny, maxy)
+                    VALUES (\(rowId), \(minX), \(maxX), \(minY), \(maxY));
+                    """
+                try db.execute(sql)
+            }
+            rowId += 1
+        }
+
+        // Register in gpkg_extensions
+        let escapedTable = GeoPackage.sanitizeStringLiteral(table)
+        let escapedCol = GeoPackage.sanitizeStringLiteral(geomColumnName)
+        try db.execute("""
+            INSERT INTO gpkg_extensions
+            (table_name, column_name, extension_name, definition, scope)
+            VALUES (\(escapedTable), \(escapedCol),
+            'gpkg_rtree_index',
+            'http://www.geopackage.org/spec120/#extension_rtree',
+            'write-only');
+            """)
     }
 
     // MARK: - Metadata

--- a/Tests/GISToolsGeoPackageTests/GeoPackageTests.swift
+++ b/Tests/GISToolsGeoPackageTests/GeoPackageTests.swift
@@ -342,13 +342,15 @@ struct GeoPackageTileTests {
         #expect(matrixSet?.tableName == "pyramid")
 
         let readMatrices = try TileReader.readTileMatrices(
-            for: "pyramid", in: db)
+            for: "pyramid",
+            in: db)
         #expect(readMatrices.count == 1)
         #expect(readMatrices[0].zoomLevel == 0)
         #expect(readMatrices[0].matrixWidth == 1)
 
         let readTiles = try TileReader.readAllTiles(
-            from: "pyramid", in: db)
+            from: "pyramid",
+            in: db)
         #expect(readTiles.count == 1)
         let readData = readTiles[TileKey(zoom: 0, column: 0, row: 0)]
         #expect(readData == tileData)
@@ -519,6 +521,109 @@ struct GeoPackageTileTests {
         #expect(featTables.contains(where: { $0.dataType == "features" }))
         #expect(featTables.first?.description != nil
                 || featTables.first?.identifier != nil)
+    }
+
+}
+
+// MARK: - Spatial index tests
+
+struct GeoPackageSpatialIndexTests {
+
+    private let tmpDir = URL(fileURLWithPath: "/tmp")
+
+    private func testUrl(_ name: String = #function) -> URL {
+        tmpDir.appendingPathComponent("gpkg_\(name).gpkg")
+    }
+
+    private func testFixture(_ name: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("TestData/\(name)")
+    }
+
+    // Validates reading with a bounding box on a GeoPackage with rtree
+    // returns fewer features than the full table.
+    @Test
+    func bboxFilteredReadUsesRTree() async throws {
+        let fixture = testFixture("ne_110m_admin_0_countries_from_geojson.gpkg")
+        let full = try FeatureCollection(geopackage: fixture, table: "ne_110m_admin_0_countries")
+        #expect(full.features.count == 177)
+
+        // Bounding box covering roughly Europe
+        let europe = BoundingBox(
+            southWest: Coordinate3D(latitude: 35.0, longitude: -10.0),
+            northEast: Coordinate3D(latitude: 60.0, longitude: 40.0))
+        let filtered = try FeatureCollection(
+            geopackage: fixture,
+            table: "ne_110m_admin_0_countries",
+            boundingBox: europe)
+        #expect(filtered.features.isNotEmpty)
+        #expect(filtered.features.count < full.features.count,
+                "Expected fewer features with bbox filter (\(filtered.features.count) vs \(full.features.count))")
+    }
+
+    // Validates bbox-filtered read falls back to full scan + in-memory
+    // filter when no rtree index exists.
+    @Test
+    func bboxFilteredReadFallback() async throws {
+        // Create a fresh GPKG without rtree
+        let point = Feature(Point(Coordinate3D(latitude: 45.0, longitude: 10.0)))
+        let fc = FeatureCollection([point])
+        try fc.writeGeopackage(to: testUrl(), createSpatialIndex: false)
+
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 44.0, longitude: 9.0),
+            northEast: Coordinate3D(latitude: 46.0, longitude: 11.0))
+        let filtered = try FeatureCollection(
+            geopackage: testUrl(),
+            table: "features",
+            boundingBox: bbox)
+        #expect(filtered.features.count == 1)
+    }
+
+    // Validates writing features with spatial index creates the rtree
+    // table and gpkg_extensions entry.
+    @Test
+    func writeWithSpatialIndex() async throws {
+        let features = [
+            Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0))),
+            Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0))),
+        ]
+        let fc = FeatureCollection(features)
+        try fc.writeGeopackage(to: testUrl(), createSpatialIndex: true)
+
+        // Verify rtree virtual table exists
+        let db = try SQLiteDB(path: testUrl().path)
+        defer { db.close() }
+
+        let hasRTree = try GeoPackage.hasRTreeIndex(
+            for: "features",
+            column: "geom",
+            in: db)
+        #expect(hasRTree)
+
+        // Verify gpkg_extensions
+        let extRows = try db.query(
+            "SELECT extension_name FROM gpkg_extensions WHERE table_name = 'features';")
+        #expect(!extRows.isEmpty)
+        #expect(extRows.first?["extension_name"] as? String == "gpkg_rtree_index")
+    }
+
+    // Validates writing without spatial index does NOT create rtree.
+    @Test
+    func writeWithoutSpatialIndex() async throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)))
+        let fc = FeatureCollection([feature])
+        try fc.writeGeopackage(to: testUrl(), createSpatialIndex: false)
+
+        let db = try SQLiteDB(path: testUrl().path)
+        defer { db.close() }
+
+        let hasRTree = try GeoPackage.hasRTreeIndex(
+            for: "features",
+            column: "geom",
+            in: db)
+        #expect(!hasRTree)
     }
 
 }


### PR DESCRIPTION
## Summary

Adds support for the GeoPackage `gpkg_rtree_index` R-tree spatial index extension, enabling faster bounding-box queries.

### Changes
- Detection helpers: `hasRTreeIndex`, `rTreeTableName`
- BBox-filtered reader: `FeatureCollection(geopackage:table:boundingBox:)` with rtree pre-filter + memory fallback
- Writer: `createSpatialIndex` parameter on `writeGeopackage`, creates/populates/registers rtree
- `isNotEmpty` on `String`
- 4 tests covering rtree path, fallback, write with/without index

Closes #187