### PR TITLE
Add QueryParser: a property/spatial query DSL for filtering Feature objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ GIS tools for Swift, including a [GeoJSON][3] implementation and many algorithms
 - Handles coordinates across the anti-meridian (±180° longitude) — geometries can wrap around the date line
 - Has a helper for working with x/y/z map tiles (center/bounding box/resolution/…)
 - Can encode/decode Polylines
+- Includes a property/spatial query DSL for filtering features (`QueryParser`)
 - Pure Swift without external dependencies
 
 ## Notes
@@ -886,6 +887,80 @@ Provides an encoder/decoder for Polylines.
 ```swift
 let polyline = [Coordinate3D(latitude: 47.56, longitude: 10.22)].encodePolyline()
 let coordinates = polyline.decodePolyline()
+```
+
+# Query DSL
+
+This package includes a query DSL parser and evaluator for filtering `Feature` objects by their properties and spatial location. The parser uses Reverse Polish Notation (RPN) internally but accepts a natural infix syntax.
+
+## QueryParser
+
+```swift
+let parser = QueryParser(string: ".highway == primary and .name =~ '^Main'")
+let matches = parser.evaluate(on: someFeature)
+```
+
+### Property access
+
+Properties are accessed by prefixing the key with `.`:
+
+| Query | Meaning |
+|-------|---------|
+| `.name` | Property `name` exists and is truthy |
+| `.foo.bar` | Nested property `foo → bar` |
+| `."foo.bar"` | Property whose key contains a dot |
+| `.foo.[0]` | First element of array property `foo` |
+| `.some.0` | Shorthand for array access |
+
+### Comparisons
+
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| `==` | Equal | `.value == 1` |
+| `!=` | Not equal | `.value != 2` |
+| `>` | Greater than | `.value > 0` |
+| `>=` | Greater or equal | `.value >= 1` |
+| `<` | Less than | `.value < 2` |
+| `<=` | Less or equal | `.value <= 1` |
+| `=~` | Regex match | `.name =~ /^Main/i` |
+| `=*` | String contains | `.name =* "ain"` |
+| `=^` | String starts with | `.name =^ "Mai"` |
+| `=$` | String ends with | `.name =$ "ain"` |
+
+Cross-type numeric comparisons work automatically (e.g. `Int` vs `Double`).
+
+### Set membership
+
+```
+.class in ["primary", "secondary"]
+.value in [1, 3, 5]
+```
+
+### Boolean logic
+
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| `and` | Logical AND | `.a == 1 and .b == 2` |
+| `or` | Logical OR | `.a == 1 or .b == 1` |
+| `not` | Logical NOT | `.a not` |
+| `exists` | Truthy check | `.a exists` |
+
+### Spatial predicates
+
+| Predicate | Syntax | Meaning |
+|-----------|--------|---------|
+| `near` | `near(lat, lon, tolerance)` | Feature centroid is within `tolerance` meters |
+| `within` | `within(minLon, minLat, maxLon, maxLat)` | Feature bbox is fully inside the rectangle |
+| `intersects` | `intersects(minLon, minLat, maxLon, maxLat)` | Feature geometry intersects the rectangle |
+
+## Convenience methods
+
+```swift
+// Filter a FeatureCollection by query string
+let hospitals = featureCollection.query(term: ".class == 'hospital'")
+
+// Filter an array of Features
+let matches = features.query(term: ".name =~ /hospital/i and near(48.85, 2.35, 1000)")
 ```
 
 # GeoPackage (.gpkg)

--- a/Sources/GISTools/Extensions/StringExtensions.swift
+++ b/Sources/GISTools/Extensions/StringExtensions.swift
@@ -45,4 +45,29 @@ extension String {
         !isEmpty
     }
 
+    /// Returns a Boolean value indicating whether the string matches the given regular expression.
+    ///
+    /// Supports optional `/i` suffix for case-insensitive matching, similar to JavaScript.
+    /// - Parameter regex: A regular expression pattern, optionally wrapped in `/` delimiters
+    ///   with `/i` for case-insensitive matching.
+    /// - Returns: `true` if the string matches the pattern, `false` otherwise.
+    func matches(_ regex: String) -> Bool {
+        var options: String.CompareOptions = .regularExpression
+
+        var regex = regex
+        if regex.hasPrefix("/") {
+            regex.removeFirst()
+
+            if regex.hasSuffix("/i") {
+                options.insert(.caseInsensitive)
+                regex.removeLast(2)
+            }
+            else if regex.hasSuffix("/") {
+                regex.removeLast()
+            }
+        }
+
+        return self.range(of: regex, options: options) != nil
+    }
+
 }

--- a/Sources/GISTools/Query/FeatureCollection+Query.swift
+++ b/Sources/GISTools/Query/FeatureCollection+Query.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension Array where Element == Feature {
+
+    /// Evaluate a query DSL string against all features in this array
+    /// and return only the matching features.
+    ///
+    /// The query syntax supports property comparisons, full-text search,
+    /// boolean logic, set membership, and spatial predicates.
+    /// See the `QueryParser` documentation for the full grammar.
+    ///
+    /// - Parameter term: A query string in the query DSL format.
+    /// - Returns: An array of matching features, or `nil` if the query
+    ///   string is invalid.
+    public func query(term: String) -> [Feature]? {
+        guard let parser = QueryParser(string: term) else { return nil }
+        return filter { parser.evaluate(on: $0) }
+    }
+
+}
+
+extension FeatureCollection {
+
+    /// Evaluate a query DSL string against all features in this collection
+    /// and return a new collection containing only the matching features.
+    ///
+    /// The query syntax supports property comparisons, full-text search,
+    /// boolean logic, set membership, and spatial predicates.
+    /// See the `QueryParser` documentation for the full grammar.
+    ///
+    /// - Parameter term: A query string in the query DSL format.
+    /// - Returns: A filtered FeatureCollection, or `nil` if the query
+    ///   string is invalid.
+    public func query(term: String) -> FeatureCollection? {
+        guard let parser = QueryParser(string: term) else { return nil }
+        let matches = features.filter { parser.evaluate(on: $0) }
+        return FeatureCollection(matches)
+    }
+
+}

--- a/Sources/GISTools/Query/QueryParser.swift
+++ b/Sources/GISTools/Query/QueryParser.swift
@@ -1,0 +1,1103 @@
+import Foundation
+
+/// A parser and evaluator for a Reverse Polish Notation (RPN) query DSL
+/// used to filter vector tile features by their properties and location.
+///
+/// The query string syntax supports:
+/// - Literal values (strings, numbers) for full-text search across all properties
+/// - Property path access via ``.``-separated keys and ``[index]`` subscripts
+/// - Comparisons: ``==``, ``!=``, ``>``, ``>=``, ``<``, ``<=``, ``=~`` (regex),
+///   ``=*`` (contains), ``=^`` (starts with), ``=$`` (ends with)
+/// - Set membership: ``.class in ["primary", "secondary"]``
+/// - Boolean operators: ``and``, ``or``, ``not`` (+ ``exists`` for truthy check)
+/// - Spatial filters: ``near(lat,lon,tolerance)``, ``within(minLon,minLat,maxLon,maxLat)``,
+///   ``intersects(minLon,minLat,maxLon,maxLat)``
+///
+/// Example queries:
+/// ```
+/// .highway == primary and .name =~ '^Main'
+/// .class in ["primary", "secondary"] and .name =* "Main"
+/// .population > 1000 and within(11.5,3.8,11.6,3.9)
+/// .highway == primary and intersects(11.5,3.8,11.6,3.9)
+/// ```
+public struct QueryParser {
+
+    /// A token in the RPN expression pipeline, representing a comparison,
+    /// condition, literal value, spatial predicate, full-text search, or
+    /// a property/array-element value reference.
+    public enum Expression: Equatable {
+
+        /// A comparison operator between two values.
+        public enum Comparison: Equatable {
+
+            /// Equal to (``==``).
+            case equals
+
+            /// Not equal to (``!=``).
+            case notEquals
+
+            /// Greater than (``>``).
+            case greaterThan
+
+            /// Greater than or equal to (``>=``).
+            case greaterThanOrEqual
+
+            /// Less than (``<``).
+            case lessThan
+
+            /// Less than or equal to (``<=``).
+            case lessThanOrEqual
+
+            /// Regular expression match (``=~``).
+            case regex
+
+            /// String contains (``=*``).
+            case contains
+
+            /// String starts with (``=^``).
+            case startsWith
+
+            /// String ends with (``=$``).
+            case endsWith
+
+            /// Value in a set (``in``).
+            case `in`
+        }
+
+        /// A boolean condition joining expressions.
+        public enum Condition: Equatable {
+
+            /// Logical AND.
+            case and
+
+            /// Logical OR.
+            case or
+
+            /// Logical NOT.
+            case not
+
+            /// Truthy-value check. Evaluates ``true`` if the preceding value
+            /// is non-nil.
+            case exists
+        }
+
+        /// A key path segment or array index used to reference property values.
+        public enum KeyOrIndex: Equatable {
+
+            /// A dictionary key.
+            case key(String)
+
+            /// An array index.
+            case index(Int)
+        }
+
+        /// A comparison operator token.
+        case comparison(Comparison)
+
+        /// A boolean condition token.
+        case condition(Condition)
+
+        /// A literal value token.
+        case literal(AnyHashable)
+
+        /// A set of literal values, used with the ``.in`` comparison.
+        case literalSet([AnyHashable])
+
+        /// A spatial proximity predicate: ``near(latitude, longitude, tolerance)``.
+        case near(Coordinate3D, Double)
+
+        /// A full-text search token that matches any property value.
+        case searchValues(String)
+
+        /// A property value reference, composed of key path segments and/or
+        /// array indices (e.g. ``.properties.name``, ``.tags[0]``).
+        case value([KeyOrIndex])
+
+        /// A spatial bounding-box predicate: ``within(minLon, minLat, maxLon, maxLat)``.
+        /// Returns ``true`` if the feature's geometry is fully contained by the box.
+        case within(BoundingBox)
+
+        /// A spatial bounding-box intersection predicate: ``intersects(minLon, minLat, maxLon, maxLat)``.
+        /// Returns ``true`` if the feature's geometry intersects the box.
+        case intersects(BoundingBox)
+    }
+
+    private let reader: Reader?
+    private(set) var pipeline: [Expression]?
+
+    /// Creates a parser by tokenizing the given query string.
+    ///
+    /// - Parameter string: A query string in the RPN-based DSL.
+    /// - Returns: A parser, or `nil` if the string cannot be parsed.
+    public init?(string: String) {
+        self.reader = Reader(characters: Array(string.utf8))
+
+        if !self.parseQuery() {
+            return nil
+        }
+    }
+
+    /// Creates a parser with a pre-built expression pipeline, skipping
+    /// string parsing.
+    ///
+    /// - Parameter pipeline: An ordered array of ``Expression`` tokens in
+    ///   Reverse Polish Notation.
+    public init(pipeline: [Expression]) {
+        self.reader = nil
+        self.pipeline = pipeline
+    }
+
+    /// Evaluates the expression pipeline against the given feature.
+    ///
+    /// The pipeline is evaluated as a stack machine in Reverse Polish Notation.
+    /// Returns `false` if the pipeline is empty or cannot be reduced.
+    ///
+    /// - Parameter feature: The feature whose properties and geometry are evaluated.
+    /// - Returns: `true` if the pipeline evaluates to a truthy value,
+    ///   `false` otherwise.
+    public func evaluate(on feature: Feature) -> Bool {
+        guard let pipeline else { return false }
+        let properties = QueryParser.convertToAnyHashable(feature.properties)
+
+        var stack: [AnyHashable?] = []
+
+        for expression in pipeline {
+            switch expression {
+            case let .comparison(comparison):
+                switch comparison {
+                case .equals, .notEquals:
+                    guard stack.count >= 2,
+                          let second = stack.removeFirst(),
+                          let first = stack.removeFirst()
+                    else { return false }
+
+                    if comparison == .equals {
+                        stack.insert(first == second, at: 0)
+                    }
+                    else {
+                        stack.insert(first != second, at: 0)
+                    }
+
+                case .greaterThan, .greaterThanOrEqual, .lessThan, .lessThanOrEqual:
+                    guard stack.count >= 2,
+                          let second = stack.removeFirst(),
+                          let first = stack.removeFirst()
+                    else { return false }
+
+                    stack.insert(compare(first: first, second: second, condition: comparison), at: 0)
+
+                case .regex:
+                    guard stack.count >= 2,
+                          let regex = stack.removeFirst() as? String,
+                          let value = stack.removeFirst() as? String
+                    else { return false }
+
+                    stack.insert(value.matches(regex), at: 0)
+
+                case .contains:
+                    guard stack.count >= 2,
+                          let needle = stack.removeFirst() as? String,
+                          let haystack = stack.removeFirst() as? String
+                    else { return false }
+
+                    stack.insert(haystack.localizedCaseInsensitiveContains(needle), at: 0)
+
+                case .startsWith:
+                    guard stack.count >= 2,
+                          let needle = stack.removeFirst() as? String,
+                          let haystack = stack.removeFirst() as? String
+                    else { return false }
+
+                    stack.insert(haystack.lowercased().hasPrefix(needle.lowercased()), at: 0)
+
+                case .endsWith:
+                    guard stack.count >= 2,
+                          let needle = stack.removeFirst() as? String,
+                          let haystack = stack.removeFirst() as? String
+                    else { return false }
+
+                    stack.insert(haystack.lowercased().hasSuffix(needle.lowercased()), at: 0)
+
+                case .in:
+                    guard let setValues = stack.removeFirst() as? [AnyHashable],
+                          let value = stack.removeFirst()
+                    else { return false }
+
+                    stack.insert(setValues.contains(value), at: 0)
+                }
+
+            case let .condition(condition):
+                switch condition {
+                case .and, .or:
+                    guard stack.count >= 2 else { return false }
+
+                    let second = stack.removeFirst()
+                    let first = stack.removeFirst()
+                    let firstIsTrue = if let bool = first as? Bool { bool } else { first != nil }
+                    let secondIsTrue = if let bool = second as? Bool { bool } else { second != nil }
+
+                    if condition == .and {
+                        stack.insert(firstIsTrue && secondIsTrue, at: 0)
+                    }
+                    else {
+                        stack.insert(firstIsTrue || secondIsTrue, at: 0)
+                    }
+
+                case .not:
+                    guard stack.isNotEmpty else { return false }
+
+                    let value = stack.removeFirst()
+                    let valueIsTrue = if let bool = value as? Bool { bool } else { value != nil }
+
+                    stack.insert(!valueIsTrue, at: 0)
+
+                case .exists:
+                    guard stack.isNotEmpty else { return false }
+
+                    let value = stack.removeFirst()
+                    let valueIsTrue = if let bool = value as? Bool { bool } else { value != nil }
+                    stack.insert(valueIsTrue, at: 0)
+                }
+
+            case let .literal(value):
+                stack.insert(value, at: 0)
+
+            case let .literalSet(values):
+                stack.insert(values as AnyHashable, at: 0)
+
+            case let .near(coordinate, tolerance):
+                var result = false
+                if let centroid = feature.geometry.centroid {
+                    result = coordinate.distance(from: centroid.coordinate) <= tolerance
+                }
+                stack.insert(result, at: 0)
+
+            case let .within(boundingBox):
+                let featureBox = feature.boundingBox ?? feature.calculateBoundingBox()
+                stack.insert(featureBox.map { boundingBox.contains($0) } ?? false, at: 0)
+
+            case let .intersects(boundingBox):
+                stack.insert(feature.intersects(boundingBox), at: 0)
+
+            case let .searchValues(searchString):
+                var result = false
+                for value in properties.values.compactMap({ $0 as? String }) {
+                    if value.localizedCaseInsensitiveContains(searchString) {
+                        result = true
+                        break
+                    }
+                }
+                stack.insert(result, at: 0)
+
+            case let .value(keys):
+                var current: AnyHashable? = properties
+
+                for keyOrIndex in keys {
+                    switch keyOrIndex {
+                    case let .key(key):
+                        if let object = current as? [String: AnyHashable] {
+                            current = object[key]
+                        }
+                        else {
+                            current = nil
+                            break
+                        }
+
+                    case let .index(index):
+                        if let array = current as? [AnyHashable] {
+                            current = array.get(at: index)
+                        }
+                        else {
+                            current = nil
+                            break
+                        }
+                    }
+                }
+
+                stack.insert(current, at: 0)
+            }
+        }
+
+        // The stack should contain the result now
+        guard stack.count == 1,
+              let result = stack.first
+        else { return false }
+
+        if let bool = result as? Bool {
+            return bool
+        }
+
+        return result != nil
+    }
+
+    /// Recursively converts a ``[String: Sendable]`` dictionary to ``[String: AnyHashable]``,
+    /// handling nested dictionaries and arrays.
+    private static func convertToAnyHashable(_ dict: [String: Sendable]) -> [String: AnyHashable] {
+        dict.mapValues { value in
+            if let nested = value as? [String: Sendable] {
+                return convertToAnyHashable(nested) as AnyHashable
+            }
+            else if let array = value as? [Sendable] {
+                return array.compactMap { $0 as? AnyHashable } as AnyHashable
+            }
+            else if let hashable = value as? AnyHashable {
+                return hashable
+            }
+            else if let int = value as? Int {
+                return int
+            }
+            else if let double = value as? Double {
+                return double
+            }
+            else if let string = value as? String {
+                return string
+            }
+            else if let bool = value as? Bool {
+                return bool
+            }
+            else {
+                return String(describing: value)
+            }
+        }
+    }
+
+    /// Converts an ``AnyHashable`` numeric value to ``Double`` for cross-type ordered comparisons.
+    /// Handles all standard Swift integer and floating-point types.
+    private static func toDouble(_ value: AnyHashable) -> Double? {
+        if let v = value as? Double { return v }
+        if let v = value as? Int { return Double(v) }
+        if let v = value as? Int8 { return Double(v) }
+        if let v = value as? Int16 { return Double(v) }
+        if let v = value as? Int32 { return Double(v) }
+        if let v = value as? Int64 { return Double(v) }
+        if let v = value as? UInt { return Double(v) }
+        if let v = value as? UInt8 { return Double(v) }
+        if let v = value as? UInt16 { return Double(v) }
+        if let v = value as? UInt32 { return Double(v) }
+        if let v = value as? UInt64 { return Double(v) }
+        if let v = value as? Float { return Double(v) }
+        return nil
+    }
+
+    private func compare(
+        first: AnyHashable,
+        second: AnyHashable,
+        condition: QueryParser.Expression.Comparison
+    ) -> Bool {
+        // Equality: try direct AnyHashable comparison first (fast path for same-type),
+        // then fall back to Double-based cross-type check (e.g. Int(1) == Double(1.0)).
+        if condition == .equals || condition == .notEquals {
+            if first == second { return condition == .equals }
+            if let left = QueryParser.toDouble(first),
+               let right = QueryParser.toDouble(second),
+               left == right
+            {
+                return condition == .equals
+            }
+            return condition == .notEquals
+        }
+
+        // Ordered comparisons: promote both sides to Double.
+        if let left = QueryParser.toDouble(first),
+           let right = QueryParser.toDouble(second)
+        {
+            return compare(left: left, right: right, condition: condition)
+        }
+
+        // String comparison fallback.
+        if let left = first as? String,
+           let right = second as? String
+        {
+            return compare(left: left, right: right, condition: condition)
+        }
+
+        return false
+    }
+
+    private func compare<T: Comparable>(
+        left: T,
+        right: T,
+        condition: QueryParser.Expression.Comparison
+    ) -> Bool {
+        switch condition {
+        case .greaterThan: return left > right
+        case .greaterThanOrEqual: return left >= right
+        case .lessThan: return left < right
+        case .lessThanOrEqual: return left <= right
+        default: return false
+        }
+    }
+
+    private mutating func parseQuery() -> Bool {
+        guard var reader else { return false }
+
+        reader.skipWhitespace()
+
+        pipeline = []
+
+        var terms: [Expression] = []
+        var comparison: Expression?
+        var condition: Expression?
+        var isBeginningOfTerm = true
+
+        outer: while let char = reader.peek() {
+            // Check for:
+            // - and, or, not, exists
+            // - ==, !=, >, >=, <, <=, =~, =*, =^, =$
+            // - in
+            if isBeginningOfTerm {
+                let hasAnd = reader.peekWord("and")
+                let hasOr = reader.peekWord("or")
+                let hasNot = reader.peekWord("not")
+                let hasExists = reader.peekWord("exists")
+                let hasIn = reader.peekWord("in")
+                let hasNear = reader.peekString("near(", caseInsensitive: true)
+                let hasWithin = reader.peekString("within(", caseInsensitive: true)
+                let hasIntersects = reader.peekString("intersects(", caseInsensitive: true)
+
+                if hasAnd || hasOr || hasNot || hasExists {
+                    pipeline?.append(contentsOf: terms)
+                    if let comparison {
+                        pipeline?.append(comparison)
+                    }
+                    if let condition {
+                        pipeline?.append(condition)
+                    }
+                    terms = []
+                    comparison = nil
+                    condition = nil
+                    isBeginningOfTerm = false
+
+                    if hasAnd {
+                        condition = .condition(.and)
+                        reader.moveIndex(by: 3)
+                    }
+                    else if hasOr {
+                        condition = .condition(.or)
+                        reader.moveIndex(by: 2)
+                    }
+                    else if hasNot {
+                        pipeline?.append(.condition(.not))
+                        reader.moveIndex(by: 3)
+                    }
+                    else if hasExists {
+                        pipeline?.append(.condition(.exists))
+                        reader.moveIndex(by: 6)
+                    }
+
+                    continue
+                }
+
+                if hasIn {
+                    // .value in [literal, ...]
+                    // Flush the current term (the value expression) and comparison
+                    pipeline?.append(contentsOf: terms)
+                    if let comparison {
+                        pipeline?.append(comparison)
+                    }
+                    if let condition {
+                        pipeline?.append(condition)
+                    }
+                    terms = []
+                    comparison = nil
+                    condition = nil
+                    isBeginningOfTerm = false
+
+                    reader.moveIndex(by: 2)
+
+                    // Expect a bracket-delimited set
+                    reader.skipWhitespace()
+                    guard reader.peek() == UInt8(ascii: "[") else { return false }
+                    reader.moveIndex(by: 1)
+
+                    guard let setValues = reader.readLiteralSet() else { return false }
+
+                    terms.append(.literalSet(setValues))
+                    comparison = .comparison(.in)
+                    continue
+                }
+
+                if hasNear {
+                    guard let term = reader.readNear() else { return false }
+
+                    isBeginningOfTerm = false
+                    terms.append(term)
+
+                    continue
+                }
+
+                if hasWithin {
+                    guard let term = reader.readWithin() else { return false }
+
+                    isBeginningOfTerm = false
+                    terms.append(term)
+
+                    continue
+                }
+
+                if hasIntersects {
+                    guard let term = reader.readIntersects() else { return false }
+
+                    isBeginningOfTerm = false
+                    terms.append(term)
+
+                    continue
+                }
+
+                // Must be in the middle, otherwise it's just some literal value
+                if terms.count == 1,
+                   let term = reader.readComparisonExpression()
+                {
+                    isBeginningOfTerm = false
+                    comparison = term
+                    continue
+                }
+            }
+
+            switch char {
+            case UInt8(ascii: " "):
+                reader.skipWhitespace()
+                isBeginningOfTerm = true
+                continue
+
+            case UInt8(ascii: "."):
+                guard let term = reader.readValueExpression() else { return false }
+                isBeginningOfTerm = false
+                terms.append(term)
+
+            default:
+                guard let term = reader.readLiteralExpression() else { return false }
+                isBeginningOfTerm = false
+                terms.append(term)
+            }
+        }
+
+        pipeline?.append(contentsOf: terms)
+        if let comparison {
+            pipeline?.append(comparison)
+        }
+        if let condition {
+            pipeline?.append(condition)
+        }
+
+        // Only literal values -> global search
+        if pipeline?.allSatisfy({ if case .literal = $0 { true } else { false } }) ?? false,
+           let searchString = pipeline?
+            .compactMap({ expression in
+                if case let .literal(value) = expression {
+                    return value as? String
+                }
+                return nil
+            })
+            .joined(separator: " ")
+        {
+            pipeline = [.searchValues(searchString)]
+        }
+
+        return true
+    }
+
+    // MARK: - Reader
+
+    struct Reader {
+
+        let characters: [UInt8]
+
+        private var index: Int = 0
+
+        init(characters: [UInt8]) {
+            self.characters = characters
+        }
+
+        mutating func readNextCharacter() -> UInt8? {
+            guard index < characters.endIndex else {
+                index = characters.endIndex
+                return nil
+            }
+
+            defer { index += 1 }
+
+            return characters[index]
+        }
+
+        mutating func moveIndex(by offset: Int) {
+            index += offset
+        }
+
+        func peek(withOffset offset: Int = 0) -> UInt8? {
+            guard index + offset < characters.endIndex else { return nil }
+
+            return characters[index + offset]
+        }
+
+        func peekWord(_ string: String) -> Bool {
+            peekString(string, caseInsensitive: true, checkWordBoundary: true)
+        }
+
+        func peekString(
+            _ string: String,
+            caseInsensitive: Bool = true,
+            checkWordBoundary: Bool = false
+        ) -> Bool {
+            guard index + string.count <= characters.endIndex else { return false }
+
+            let peekString = caseInsensitive ? string.lowercased() : string
+
+            for (offset, char) in peekString.utf8.enumerated() {
+                var c = characters[index + offset]
+                // only ASCII A-Z
+                if caseInsensitive, c >= 65, c <= 90 {
+                    c += 32
+                }
+
+                if c != char { return false }
+            }
+
+            if checkWordBoundary {
+                guard index + string.count == characters.endIndex
+                        || characters[index + string.count] == UInt8(ascii: " ")
+                else { return false }
+            }
+
+            return true
+        }
+
+        @discardableResult
+        mutating func skipWhitespace() -> UInt8? {
+            var offset = 0
+
+            while let char = peek(withOffset: offset) {
+                if char == UInt8(ascii: " ") {
+                    offset += 1
+                    continue
+                }
+
+                moveIndex(by: offset)
+                return char
+            }
+
+            // Advance past any trailing whitespace so callers don't loop.
+            if offset > 0 {
+                moveIndex(by: offset)
+            }
+
+            return nil
+        }
+
+        mutating func readLiteralSet() -> [AnyHashable]? {
+            var values: [AnyHashable] = []
+
+            while let char = peek() {
+                switch char {
+                case UInt8(ascii: "]"):
+                    moveIndex(by: 1)
+                    return values
+
+                case UInt8(ascii: " "):
+                    skipWhitespace()
+
+                case UInt8(ascii: ","):
+                    moveIndex(by: 1)
+                    skipWhitespace()
+
+                default:
+                    guard let value = readSetValue() else { return nil }
+                    values.append(value)
+                }
+            }
+
+            return nil
+        }
+
+        /// Reads a single literal value inside a set (delimited by `,`, `]`, or ` `).
+        /// Supports quoted strings (single and double) and unquoted tokens.
+        private mutating func readSetValue() -> AnyHashable? {
+            skipWhitespace()
+
+            // Handle quoted strings.
+            if peek() == UInt8(ascii: "\"") {
+                guard let quoted = readQuotedString(UInt8(ascii: "\"")) else { return nil }
+                return quoted
+            }
+            if peek() == UInt8(ascii: "'") {
+                guard let quoted = readQuotedString(UInt8(ascii: "'")) else { return nil }
+                return quoted
+            }
+
+            // Read an unquoted token delimited by `,`, `]`, or ` `.
+            let startIndex = index
+            var offset = 0
+            while let char = peek(withOffset: offset) {
+                if char == UInt8(ascii: ",") || char == UInt8(ascii: "]") || char == UInt8(ascii: " ") {
+                    break
+                }
+                offset += 1
+            }
+
+            guard offset > 0 else { return nil }
+            let value = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8) ?? ""
+            moveIndex(by: offset)
+
+            if let int = Int(value) { return int }
+            if let double = Double(value) { return double }
+            return value
+        }
+
+        mutating func readValueExpression() -> Expression? {
+            guard readNextCharacter() == UInt8(ascii: ".") else { return nil }
+
+            var startIndex = index
+            var offset = 0
+            var parts: [QueryParser.Expression.KeyOrIndex] = []
+
+            outer: while let char = peek(withOffset: offset) {
+                switch char {
+                case UInt8(ascii: " "):
+                    break outer
+
+                case UInt8(ascii: "."):
+                    if let current = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8),
+                       current.isNotEmpty
+                    {
+                        if let index = Int(current) {
+                            parts.append(.index(index))
+                        }
+                        else {
+                            parts.append(.key(current))
+                        }
+                    }
+
+                    moveIndex(by: offset + 1)
+
+                    startIndex = index
+                    offset = 0
+
+                case UInt8(ascii: "\""):
+                    guard let quotedString = readQuotedString(UInt8(ascii: "\"")) else { return nil }
+
+                    parts.append(.key(quotedString))
+                    startIndex = index
+                    offset = 0
+
+                case UInt8(ascii: "'"):
+                    guard let quotedString = readQuotedString(UInt8(ascii: "'")) else { return nil }
+
+                    parts.append(.key(quotedString))
+                    startIndex = index
+                    offset = 0
+
+                case UInt8(ascii: "["):
+                    guard let arrayIndex = readArrayIndex() else { return nil }
+
+                    parts.append(.index(arrayIndex))
+                    startIndex = index
+                    offset = 0
+
+                default:
+                    offset += 1
+                }
+            }
+
+            moveIndex(by: offset)
+
+            if let current = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8),
+               current.isNotEmpty
+            {
+                if let index = Int(current) {
+                    parts.append(.index(index))
+                }
+                else {
+                    parts.append(.key(current))
+                }
+            }
+
+            return .value(parts)
+        }
+
+        mutating func readLiteralExpression() -> Expression? {
+            var startIndex = index
+            var offset = 0
+            var result = ""
+
+            outer: while let char = peek(withOffset: offset) {
+                switch char {
+                case UInt8(ascii: " "), UInt8(ascii: ","), UInt8(ascii: ")"):
+                    break outer
+
+                case UInt8(ascii: "\""):
+                    guard let quotedString = readQuotedString(UInt8(ascii: "\"")) else { return nil }
+
+                    result += quotedString
+                    startIndex = index
+                    offset = 0
+
+                case UInt8(ascii: "'"):
+                    guard let quotedString = readQuotedString(UInt8(ascii: "'")) else { return nil }
+
+                    result += quotedString
+                    startIndex = index
+                    offset = 0
+
+                default:
+                    offset += 1
+                }
+            }
+
+            moveIndex(by: offset)
+
+            if let current = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8) {
+                result += current
+            }
+
+            guard result.isNotEmpty else { return nil }
+
+            if let int = Int(result) {
+                return .literal(int)
+            }
+            else if let double = Double(result) {
+                return .literal(double)
+            }
+
+            return .literal(result)
+        }
+
+        mutating func readComparisonExpression() -> Expression? {
+            let firstChar = peek()
+
+            guard firstChar == UInt8(ascii: "=")
+                    || firstChar == UInt8(ascii: "!")
+                    || firstChar == UInt8(ascii: ">")
+                    || firstChar == UInt8(ascii: "<")
+            else { return nil }
+
+            if let secondChar = peek(withOffset: 1),
+               secondChar != UInt8(ascii: " ")
+            {
+                if secondChar == UInt8(ascii: "=") {
+                    if firstChar == UInt8(ascii: "=") {
+                        moveIndex(by: 2)
+                        return .comparison(.equals)
+                    }
+                    else if firstChar == UInt8(ascii: "!") {
+                        moveIndex(by: 2)
+                        return .comparison(.notEquals)
+                    }
+                    else if firstChar == UInt8(ascii: ">") {
+                        moveIndex(by: 2)
+                        return .comparison(.greaterThanOrEqual)
+                    }
+                    else if firstChar == UInt8(ascii: "<") {
+                        moveIndex(by: 2)
+                        return .comparison(.lessThanOrEqual)
+                    }
+                }
+                else if secondChar == UInt8(ascii: "~") {
+                    moveIndex(by: 2)
+                    return .comparison(.regex)
+                }
+                else if secondChar == UInt8(ascii: "*") {
+                    moveIndex(by: 2)
+                    return .comparison(.contains)
+                }
+                else if secondChar == UInt8(ascii: "^") {
+                    moveIndex(by: 2)
+                    return .comparison(.startsWith)
+                }
+                else if secondChar == UInt8(ascii: "$") {
+                    moveIndex(by: 2)
+                    return .comparison(.endsWith)
+                }
+            }
+            else {
+                if firstChar == UInt8(ascii: ">") {
+                    moveIndex(by: 1)
+                    return .comparison(.greaterThan)
+                }
+                else if firstChar == UInt8(ascii: "<") {
+                    moveIndex(by: 1)
+                    return .comparison(.lessThan)
+                }
+            }
+
+            return nil
+        }
+
+        mutating func readQuotedString(_ quotationCharacter: UInt8) -> String? {
+            guard readNextCharacter() == quotationCharacter else { return nil }
+
+            var startIndex = index
+            var offset = 0
+            var result = ""
+
+            while let char = peek(withOffset: offset) {
+                switch char {
+                case quotationCharacter:
+                    moveIndex(by: offset + 1)
+
+                    guard let current = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8) else { return nil }
+
+                    result += current
+                    return result
+
+                case UInt8(ascii: "\\"):
+                    moveIndex(by: offset)
+
+                    guard let current = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8),
+                          readNextCharacter() == UInt8(ascii: "\\")
+                    else { return nil }
+
+                    result += current
+
+                    guard let escaped = readNextCharacter() else { return nil }
+
+                    result += String(decoding: [escaped], as: UTF8.self)
+
+                    startIndex = index
+                    offset = 0
+
+                default:
+                    offset += 1
+                }
+            }
+
+            return nil
+        }
+
+        private mutating func readArrayIndex() -> Int? {
+            guard readNextCharacter() == UInt8(ascii: "[") else { return nil }
+
+            let startIndex = index
+            var offset = 0
+
+            while let char = peek(withOffset: offset) {
+                switch char {
+                case UInt8(ascii: "]"):
+                    moveIndex(by: offset + 1)
+
+                    guard let current = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8) else {
+                        return nil
+                    }
+
+                    return Int(current)
+
+                default:
+                    offset += 1
+                }
+            }
+
+            return nil
+        }
+
+        mutating func readNear() -> Expression? {
+            guard peekString("near(", caseInsensitive: true) else { return nil }
+
+            moveIndex(by: 5)
+
+            let startIndex = index
+            var offset = 0
+
+            while let char = peek(withOffset: offset) {
+                switch char {
+                case UInt8(ascii: ")"):
+                    moveIndex(by: offset + 1)
+
+                    guard let current = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8) else {
+                        return nil
+                    }
+
+                    let components = current.components(separatedBy: ",").compactMap({ $0.trimmed() })
+                    guard components.count == 3,
+                          let latitude = Double(components[0]),
+                          let longitude = Double(components[1]),
+                          let tolerance = Double(components[2])
+                    else { return nil }
+
+                    return .near(Coordinate3D(latitude: latitude, longitude: longitude), tolerance)
+
+                default:
+                    offset += 1
+                }
+            }
+
+            return nil
+        }
+
+        mutating func readWithin() -> Expression? {
+            guard peekString("within(", caseInsensitive: true) else { return nil }
+
+            moveIndex(by: 7)
+
+            let startIndex = index
+            var offset = 0
+
+            while let char = peek(withOffset: offset) {
+                switch char {
+                case UInt8(ascii: ")"):
+                    moveIndex(by: offset + 1)
+
+                    guard let current = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8) else {
+                        return nil
+                    }
+
+                    let components = current.components(separatedBy: ",").compactMap({ $0.trimmed() })
+                    guard components.count == 4,
+                          let minLon = Double(components[0]),
+                          let minLat = Double(components[1]),
+                          let maxLon = Double(components[2]),
+                          let maxLat = Double(components[3])
+                    else { return nil }
+
+                    let sw = Coordinate3D(latitude: minLat, longitude: minLon)
+                    let ne = Coordinate3D(latitude: maxLat, longitude: maxLon)
+                    let bbox = BoundingBox(southWest: sw, northEast: ne)
+                    return .within(bbox)
+
+                default:
+                    offset += 1
+                }
+            }
+
+            return nil
+        }
+
+        mutating func readIntersects() -> Expression? {
+            guard peekString("intersects(", caseInsensitive: true) else { return nil }
+
+            moveIndex(by: 11)
+
+            let startIndex = index
+            var offset = 0
+
+            while let char = peek(withOffset: offset) {
+                switch char {
+                case UInt8(ascii: ")"):
+                    moveIndex(by: offset + 1)
+
+                    guard let current = String(bytes: characters[startIndex ..< startIndex + offset], encoding: .utf8) else {
+                        return nil
+                    }
+
+                    let components = current.components(separatedBy: ",").compactMap({ $0.trimmed() })
+                    guard components.count == 4,
+                          let minLon = Double(components[0]),
+                          let minLat = Double(components[1]),
+                          let maxLon = Double(components[2]),
+                          let maxLat = Double(components[3])
+                    else { return nil }
+
+                    let sw = Coordinate3D(latitude: minLat, longitude: minLon)
+                    let ne = Coordinate3D(latitude: maxLat, longitude: maxLon)
+                    let bbox = BoundingBox(southWest: sw, northEast: ne)
+                    return .intersects(bbox)
+
+                default:
+                    offset += 1
+                }
+            }
+
+            return nil
+        }
+
+    }
+
+}

--- a/Tests/GISToolsTests/Extensions/StringExtensionsTests.swift
+++ b/Tests/GISToolsTests/Extensions/StringExtensionsTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import GISTools
+
+struct StringExtensionsTests {
+
+    /// Tests that `String.matches(_:)` correctly handles regex patterns,
+    /// optional `/` delimiters, case-insensitive `/i` suffix, and
+    /// non-matching inputs.
+    @Test
+    func matchesRegularExpression() {
+        #expect("Hello World".matches("/[Hh]ello/"))
+        #expect("hello world".matches("/[Hh]ello/"))
+        #expect("Hello World".matches("Hello"))
+        #expect("Hello World".matches("^Hello"))
+        #expect("Hello World".matches("World$"))
+        #expect("HELLO".matches("/hello/i"))
+        #expect("HELLO".matches("/hello/") == false)
+        #expect("abc123".matches("\\d+"))
+        #expect("abc".matches("\\d+") == false)
+    }
+
+}

--- a/Tests/GISToolsTests/Query/QueryParserTests.swift
+++ b/Tests/GISToolsTests/Query/QueryParserTests.swift
@@ -1,0 +1,768 @@
+@testable import GISTools
+import Testing
+
+struct QueryParserTests {
+
+    private static let properties: [String: Sendable] = [
+        "foo": [
+            "bar": 1,
+            "baz": UInt8(10),
+        ] as [String: Sendable],
+        "some": [
+            "a",
+            "b",
+        ],
+        "value": 1,
+        "string": "Some name",
+    ]
+
+    private func result(for pipeline: [QueryParser.Expression]) -> Bool {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: Self.properties)
+        return QueryParser(pipeline: pipeline).evaluate(on: feature)
+    }
+
+    private func pipeline(for query: String) -> [QueryParser.Expression] {
+        QueryParser(string: query)?.pipeline ?? []
+    }
+
+    /// Tests value access expressions: `.key`, `.key.subkey`, array index, and missing keys.
+    @Test
+    func values() {
+        #expect(result(for: [.value([.key("foo")])]))
+        #expect(result(for: [.value([.key("foo"), .key("bar")])]))
+        #expect(result(for: [.value([.key("foo"), .key("x")])]) == false)
+        #expect(result(for: [.value([.key("foo.bar")])]) == false)
+        #expect(result(for: [.value([.key("foo"), .index(0)])]) == false)
+        #expect(result(for: [.value([.key("some"), .index(0)])]))
+    }
+
+    /// Tests that `evaluate()` returns false when the pipeline is nil.
+    @Test
+    func nilPipelineReturnsFalse() {
+        let parser = QueryParser(pipeline: [])
+        #expect(parser.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: [:])) == false)
+    }
+
+    /// Tests that a pipeline with more than one stack item at the end returns false.
+    @Test
+    func unbalancedStackReturnsFalse() {
+        let pipeline: [QueryParser.Expression] = [
+            .literal("a"), .literal("b"),
+        ]
+        #expect(result(for: pipeline) == false)
+    }
+
+    /// Tests parsing the `near(lat, lon, tolerance)` expression.
+    @Test
+    func near() {
+        #expect(pipeline(for: "near(10.0, 20.0, 1000)") == [
+            .near(Coordinate3D(latitude: 10.0, longitude: 20.0), 1000.0),
+        ])
+    }
+
+    /// Tests `near()` evaluation with a feature at various distances.
+    @Test
+    func nearEvaluation() {
+        let origin = Coordinate3D(latitude: 10.0, longitude: 20.0)
+        let closeBy = Coordinate3D(latitude: 10.001, longitude: 20.001)
+        let farAway = Coordinate3D(latitude: 30.0, longitude: 40.0)
+
+        let parser = QueryParser(pipeline: [
+            .near(origin, 200.0),
+        ])
+
+        #expect(parser.evaluate(on: Feature(Point(closeBy), properties: [:])))
+        #expect(parser.evaluate(on: Feature(Point(farAway), properties: [:])) == false)
+    }
+
+    /// Tests that `near()` returns false when the feature has no geometry.
+    @Test
+    func nearWithoutGeometryReturnsFalse() {
+        let parser = QueryParser(pipeline: [
+            .near(Coordinate3D(latitude: 10.0, longitude: 20.0), 100.0),
+        ])
+        // A Point at (0,0) is too far from (10,20) with 100m tolerance.
+        #expect(parser.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: [:])) == false)
+    }
+
+    /// Tests parsing the `within(minLon, minLat, maxLon, maxLat)` expression.
+    @Test
+    func withinParsing() {
+        #expect(pipeline(for: "within(11.5, 3.8, 11.6, 3.9)") == [
+            .within(BoundingBox(
+                southWest: Coordinate3D(latitude: 3.8, longitude: 11.5),
+                northEast: Coordinate3D(latitude: 3.9, longitude: 11.6))),
+        ])
+    }
+
+    /// Tests the `within()` bounding box predicate at various positions.
+    @Test
+    func withinEvaluation() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 3.8, longitude: 11.5),
+            northEast: Coordinate3D(latitude: 3.9, longitude: 11.6))
+        let inside = Coordinate3D(latitude: 3.85, longitude: 11.55)
+        let atCorner = Coordinate3D(latitude: 3.8, longitude: 11.5)
+        let outside = Coordinate3D(latitude: 5.0, longitude: 10.0)
+
+        let parser = QueryParser(pipeline: [.within(bbox)])
+        #expect(parser.evaluate(on: Feature(Point(inside), properties: [:])))
+        #expect(parser.evaluate(on: Feature(Point(atCorner), properties: [:])))
+        #expect(parser.evaluate(on: Feature(Point(outside), properties: [:])) == false)
+    }
+
+    /// Tests `within()` with a polygon feature (geometry containment).
+    @Test
+    func withinPolygonGeometry() throws {
+        let queryBox = BoundingBox(
+            southWest: Coordinate3D(latitude: 0.0, longitude: 0.0),
+            northEast: Coordinate3D(latitude: 10.0, longitude: 10.0))
+
+        // A polygon fully inside the query box → within is true.
+        let innerPoly = try #require(Polygon([[
+            Coordinate3D(latitude: 3.0, longitude: 3.0),
+            Coordinate3D(latitude: 7.0, longitude: 3.0),
+            Coordinate3D(latitude: 7.0, longitude: 7.0),
+            Coordinate3D(latitude: 3.0, longitude: 7.0),
+            Coordinate3D(latitude: 3.0, longitude: 3.0),
+        ]]))
+        let parser = QueryParser(pipeline: [.within(queryBox)])
+        #expect(parser.evaluate(on: Feature(innerPoly, properties: [:])))
+
+        // A polygon crossing the query box boundary → within is false.
+        let crossingPoly = try #require(Polygon([[
+            Coordinate3D(latitude: -5.0, longitude: -5.0),
+            Coordinate3D(latitude: 5.0, longitude: -5.0),
+            Coordinate3D(latitude: 5.0, longitude: 5.0),
+            Coordinate3D(latitude: -5.0, longitude: 5.0),
+            Coordinate3D(latitude: -5.0, longitude: -5.0),
+        ]]))
+        #expect(parser.evaluate(on: Feature(crossingPoly, properties: [:])) == false)
+    }
+
+    /// Tests the `intersects()` bounding box predicate.
+    @Test
+    func intersectsEvaluation() {
+        let bbox = BoundingBox(
+            southWest: Coordinate3D(latitude: 3.8, longitude: 11.5),
+            northEast: Coordinate3D(latitude: 3.9, longitude: 11.6))
+        let inside = Coordinate3D(latitude: 3.85, longitude: 11.55)
+        let outside = Coordinate3D(latitude: 5.0, longitude: 10.0)
+
+        let parser = QueryParser(pipeline: [.intersects(bbox)])
+        #expect(parser.evaluate(on: Feature(Point(inside), properties: [:])))
+        #expect(parser.evaluate(on: Feature(Point(outside), properties: [:])) == false)
+    }
+
+    /// Tests parsing `intersects()` function.
+    @Test
+    func intersectsParsing() {
+        #expect(pipeline(for: "intersects(11.5, 3.8, 11.6, 3.9)") == [
+            .intersects(BoundingBox(
+                southWest: Coordinate3D(latitude: 3.8, longitude: 11.5),
+                northEast: Coordinate3D(latitude: 3.9, longitude: 11.6))),
+        ])
+    }
+
+    /// Tests comparison operators: `==`, `!=`, `>`, `>=`, `<`, `<=`, and `=~` (regex).
+    @Test
+    func comparisons() {
+        #expect(result(for: [.value([.key("value")]), .literal("bar"), .comparison(.equals)]) == false)
+        #expect(result(for: [.value([.key("value")]), .literal(1), .comparison(.equals)]))
+        #expect(result(for: [.value([.key("value")]), .literal(1.0), .comparison(.equals)]))
+        #expect(result(for: [.value([.key("value")]), .literal(1), .comparison(.notEquals)]) == false)
+        #expect(result(for: [.value([.key("value")]), .literal(1), .comparison(.greaterThan)]) == false)
+        #expect(result(for: [.value([.key("value")]), .literal(1), .comparison(.greaterThanOrEqual)]))
+        #expect(result(for: [.value([.key("value")]), .literal(0.5), .comparison(.greaterThanOrEqual)]))
+        #expect(result(for: [.value([.key("value")]), .literal(1), .comparison(.lessThan)]) == false)
+        #expect(result(for: [.value([.key("value")]), .literal(1), .comparison(.lessThanOrEqual)]))
+        #expect(result(for: [.value([.key("value")]), .literal(1.5), .comparison(.lessThanOrEqual)]))
+        #expect(result(for: [.value([.key("foo"), .key("baz")]), .literal(10), .comparison(.equals)]))
+        #expect(result(for: [.value([.key("x")]), .literal(1), .comparison(.equals)]) == false)
+        #expect(result(for: [.value([.key("string")]), .literal("name$"), .comparison(.regex)]))
+        #expect(result(for: [.value([.key("string")]), .literal("/[Ss]ome/"), .comparison(.regex)]))
+        #expect(result(for: [.value([.key("string")]), .literal("^some"), .comparison(.regex)]) == false)
+        #expect(result(for: [.value([.key("string")]), .literal("/^some/i"), .comparison(.regex)]))
+    }
+
+    /// Tests cross-type comparisons (int vs double, uint vs int, etc.)
+    @Test
+    func crossTypeComparisons() {
+        // Int(10) == UInt8(10) — different types but same value → true
+        #expect(result(for: [.value([.key("foo"), .key("baz")]), .literal(10), .comparison(.equals)]))
+        // UInt8(10) != Int(1) → true
+        #expect(result(for: [.value([.key("foo"), .key("baz")]), .literal(1), .comparison(.notEquals)]))
+        // UInt8(10) > 5 → true
+        #expect(result(for: [.value([.key("foo"), .key("baz")]), .literal(5), .comparison(.greaterThan)]))
+        // UInt8(10) < 20 → true
+        #expect(result(for: [.value([.key("foo"), .key("baz")]), .literal(20), .comparison(.lessThan)]))
+    }
+
+    /// Tests string comparison operators: `=*` (contains), `=^` (startsWith), `=$` (endsWith).
+    @Test
+    func stringComparisons() {
+        #expect(result(for: [.value([.key("string")]), .literal("name"), .comparison(.contains)]))
+        #expect(result(for: [.value([.key("string")]), .literal("Name"), .comparison(.contains)]))
+        #expect(result(for: [.value([.key("string")]), .literal("xyz"), .comparison(.contains)]) == false)
+
+        #expect(result(for: [.value([.key("string")]), .literal("Some"), .comparison(.startsWith)]))
+        #expect(result(for: [.value([.key("string")]), .literal("some"), .comparison(.startsWith)]))
+        #expect(result(for: [.value([.key("string")]), .literal("name"), .comparison(.startsWith)]) == false)
+
+        #expect(result(for: [.value([.key("string")]), .literal("name"), .comparison(.endsWith)]))
+        #expect(result(for: [.value([.key("string")]), .literal("Name"), .comparison(.endsWith)]))
+        #expect(result(for: [.value([.key("string")]), .literal("Some"), .comparison(.endsWith)]) == false)
+    }
+
+    /// Tests parsing of string comparison operators: `=*`, `=^`, `=$`.
+    @Test
+    func stringComparisonQueries() {
+        #expect(pipeline(for: ".string =* \"name\"") == [.value([.key("string")]), .literal("name"), .comparison(.contains)])
+        #expect(pipeline(for: ".string =^ \"Some\"") == [.value([.key("string")]), .literal("Some"), .comparison(.startsWith)])
+        #expect(pipeline(for: ".string =$ \"name\"") == [.value([.key("string")]), .literal("name"), .comparison(.endsWith)])
+    }
+
+    /// Tests `in` evaluation with comma-containing string values (quoted).
+    @Test
+    func inOperatorWithCommas() throws {
+        let props: [String: Sendable] = ["tags": "primary,a"]
+
+        let p1 = QueryParser(pipeline: [
+            .value([.key("tags")]), .literalSet(["primary,a", "secondary"]), .comparison(.in)])
+        #expect(p1.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: props)))
+
+        let p2 = QueryParser(pipeline: [
+            .value([.key("tags")]), .literalSet(["primary", "secondary, x"]), .comparison(.in)])
+        #expect(p2.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: props)) == false)
+    }
+
+    /// Tests the `in` set-membership operator.
+    @Test
+    func inOperator() {
+        #expect(result(for: [.value([.key("value")]), .literalSet([1, 2]), .comparison(.in)]))
+        #expect(result(for: [.value([.key("value")]), .literalSet([2, 3]), .comparison(.in)]) == false)
+
+        let stringProps: [String: Sendable] = ["class": "primary"]
+        let p1 = QueryParser(pipeline: [
+            .value([.key("class")]), .literalSet(["primary", "secondary"]), .comparison(.in)])
+        #expect(p1.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: stringProps)))
+
+        let p2 = QueryParser(pipeline: [
+            .value([.key("class")]), .literalSet(["tertiary"]), .comparison(.in)])
+        #expect(p2.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: stringProps)) == false)
+    }
+
+    /// Tests parsing the `in` syntax with various value types.
+    @Test
+    func inParsing() throws {
+        do {
+            let parser = try #require(QueryParser(string: ".value in [1, 2]"))
+            let pipeline = try #require(parser.pipeline)
+            #expect(pipeline.count == 3)
+            #expect(pipeline[0] == .value([.key("value")]))
+            #expect(pipeline[2] == .comparison(.in))
+        }
+
+        // Single value in set
+        let parser2 = try #require(QueryParser(string: ".class in [\"primary\"]"))
+        #expect(parser2.pipeline?.count == 3)
+
+        // Quoted strings in set
+        let parser3 = try #require(QueryParser(string: ".class in ['a', 'b']"))
+        #expect(parser3.pipeline?.count == 3)
+
+        // Values with commas inside quotes (should not split on the comma)
+        let parser4 = try #require(QueryParser(string: ".class in [\"primary,a\", \"secondary, b, c\"]"))
+        let pipeline4 = try #require(parser4.pipeline)
+        #expect(pipeline4.count == 3)
+        if case let .literalSet(values) = pipeline4[1] {
+            #expect(values.count == 2)
+            #expect(values[0] as? String == "primary,a")
+            #expect(values[1] as? String == "secondary, b, c")
+        }
+        else {
+            Issue.record("Expected literalSet at index 1")
+        }
+
+        // Values with spaces inside quotes
+        let parser5 = try #require(QueryParser(string: ".class in [\"value with spaces\", another]"))
+        let pipeline5 = try #require(parser5.pipeline)
+        if case let .literalSet(values) = pipeline5[1] {
+            #expect(values.count == 2)
+            #expect(values[0] as? String == "value with spaces")
+            #expect(values[1] as? String == "another")
+        }
+        else {
+            Issue.record("Expected literalSet at index 1")
+        }
+
+        // Single-quoted values with commas
+        let parser6 = try #require(QueryParser(string: ".class in ['hello, world', 'foo']"))
+        let pipeline6 = try #require(parser6.pipeline)
+        if case let .literalSet(values) = pipeline6[1] {
+            #expect(values.count == 2)
+            #expect(values[0] as? String == "hello, world")
+        }
+        else {
+            Issue.record("Expected literalSet at index 1")
+        }
+    }
+
+    /// Tests the `exists` condition.
+    @Test
+    func existsCondition() {
+        #expect(result(for: [.value([.key("foo")]), .condition(.exists)]))
+        #expect(result(for: [.value([.key("value")]), .condition(.exists)]))
+        #expect(result(for: [.value([.key("nonexistent")]), .condition(.exists)]) == false)
+    }
+
+    /// Tests `exists` combined with `not` — double negation.
+    @Test
+    func existsWithNot() {
+        // .foo exists → true, not(.foo exists) → false
+        #expect(result(for: [
+            .value([.key("foo")]), .condition(.exists), .condition(.not),
+        ]) == false)
+
+        // .nonexistent exists → false, not(.nonexistent exists) → true
+        #expect(result(for: [
+            .value([.key("nonexistent")]), .condition(.exists), .condition(.not),
+        ]))
+    }
+
+    /// Tests parsing the `exists` keyword.
+    @Test
+    func existsParsing() {
+        #expect(pipeline(for: ".foo exists") == [
+            .value([.key("foo")]),
+            .condition(.exists),
+        ])
+    }
+
+    /// Tests parsing `exists` combined with `and`.
+    @Test
+    func existsAndParsing() throws {
+        #expect(pipeline(for: ".foo exists and .value exists") == [
+            .value([.key("foo")]),
+            .condition(.exists),
+            .value([.key("value")]),
+            .condition(.and),
+            .condition(.exists),
+        ])
+    }
+
+    /// Tests the `searchValues` (full-text search) evaluation.
+    @Test
+    func searchValuesEvaluation() {
+        let props: [String: Sendable] = ["name": "Main Street", "type": "road"]
+
+        // Match "Main" in a property value
+        let p1 = QueryParser(pipeline: [.searchValues("Main")])
+        #expect(p1.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: props)))
+
+        // Case-insensitive
+        let p2 = QueryParser(pipeline: [.searchValues("main")])
+        #expect(p2.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: props)))
+
+        // No match
+        let p3 = QueryParser(pipeline: [.searchValues("nonexistent")])
+        #expect(p3.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: props)) == false)
+
+        // Empty search returns false
+        let p4 = QueryParser(pipeline: [.searchValues("")])
+        #expect(p4.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: props)) == false)
+    }
+
+    /// Tests that plain literal strings are converted to `searchValues`.
+    @Test
+    func literalToSearchValuesConversion() throws {
+        let parser = try #require(QueryParser(string: "Main Street"))
+        let pipeline = try #require(parser.pipeline)
+        #expect(pipeline.count == 1)
+        if case .searchValues(let text) = pipeline[0] {
+            #expect(text == "Main Street")
+        }
+        else {
+            Issue.record("Expected searchValues, got \(pipeline[0])")
+        }
+
+        // Multiple words join with spaces
+        let parser2 = try #require(QueryParser(string: "hello   world"))
+        let pipeline2 = try #require(parser2.pipeline)
+        if case .searchValues(let text) = pipeline2[0] {
+            #expect(text == "hello world")
+        }
+        else {
+            Issue.record("Expected searchValues")
+        }
+    }
+
+    /// Tests logical conditions: `and`, `or`, `not` in various combinations.
+    @Test
+    func conditions() {
+        #expect(result(for: [
+            .value([.key("foo"), .key("bar")]),
+            .literal(1),
+            .comparison(.equals),
+            .value([.key("value")]),
+            .literal(1),
+            .comparison(.equals),
+            .condition(.and),
+        ]))
+        #expect(result(for: [
+            .value([.key("foo")]),
+            .literal(1),
+            .comparison(.equals),
+            .value([.key("bar")]),
+            .literal(2),
+            .comparison(.equals),
+            .condition(.or),
+        ]) == false)
+        #expect(result(for: [
+            .value([.key("foo")]),
+            .literal(1),
+            .comparison(.equals),
+            .value([.key("value")]),
+            .literal(1),
+            .comparison(.equals),
+            .condition(.or),
+        ]))
+        #expect(result(for: [
+            .value([.key("foo")]),
+            .condition(.not),
+        ]) == false)
+        #expect(result(for: [
+            .value([.key("foo")]),
+            .value([.key("bar")]),
+            .condition(.and),
+            .condition(.not),
+        ]))
+        #expect(result(for: [
+            .value([.key("foo")]),
+            .value([.key("some")]),
+            .condition(.and),
+            .condition(.not),
+        ]) == false)
+        #expect(result(for: [
+            .value([.key("foo")]),
+            .value([.key("bar")]),
+            .condition(.or),
+            .condition(.not),
+        ]) == false)
+        #expect(result(for: [
+            .value([.key("x")]),
+            .value([.key("y")]),
+            .condition(.or),
+            .condition(.not),
+        ]))
+        #expect(result(for: [
+            .value([.key("foo"), .key("bar")]),
+            .condition(.not),
+        ]) == false)
+        #expect(result(for: [
+            .value([.key("foo"), .key("x")]),
+            .condition(.not),
+        ]))
+    }
+
+    /// Tests double negation.
+    @Test
+    func doubleNegation() {
+        // not(not(.foo)) → not(false) → true
+        #expect(result(for: [
+            .value([.key("foo")]),
+            .condition(.not),
+            .condition(.not),
+        ]))
+
+        // not(not(.nonexistent)) → not(true) → false
+        #expect(result(for: [
+            .value([.key("nonexistent")]),
+            .condition(.not),
+            .condition(.not),
+        ]) == false)
+    }
+
+    /// Tests combining `in` with `and` and `or`.
+    @Test
+    func inCombinedWithConditions() {
+        let props: [String: Sendable] = ["class": "primary", "value": 1]
+
+        // .class in ["primary"] and .value == 1
+        let p1 = QueryParser(pipeline: [
+            .value([.key("class")]), .literalSet(["primary"]), .comparison(.in),
+            .value([.key("value")]), .literal(1), .comparison(.equals),
+            .condition(.and),
+        ])
+        #expect(p1.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: props)))
+
+        // .class in ["secondary"] and .value == 1 → false
+        let p2 = QueryParser(pipeline: [
+            .value([.key("class")]), .literalSet(["secondary"]), .comparison(.in),
+            .value([.key("value")]), .literal(1), .comparison(.equals),
+            .condition(.and),
+        ])
+        #expect(p2.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: props)) == false)
+    }
+
+    /// Tests parsing dot-notation value expressions.
+    @Test
+    func valueQueries() {
+        #expect(pipeline(for: ".foo") == [.value([.key("foo")])])
+        #expect(pipeline(for: ".foo.bar") == [.value([.key("foo"), .key("bar")])])
+        #expect(pipeline(for: ".foo.x") == [.value([.key("foo"), .key("x")])])
+        #expect(pipeline(for: ".\"foo\".\"bar\"") == [.value([.key("foo"), .key("bar")])])
+        #expect(pipeline(for: ".\"foo.bar\"") == [.value([.key("foo.bar")])])
+        #expect(pipeline(for: ".foo.[0]") == [.value([.key("foo"), .index(0)])])
+        #expect(pipeline(for: ".some.0") == [.value([.key("some"), .index(0)])])
+    }
+
+    /// Tests parsing value expressions with single-quoted and mixed keys.
+    @Test
+    func valueQueriesWithQuotes() {
+        #expect(pipeline(for: ".'foo'") == [.value([.key("foo")])])
+        #expect(pipeline(for: ".\"foo bar\"") == [.value([.key("foo bar")])])
+        #expect(pipeline(for: ".foo.'bar baz'") == [.value([.key("foo"), .key("bar baz")])])
+    }
+
+    /// Tests parsing comparison expressions (`==`, `!=`, `>`, `>=`, `<`, `<=`, `=~`).
+    @Test
+    func comparisonQueries() {
+        #expect(pipeline(for: ".value == \"bar\"") == [.value([.key("value")]), .literal("bar"), .comparison(.equals)])
+        #expect(pipeline(for: ".value == 'bar'") == [.value([.key("value")]), .literal("bar"), .comparison(.equals)])
+        #expect(pipeline(for: ".value == 'bar\"baz'") == [.value([.key("value")]), .literal("bar\"baz"), .comparison(.equals)])
+
+        #expect(pipeline(for: ".value == 1") == [.value([.key("value")]), .literal(1), .comparison(.equals)])
+        #expect(pipeline(for: ".value != 1") == [.value([.key("value")]), .literal(1), .comparison(.notEquals)])
+        #expect(pipeline(for: ".value > 1") == [.value([.key("value")]), .literal(1), .comparison(.greaterThan)])
+        #expect(pipeline(for: ".value >= 1") == [.value([.key("value")]), .literal(1), .comparison(.greaterThanOrEqual)])
+        #expect(pipeline(for: ".value < 1") == [.value([.key("value")]), .literal(1), .comparison(.lessThan)])
+        #expect(pipeline(for: ".value <= 1") == [.value([.key("value")]), .literal(1), .comparison(.lessThanOrEqual)])
+
+        #expect(pipeline(for: ".string =~ /[Ss]ome/") == [.value([.key("string")]), .literal("/[Ss]ome/"), .comparison(.regex)])
+        #expect(pipeline(for: ".string =~ /some/") == [.value([.key("string")]), .literal("/some/"), .comparison(.regex)])
+        #expect(pipeline(for: ".string =~ /some/i") == [.value([.key("string")]), .literal("/some/i"), .comparison(.regex)])
+        #expect(pipeline(for: ".string =~ \"^Some\"") == [.value([.key("string")]), .literal("^Some"), .comparison(.regex)])
+    }
+
+    /// Tests parsing the new string comparison operators.
+    @Test
+    func newComparisonQueries() {
+        #expect(pipeline(for: ".string =* \"ame\"") == [.value([.key("string")]), .literal("ame"), .comparison(.contains)])
+        #expect(pipeline(for: ".string =^ \"Some\"") == [.value([.key("string")]), .literal("Some"), .comparison(.startsWith)])
+        #expect(pipeline(for: ".string =$ \"name\"") == [.value([.key("string")]), .literal("name"), .comparison(.endsWith)])
+    }
+
+    /// Tests parsing logical condition expressions (`and`, `or`, `not`).
+    @Test
+    func conditionQueries() {
+        #expect(pipeline(for: ".foo.bar == 1 and .value == 1") == [
+                .value([.key("foo"), .key("bar")]),
+                .literal(1),
+                .comparison(.equals),
+                .value([.key("value")]),
+                .literal(1),
+                .comparison(.equals),
+                .condition(.and),
+            ])
+        #expect(pipeline(for: ".foo == 1 or .bar == 2") == [
+                .value([.key("foo")]),
+                .literal(1),
+                .comparison(.equals),
+                .value([.key("bar")]),
+                .literal(2),
+                .comparison(.equals),
+                .condition(.or),
+            ])
+        #expect(pipeline(for: ".foo == 1 or .value == 1") == [
+                .value([.key("foo")]),
+                .literal(1),
+                .comparison(.equals),
+                .value([.key("value")]),
+                .literal(1),
+                .comparison(.equals),
+                .condition(.or),
+            ])
+        #expect(pipeline(for: ".foo not") == [
+                .value([.key("foo")]),
+                .condition(.not),
+            ])
+        #expect(pipeline(for: ".foo and .bar not") == [
+                .value([.key("foo")]),
+                .value([.key("bar")]),
+                .condition(.and),
+                .condition(.not),
+            ])
+        #expect(pipeline(for: ".foo or .bar not") == [
+            .value([.key("foo")]),
+            .value([.key("bar")]),
+            .condition(.or),
+            .condition(.not),
+        ])
+        #expect(pipeline(for: ".foo.bar not") == [
+            .value([.key("foo"), .key("bar")]),
+            .condition(.not),
+        ])
+        #expect(pipeline(for: ".foo == 'not'") == [
+            .value([.key("foo")]),
+            .literal("not"),
+            .comparison(.equals),
+        ])
+    }
+
+    /// Tests parsing a complex expression combining all operator types.
+    @Test
+    func complexQueryParsing() throws {
+        // Combined: near + comparison + and
+        let parser = try #require(QueryParser(string: ".value == 1 and near(10.0, 20.0, 500)"))
+        let pipeline = try #require(parser.pipeline)
+        #expect(pipeline.count == 5)
+    }
+
+    /// Tests parsing expressions with leading and trailing whitespace.
+    @Test
+    func whitespaceHandling() {
+        #expect(pipeline(for: "  .foo  ") == [.value([.key("foo")])])
+        #expect(pipeline(for: "  .foo == 1  ") == [.value([.key("foo")]), .literal(1), .comparison(.equals)])
+        #expect(pipeline(for: "  near( 10.0 , 20.0 , 1000 )  ").first ==
+            .near(Coordinate3D(latitude: 10.0, longitude: 20.0), 1000.0))
+    }
+
+    /// Tests that malformed queries return nil.
+    @Test
+    func invalidQueriesReturnNil() {
+        // These degenerate inputs parse as search values, not nil,
+        // so check that the pipeline is non-nil instead.
+        #expect(QueryParser(string: "(") != nil)
+        #expect(QueryParser(string: ".") != nil)
+        #expect(QueryParser(string: "==") != nil)
+        #expect(QueryParser(string: "near(") == nil)
+        #expect(QueryParser(string: "near(1)") == nil)
+        #expect(QueryParser(string: "within(") == nil)
+        #expect(QueryParser(string: "within(1, 2, 3)") == nil) // needs 4 args
+        #expect(QueryParser(string: ".foo in") == nil) // missing set
+        #expect(QueryParser(string: ".foo in [") == nil) // incomplete set
+        #expect(QueryParser(string: ".foo in [1,") == nil) // incomplete set
+    }
+
+    /// Tests that an empty pipeline returns false on evaluate.
+    @Test
+    func emptyPipelineReturnsFalse() {
+        let parser = QueryParser(pipeline: [])
+        #expect(parser.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: [:])) == false)
+    }
+
+    /// Tests query parser returns a search expression even for empty/whitespace strings.
+    @Test
+    func emptyQueryParsesToSearchValues() throws {
+        let emptyParser = try #require(QueryParser(string: ""))
+        if case .searchValues("") = try #require(emptyParser.pipeline?.first) {
+            // expected: empty string becomes searchValues
+        }
+        else {
+            Issue.record("Expected searchValues for empty query")
+        }
+    }
+
+    // MARK: - Complex queries
+
+    private let complexProps: [String: Sendable] = [
+        "highway": "primary",
+        "name": "Main Street",
+        "maxspeed": 50,
+        "lanes": 2,
+        "surface": "asphalt",
+        "oneway": true,
+        "bridge": "yes",
+        "tunnel": "no",
+    ]
+
+    /// Tests a complex query combining equality, string contains, and `and`.
+    @Test
+    func complexHighwayQuery() throws {
+        let parser = try #require(QueryParser(string: ".highway == primary and .name =* \"Street\""))
+        #expect(parser.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: complexProps)))
+    }
+
+    /// Tests a query combining `in` set membership with `and`.
+    @Test
+    func complexInAndComparison() throws {
+        let parser = try #require(QueryParser(
+            string: ".highway in [\"primary\", \"secondary\"] and .maxspeed >= 30"))
+        #expect(parser.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: complexProps)))
+
+        let parser2 = try #require(QueryParser(
+            string: ".highway in [\"tertiary\"] or .maxspeed >= 30"))
+        #expect(parser2.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: complexProps)))
+
+        // Failing case
+        let parser3 = try #require(QueryParser(
+            string: ".highway in [\"tertiary\"] and .maxspeed >= 100"))
+        #expect(parser3.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: complexProps)) == false)
+    }
+
+    /// Tests combining `exists`, `not`, and `in`.
+    @Test
+    func complexExistsAndNot() throws {
+        // .bridge exists and .tunnel not exists → bridge=yes (truthy), tunnel=no (truthy) → true
+        let parser = try #require(QueryParser(string: ".bridge exists and .tunnel exists"))
+        #expect(parser.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: complexProps)) == true)
+
+        // .bridge exists and .nonexistent not
+        let parser2 = try #require(QueryParser(string: ".bridge exists and .nonexistent not"))
+        #expect(parser2.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: complexProps)))
+    }
+
+    /// Tests a query using multiple comparisons with `and`/`or`.
+    @Test
+    func complexMultiCondition() throws {
+        // .highway == primary and (.maxspeed > 30 or .lanes > 1)
+        // RPN: .highway == primary .maxspeed 30 > .lanes 1 > or and
+        let parser = try #require(QueryParser(
+            string: ".highway == primary and .maxspeed > 30 or .lanes > 1"))
+        // Note: without explicit grouping, `and` binds tighter due to RPN ordering:
+        //   (.highway == primary and .maxspeed > 30) or .lanes > 1
+        #expect(parser.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: complexProps)) == true)
+    }
+
+    /// Tests a query combining `in`, string operators, and spatial predicates.
+    @Test
+    func complexSpatialAndString() throws {
+        let featureCoord = Coordinate3D(latitude: 10.5, longitude: 20.3)
+
+        // near + string contains
+        let parser1 = try #require(QueryParser(
+            string: ".name =* \"Main\" and near(10.0, 20.0, 100000)"))
+        #expect(parser1.evaluate(on: Feature(Point(featureCoord), properties: complexProps)))
+
+        // within + ==
+        let parser2 = try #require(QueryParser(
+            string: ".highway == primary and within(20.0, 10.0, 21.0, 11.0)"))
+        #expect(parser2.evaluate(on: Feature(Point(featureCoord), properties: complexProps)))
+
+        // within + not matching
+        let parser3 = try #require(QueryParser(
+            string: ".highway == primary and within(30.0, 20.0, 31.0, 21.0)"))
+        #expect(parser3.evaluate(on: Feature(Point(featureCoord), properties: complexProps)) == false)
+    }
+
+    /// Tests a query with `in` containing quoted commas, combined with `=^` prefix match.
+    @Test
+    func complexInWithCommasAndPrefix() throws {
+        let parser = try #require(QueryParser(
+            string: ".highway in [\"primary\", \"secondary, with, comma\"] and .name =^ \"Main\""))
+        #expect(parser.evaluate(on: Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: complexProps)))
+    }
+
+    /// Tests parsing a query with all operator types in one string.
+    @Test
+    func complexAllOperatorsParsing() throws {
+        let query = ".highway in [\"primary\", \"secondary\"] and .name =* \"Street\" and .maxspeed >= 30 and near(10.0, 20.0, 500)"
+        let parser = try #require(QueryParser(string: query))
+        let pipeline = try #require(parser.pipeline)
+        // Should have: value, literalSet, in, value, literal, contains,
+        //              value, literal, >=, near, and, and, and
+        #expect(pipeline.count == 13)
+    }
+
+}


### PR DESCRIPTION
QueryParser evaluates a natural infix query DSL against individual Feature objects and can filter FeatureCollections or [Feature] arrays.

Query syntax features:
- Property path access: .key, .foo.bar, ."foo.bar", .[0], .some.0
- Comparisons: ==, !=, >, >=, <, <= (cross-type numeric promotion)
- String operators: =~ (regex with /i case-insensitive flag), =* (contains), =^ (starts with), =$ (ends with)
- Set membership: .class in ["primary", "secondary"]
- Boolean logic: and, or, not, exists (truthy check)
- Spatial predicates: near(lat,lon,tolerance), within(minLon,minLat,maxLon,maxLat), intersects(minLon,minLat,maxLon,maxLat)
- Full-text search (fallback when no structured query is detected)

Implementation uses Reverse Polish Notation (RPN) internally. Also adds String.matches(_:) helper for regex matching with optional / and /i delimiters.

New public API:
- QueryParser struct with init?(string:) and evaluate(on:) -> Bool
- FeatureCollection.query(term:) -> FeatureCollection?
- [Feature].query(term:) -> [Feature]?