### PR TITLE
Parentheses grouping and comprehensive edge case tests for QueryParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,18 @@ Cross-type numeric comparisons work automatically (e.g. `Int` vs `Double`).
 .value in [1, 3, 5]
 ```
 
+### Grouping with parentheses
+
+Expressions can be grouped with `(` and `)` to override default left-to-right evaluation:
+
+```
+(.name == "Berlin" OR .name == "Paris") AND .population > 100000
+NOT (.bridge exists) OR .oneway == true
+(.highway in ["primary", "secondary"] AND .surface == "asphalt") OR .bridge == "yes"
+```
+
+Parentheses may be nested up to any depth.
+
 ### Boolean logic
 
 | Operator | Meaning | Example |
@@ -961,6 +973,9 @@ let hospitals = featureCollection.query(term: ".class == 'hospital'")
 
 // Filter an array of Features
 let matches = features.query(term: ".name =~ /hospital/i and near(48.85, 2.35, 1000)")
+
+// Complex grouped query
+let result = featureCollection.query(term: "(.amenity == \"restaurant\" AND .stars >= 3) OR .cuisine == \"italian\"")
 ```
 
 # GeoPackage (.gpkg)

--- a/Sources/GISTools/Query/QueryParser.swift
+++ b/Sources/GISTools/Query/QueryParser.swift
@@ -9,7 +9,7 @@ import Foundation
 /// - Comparisons: ``==``, ``!=``, ``>``, ``>=``, ``<``, ``<=``, ``=~`` (regex),
 ///   ``=*`` (contains), ``=^`` (starts with), ``=$`` (ends with)
 /// - Set membership: ``.class in ["primary", "secondary"]``
-/// - Boolean operators: ``and``, ``or``, ``not`` (+ ``exists`` for truthy check)
+/// - Boolean operators: ``and``, ``or``, ``not`` (+ ``exists`` for presence check)
 /// - Spatial filters: ``near(lat,lon,tolerance)``, ``within(minLon,minLat,maxLon,maxLat)``,
 ///   ``intersects(minLon,minLat,maxLon,maxLat)``
 /// - Grouping with parentheses: ``(A AND B) OR C``
@@ -174,8 +174,8 @@ public struct QueryParser {
                     let rawSecond = stack.removeFirst()
                     let rawFirst = stack.removeFirst()
                     let result: Bool
-                    if let second = rawSecond as? AnyHashable,
-                       let first = rawFirst as? AnyHashable
+                    if let second = rawSecond,
+                       let first = rawFirst
                     {
                         result = comparison == .equals ? (first == second) : (first != second)
                     }
@@ -298,8 +298,7 @@ public struct QueryParser {
                     guard stack.isNotEmpty else { return false }
 
                     let value = stack.removeFirst()
-                    let valueIsTrue = if let bool = value as? Bool { bool } else { value != nil }
-                    stack.insert(valueIsTrue, at: 0)
+                    stack.insert(value != nil, at: 0)
                 }
 
             case let .literal(value):

--- a/Sources/GISTools/Query/QueryParser.swift
+++ b/Sources/GISTools/Query/QueryParser.swift
@@ -12,6 +12,7 @@ import Foundation
 /// - Boolean operators: ``and``, ``or``, ``not`` (+ ``exists`` for truthy check)
 /// - Spatial filters: ``near(lat,lon,tolerance)``, ``within(minLon,minLat,maxLon,maxLat)``,
 ///   ``intersects(minLon,minLat,maxLon,maxLat)``
+/// - Grouping with parentheses: ``(A AND B) OR C``
 ///
 /// Example queries:
 /// ```
@@ -19,6 +20,8 @@ import Foundation
 /// .class in ["primary", "secondary"] and .name =* "Main"
 /// .population > 1000 and within(11.5,3.8,11.6,3.9)
 /// .highway == primary and intersects(11.5,3.8,11.6,3.9)
+/// (.name == "Berlin" OR .name == "Paris") AND .population > 100000
+/// NOT (.name exists) OR .value >= 10
 /// ```
 public struct QueryParser {
 
@@ -132,9 +135,9 @@ public struct QueryParser {
     public init?(string: String) {
         self.reader = Reader(characters: Array(string.utf8))
 
-        if !self.parseQuery() {
-            return nil
-        }
+        guard var reader = self.reader,
+              parseQuery(reader: &reader)
+        else { return nil }
     }
 
     /// Creates a parser with a pre-built expression pipeline, skipping
@@ -166,64 +169,104 @@ public struct QueryParser {
             case let .comparison(comparison):
                 switch comparison {
                 case .equals, .notEquals:
-                    guard stack.count >= 2,
-                          let second = stack.removeFirst(),
-                          let first = stack.removeFirst()
-                    else { return false }
+                    guard stack.count >= 2 else { return false }
 
-                    if comparison == .equals {
-                        stack.insert(first == second, at: 0)
+                    let rawSecond = stack.removeFirst()
+                    let rawFirst = stack.removeFirst()
+                    let result: Bool
+                    if let second = rawSecond as? AnyHashable,
+                       let first = rawFirst as? AnyHashable
+                    {
+                        result = comparison == .equals ? (first == second) : (first != second)
                     }
                     else {
-                        stack.insert(first != second, at: 0)
+                        result = false
                     }
+                    stack.insert(result, at: 0)
 
                 case .greaterThan, .greaterThanOrEqual, .lessThan, .lessThanOrEqual:
-                    guard stack.count >= 2,
-                          let second = stack.removeFirst(),
-                          let first = stack.removeFirst()
-                    else { return false }
+                    guard stack.count >= 2 else { return false }
 
-                    stack.insert(compare(first: first, second: second, condition: comparison), at: 0)
+                    let rawSecond = stack.removeFirst()
+                    let rawFirst = stack.removeFirst()
+                    if let first = rawFirst, let second = rawSecond {
+                        stack.insert(compare(first: first, second: second, condition: comparison), at: 0)
+                    }
+                    else {
+                        stack.insert(false, at: 0)
+                    }
 
                 case .regex:
-                    guard stack.count >= 2,
-                          let regex = stack.removeFirst() as? String,
-                          let value = stack.removeFirst() as? String
-                    else { return false }
+                    guard stack.count >= 2 else { return false }
 
-                    stack.insert(value.matches(regex), at: 0)
+                    let rawRegex = stack.removeFirst()
+                    let rawValue = stack.removeFirst()
+                    if let regex = rawRegex as? String,
+                       let value = rawValue as? String
+                    {
+                        stack.insert(value.matches(regex), at: 0)
+                    }
+                    else {
+                        stack.insert(false, at: 0)
+                    }
 
                 case .contains:
-                    guard stack.count >= 2,
-                          let needle = stack.removeFirst() as? String,
-                          let haystack = stack.removeFirst() as? String
-                    else { return false }
+                    guard stack.count >= 2 else { return false }
 
-                    stack.insert(haystack.localizedCaseInsensitiveContains(needle), at: 0)
+                    let rawNeedle = stack.removeFirst()
+                    let rawHaystack = stack.removeFirst()
+                    if let needle = rawNeedle as? String,
+                       let haystack = rawHaystack as? String
+                    {
+                        stack.insert(haystack.localizedCaseInsensitiveContains(needle), at: 0)
+                    }
+                    else {
+                        stack.insert(false, at: 0)
+                    }
 
                 case .startsWith:
-                    guard stack.count >= 2,
-                          let needle = stack.removeFirst() as? String,
-                          let haystack = stack.removeFirst() as? String
-                    else { return false }
+                    guard stack.count >= 2 else { return false }
 
-                    stack.insert(haystack.lowercased().hasPrefix(needle.lowercased()), at: 0)
+                    let rawNeedle = stack.removeFirst()
+                    let rawHaystack = stack.removeFirst()
+                    if let needle = rawNeedle as? String,
+                       let haystack = rawHaystack as? String
+                    {
+                        stack.insert(haystack.lowercased().hasPrefix(needle.lowercased()), at: 0)
+                    }
+                    else {
+                        stack.insert(false, at: 0)
+                    }
 
                 case .endsWith:
-                    guard stack.count >= 2,
-                          let needle = stack.removeFirst() as? String,
-                          let haystack = stack.removeFirst() as? String
-                    else { return false }
+                    guard stack.count >= 2 else { return false }
 
-                    stack.insert(haystack.lowercased().hasSuffix(needle.lowercased()), at: 0)
+                    let rawNeedle = stack.removeFirst()
+                    let rawHaystack = stack.removeFirst()
+                    if let needle = rawNeedle as? String,
+                       let haystack = rawHaystack as? String
+                    {
+                        stack.insert(haystack.lowercased().hasSuffix(needle.lowercased()), at: 0)
+                    }
+                    else {
+                        stack.insert(false, at: 0)
+                    }
 
                 case .in:
-                    guard let setValues = stack.removeFirst() as? [AnyHashable],
-                          let value = stack.removeFirst()
-                    else { return false }
+                    guard stack.isNotEmpty else { return false }
 
-                    stack.insert(setValues.contains(value), at: 0)
+                    let rawSetValues = stack.removeFirst()
+                    guard stack.isNotEmpty else { return false }
+                    let rawValue = stack.removeFirst()
+
+                    if let setValues = rawSetValues as? [AnyHashable],
+                       let value = rawValue
+                    {
+                        stack.insert(setValues.contains(value), at: 0)
+                    }
+                    else {
+                        stack.insert(false, at: 0)
+                    }
                 }
 
             case let .condition(condition):
@@ -428,12 +471,12 @@ public struct QueryParser {
         }
     }
 
-    private mutating func parseQuery() -> Bool {
-        guard var reader else { return false }
-
-        reader.skipWhitespace()
-
+    private mutating func parseQuery(
+        reader: inout Reader,
+        until terminator: UInt8? = nil
+    ) -> Bool {
         pipeline = []
+        reader.skipWhitespace()
 
         var terms: [Expression] = []
         var comparison: Expression?
@@ -441,6 +484,11 @@ public struct QueryParser {
         var isBeginningOfTerm = true
 
         outer: while let char = reader.peek() {
+            // Check for terminator (e.g., ')') when in a sub-expression
+            if let terminator, char == terminator {
+                break
+            }
+
             // Check for:
             // - and, or, not, exists
             // - ==, !=, >, >=, <, <=, =~, =*, =^, =$
@@ -489,8 +537,6 @@ public struct QueryParser {
                 }
 
                 if hasIn {
-                    // .value in [literal, ...]
-                    // Flush the current term (the value expression) and comparison
                     pipeline?.append(contentsOf: terms)
                     if let comparison {
                         pipeline?.append(comparison)
@@ -505,7 +551,6 @@ public struct QueryParser {
 
                     reader.moveIndex(by: 2)
 
-                    // Expect a bracket-delimited set
                     reader.skipWhitespace()
                     guard reader.peek() == UInt8(ascii: "[") else { return false }
                     reader.moveIndex(by: 1)
@@ -544,7 +589,6 @@ public struct QueryParser {
                     continue
                 }
 
-                // Must be in the middle, otherwise it's just some literal value
                 if terms.count == 1,
                    let term = reader.readComparisonExpression()
                 {
@@ -555,10 +599,29 @@ public struct QueryParser {
             }
 
             switch char {
-            case UInt8(ascii: " "):
+            case UInt8(ascii: " "), UInt8(ascii: "\t"), UInt8(ascii: "\n"), UInt8(ascii: "\r"):
                 reader.skipWhitespace()
                 isBeginningOfTerm = true
                 continue
+
+            case UInt8(ascii: "("):
+                pipeline?.append(contentsOf: terms)
+                if let comparison { pipeline?.append(comparison) }
+                if let condition { pipeline?.append(condition) }
+                terms = []
+                comparison = nil
+                condition = nil
+                isBeginningOfTerm = false
+
+                reader.moveIndex(by: 1)
+
+                guard parseQuery(reader: &reader, until: UInt8(ascii: ")")) else { return false }
+
+                reader.skipWhitespace()
+                guard reader.peek() == UInt8(ascii: ")") else { return false }
+                reader.moveIndex(by: 1)
+
+                isBeginningOfTerm = true
 
             case UInt8(ascii: "."):
                 guard let term = reader.readValueExpression() else { return false }
@@ -580,7 +643,9 @@ public struct QueryParser {
             pipeline?.append(condition)
         }
 
-        // Only literal values -> global search
+        // Only apply the global-search fallback at the top level (no terminator)
+        guard terminator == nil else { return true }
+
         if pipeline?.allSatisfy({ if case .literal = $0 { true } else { false } }) ?? false,
            let searchString = pipeline?
             .compactMap({ expression in
@@ -667,13 +732,14 @@ public struct QueryParser {
             var offset = 0
 
             while let char = peek(withOffset: offset) {
-                if char == UInt8(ascii: " ") {
+                switch char {
+                case UInt8(ascii: " "), UInt8(ascii: "\t"), UInt8(ascii: "\n"), UInt8(ascii: "\r"):
                     offset += 1
                     continue
+                default:
+                    moveIndex(by: offset)
+                    return char
                 }
-
-                moveIndex(by: offset)
-                return char
             }
 
             // Advance past any trailing whitespace so callers don't loop.
@@ -693,7 +759,7 @@ public struct QueryParser {
                     moveIndex(by: 1)
                     return values
 
-                case UInt8(ascii: " "):
+                case UInt8(ascii: " "), UInt8(ascii: "\t"), UInt8(ascii: "\n"), UInt8(ascii: "\r"):
                     skipWhitespace()
 
                 case UInt8(ascii: ","):
@@ -752,7 +818,7 @@ public struct QueryParser {
 
             outer: while let char = peek(withOffset: offset) {
                 switch char {
-                case UInt8(ascii: " "):
+                case UInt8(ascii: " "), UInt8(ascii: "\t"), UInt8(ascii: "\n"), UInt8(ascii: "\r"):
                     break outer
 
                 case UInt8(ascii: "."):
@@ -821,7 +887,7 @@ public struct QueryParser {
 
             outer: while let char = peek(withOffset: offset) {
                 switch char {
-                case UInt8(ascii: " "), UInt8(ascii: ","), UInt8(ascii: ")"):
+                case UInt8(ascii: " "), UInt8(ascii: "\t"), UInt8(ascii: "\n"), UInt8(ascii: "\r"), UInt8(ascii: ","), UInt8(ascii: ")"):
                     break outer
 
                 case UInt8(ascii: "\""):

--- a/Tests/GISToolsTests/Query/QueryParserTests.swift
+++ b/Tests/GISToolsTests/Query/QueryParserTests.swift
@@ -633,7 +633,7 @@ struct QueryParserTests {
     func invalidQueriesReturnNil() {
         // These degenerate inputs parse as search values, not nil,
         // so check that the pipeline is non-nil instead.
-        #expect(QueryParser(string: "(") != nil)
+        #expect(QueryParser(string: "(") == nil)
         #expect(QueryParser(string: ".") != nil)
         #expect(QueryParser(string: "==") != nil)
         #expect(QueryParser(string: "near(") == nil)
@@ -763,6 +763,276 @@ struct QueryParserTests {
         // Should have: value, literalSet, in, value, literal, contains,
         //              value, literal, >=, near, and, and, and
         #expect(pipeline.count == 13)
+    }
+
+    // MARK: - Parenthesized groups
+
+    @Test
+    func parensInsideString() throws {
+        #expect(QueryParser(string: #".name == "test(value)""#) != nil)
+        #expect(QueryParser(string: ".name == 'test(value)'") != nil)
+        #expect(QueryParser(string: #".name in ["a(b)", "c)d"]"#) != nil)
+    }
+
+    @Test
+    func basicGrouping() throws {
+        let expr = #"(.name == "a" AND .value == 1) OR .other == "b""#
+        let parser = try #require(QueryParser(string: expr))
+        #expect(parser.pipeline != nil)
+    }
+
+    @Test
+    func groupingWithParensInStrings() throws {
+        let expr = #"(.name == "test(a)" OR .value == 2) AND .other == "b""#
+        let parser = try #require(QueryParser(string: expr))
+        #expect(parser.pipeline != nil)
+    }
+
+    @Test
+    func notBeforeGroup() throws {
+        let expr = "NOT (.name == 'a' AND .value == 1)"
+        let parser = try #require(QueryParser(string: expr))
+        #expect(parser.pipeline != nil)
+    }
+
+    @Test
+    func nestedGroups() throws {
+        let expr = "( (.a == 1 AND .b == 2) OR (.c == 3 AND .d == 4) ) AND .e == 5"
+        let parser = try #require(QueryParser(string: expr))
+        #expect(parser.pipeline != nil)
+    }
+
+    @Test
+    func unmatchedParensReturnNil() throws {
+        #expect(QueryParser(string: ".name == \"a\")") == nil)
+        #expect(QueryParser(string: "(.name == \"a\"") == nil)
+    }
+
+    @Test
+    func groupedEvaluation() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: [
+            "name": "Berlin",
+            "value": 5,
+        ])
+        var parser = try #require(QueryParser(string: #"(.name == "Berlin" AND .value == 5) OR .other == "nope""#))
+        #expect(parser.evaluate(on: feature))
+
+        parser = try #require(QueryParser(string: #".name == "Berlin" AND (.value == 999 OR .other == "nope")"#))
+        #expect(parser.evaluate(on: feature) == false)
+    }
+
+    @Test
+    func parensAroundSingleExpression() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: ["a": 1])
+        let parser = try #require(QueryParser(string: "(.a == 1)"))
+        #expect(parser.evaluate(on: feature))
+    }
+
+    // MARK: - Edge cases
+
+    @Test
+    func stringEscaping() throws {
+        #expect(QueryParser(string: #".name == "it's fine""#) != nil)
+        #expect(QueryParser(string: ".name == 'he said \"hello\"'") != nil)
+        #expect(QueryParser(string: #".tags in ["it's", '"hello"']"#) != nil)
+        #expect(QueryParser(string: #".name == "   ""#) != nil)
+        #expect(QueryParser(string: ".name == 'straße'") != nil)
+        #expect(QueryParser(string: ".name == 'café'") != nil)
+    }
+
+    @Test
+    func stringEscapingEvaluation() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: [
+            "name": "it's fine",
+            "greeting": "hello \"world\"",
+            "unicode": "café",
+        ])
+        var parser = try #require(QueryParser(string: #".name == "it's fine""#))
+        #expect(parser.evaluate(on: feature))
+        parser = try #require(QueryParser(string: ".greeting == 'hello \"world\"'"))
+        #expect(parser.evaluate(on: feature))
+        parser = try #require(QueryParser(string: ".unicode == 'café'"))
+        #expect(parser.evaluate(on: feature))
+    }
+
+    @Test
+    func numericEdgeCases() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: [
+            "large": Int.max,
+            "small": Int.min,
+            "negative": -42,
+            "zero": 0,
+        ])
+        #expect(QueryParser(pipeline: [.value([.key("large")]), .literal(Int.max), .comparison(.equals)]).evaluate(on: feature))
+        #expect(QueryParser(pipeline: [.value([.key("negative")]), .literal(-42), .comparison(.equals)]).evaluate(on: feature))
+        #expect(QueryParser(pipeline: [.value([.key("zero")]), .literal(0), .comparison(.equals)]).evaluate(on: feature))
+        let parser = try #require(QueryParser(string: ".negative == -42"))
+        #expect(parser.evaluate(on: feature))
+    }
+
+    @Test
+    func propertyAccessEdgeCases() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: [
+            "a": ["b": ["c": ["d": 42]]] as [String: Sendable],
+            "arr": [1, 2, 3],
+            "empty_arr": [] as [Sendable],
+        ])
+        #expect(QueryParser(pipeline: [
+            .value([.key("a"), .key("b"), .key("c"), .key("d")]), .literal(42), .comparison(.equals)]).evaluate(on: feature))
+        #expect(QueryParser(pipeline: [
+            .value([.key("arr"), .index(0)]), .literal(1), .comparison(.equals)]).evaluate(on: feature))
+        #expect(QueryParser(pipeline: [
+            .value([.key("arr"), .index(999)]), .literal(1), .comparison(.equals)]).evaluate(on: feature) == false)
+        #expect(QueryParser(pipeline: [
+            .value([.key("empty_arr"), .index(0)]), .literal(1), .comparison(.equals)]).evaluate(on: feature) == false)
+        #expect(QueryParser(pipeline: [
+            .value([.key("nonexistent")]), .literal(1), .comparison(.equals)]).evaluate(on: feature) == false)
+    }
+
+    @Test
+    func spatialEdgeCases() throws {
+        let origin = Coordinate3D(latitude: 10.0, longitude: 20.0)
+        var parser = QueryParser(pipeline: [.near(origin, 0.0)])
+        #expect(parser.evaluate(on: Feature(Point(origin), properties: [:])))
+        parser = QueryParser(pipeline: [.near(origin, -1.0)])
+        #expect(parser.evaluate(on: Feature(Point(Coordinate3D(latitude: 10.001, longitude: 20.001)), properties: [:])) == false)
+
+        let point = Coordinate3D(latitude: 5.0, longitude: 10.0)
+        let degenerate = BoundingBox(southWest: point, northEast: point)
+        parser = QueryParser(pipeline: [.intersects(degenerate)])
+        #expect(parser.evaluate(on: Feature(Point(point), properties: [:])))
+
+        let poly = try #require(Polygon([[
+            Coordinate3D(latitude: 10.0, longitude: 20.0),
+            Coordinate3D(latitude: 11.0, longitude: 20.0),
+            Coordinate3D(latitude: 11.0, longitude: 21.0),
+            Coordinate3D(latitude: 10.0, longitude: 21.0),
+            Coordinate3D(latitude: 10.0, longitude: 20.0),
+        ]]))
+        parser = QueryParser(pipeline: [.near(Coordinate3D(latitude: 10.5, longitude: 20.5), 1_000_000.0)])
+        #expect(parser.evaluate(on: Feature(poly, properties: [:])))
+    }
+
+    @Test
+    func booleanEdgeCases() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: ["a": 1, "b": 2, "c": 3])
+
+        #expect(QueryParser(pipeline: [
+            .value([.key("a")]), .condition(.not), .condition(.not), .condition(.not)]).evaluate(on: feature) == false)
+        #expect(QueryParser(pipeline: [
+            .value([.key("nonexistent")]), .condition(.not), .condition(.not)]).evaluate(on: feature) == false)
+        #expect(QueryParser(pipeline: [
+            .value([.key("a")]), .literal(1), .comparison(.equals),
+            .value([.key("b")]), .literal(2), .comparison(.equals),
+            .condition(.and),
+            .value([.key("c")]), .literal(3), .comparison(.equals),
+            .condition(.and),
+        ]).evaluate(on: feature))
+    }
+
+    @Test
+    func booleanChaining() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: ["a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6, "g": 7, "h": 8, "i": 9, "j": 10])
+
+        let query = ".a == 1 and .b == 2 and .c == 3 and .d == 4 and .e == 5 and .f == 6 and .g == 7 and .h == 8 and .i == 9 and .j == 10"
+        var parser = try #require(QueryParser(string: query))
+        #expect(parser.evaluate(on: feature))
+
+        let queryFail = ".a == 1 and .b == 2 and .c == 3 and .d == 4 and .e == 5 and .f == 6 and .g == 7 and .h == 8 and .i == 9 and .j == 999"
+        parser = try #require(QueryParser(string: queryFail))
+        #expect(parser.evaluate(on: feature) == false)
+
+        let condition = ".a == 1 and "
+        let longQuery = String(repeating: condition, count: 100) + ".a == 1"
+        parser = try #require(QueryParser(string: longQuery))
+        #expect(parser.evaluate(on: feature))
+
+        let veryLongQuery = String(repeating: condition, count: 1000) + ".a == 1"
+        parser = try #require(QueryParser(string: veryLongQuery))
+        #expect(parser.evaluate(on: feature))
+    }
+
+    @Test
+    func keywordsAsValues() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: [
+            "word_and": "and", "word_or": "or", "word_not": "not",
+            "word_exists": "exists", "word_in": "in",
+        ])
+        #expect(try #require(QueryParser(string: #".word_and == "and""#)).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: ".word_or == 'or'")).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: #".word_not == "not""#)).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: ".word_exists == 'exists'")).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: #".word_in == "in""#)).evaluate(on: feature))
+    }
+
+    @Test
+    func whitespaceEdgeCases() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: ["a": 1])
+        #expect(try #require(QueryParser(string: ".a\t==\t1")).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: ".a\n==\n1")).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: "\n\n  .a   ==   1  \n")).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: ".a in [ 1 , 2 , 3 ]")).evaluate(on: feature))
+    }
+
+    @Test
+    func caseInsensitiveKeywords() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: ["a": 1, "b": 2])
+        #expect(try #require(QueryParser(string: ".a == 1 AND .b == 2")).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: ".a == 1 And .b == 2")).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: ".a == 1 OR .b == 2")).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: "NOT .a == 1")).evaluate(on: feature) == false)
+    }
+
+    @Test
+    func osmLikeQueries() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 48.85, longitude: 2.35)), properties: [
+            "highway": "primary", "name": "Rue de Rivoli", "maxspeed": 50,
+            "oneway": true, "surface": "asphalt", "lanes": 4, "bridge": "yes",
+        ])
+        let queries: [(String, Bool)] = [
+            (#".highway in ["primary", "secondary"] and .maxspeed >= 30 and .surface == "asphalt""#, true),
+            (#".bridge exists and .oneway exists and .lanes >= 2"#, true),
+            (#".highway == "motorway" and .surface == "concrete""#, false),
+            ("near(48.85, 2.35, 1000) and .highway == \"primary\"",  true),
+            (#".bridge exists and .tunnel not"#, true),
+            (#"(.highway in ["primary", "secondary"] AND .surface == "asphalt") OR .bridge == "yes""#, true),
+        ]
+        for (query, expected) in queries {
+            let parser = try #require(QueryParser(string: query))
+            #expect(parser.evaluate(on: feature) == expected, "Failed for query: \(query)")
+        }
+    }
+
+    @Test
+    func existsWithVariousTypes() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: [
+            "str": "", "zero": 0,
+        ])
+        #expect(QueryParser(pipeline: [.value([.key("str")]), .condition(.exists)]).evaluate(on: feature))
+        #expect(QueryParser(pipeline: [.value([.key("zero")]), .condition(.exists)]).evaluate(on: feature))
+        #expect(QueryParser(pipeline: [.value([.key("totally_missing")]), .condition(.exists)]).evaluate(on: feature) == false)
+    }
+
+    @Test
+    func missingPropertyComparisons() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: ["only_key": 1])
+        #expect(QueryParser(pipeline: [
+            .value([.key("missing")]), .literal(1), .comparison(.equals)]).evaluate(on: feature) == false)
+        #expect(QueryParser(pipeline: [
+            .value([.key("missing")]), .literal(1), .comparison(.notEquals)]).evaluate(on: feature) == false)
+        #expect(QueryParser(pipeline: [
+            .value([.key("missing")]), .literal(1), .comparison(.greaterThan)]).evaluate(on: feature) == false)
+        #expect(QueryParser(pipeline: [
+            .value([.key("missing")]), .literal("x"), .comparison(.contains)]).evaluate(on: feature) == false)
+        #expect(QueryParser(pipeline: [
+            .value([.key("missing")]), .literalSet([1]), .comparison(.in)]).evaluate(on: feature) == false)
+    }
+
+    @Test
+    func deeplyNestedParens() throws {
+        let feature = Feature(Point(Coordinate3D(latitude: 0.0, longitude: 0.0)), properties: ["a": 1, "b": 2])
+        #expect(try #require(QueryParser(string: "(((.a == 1))) AND (.b == 2)")).evaluate(on: feature))
+        #expect(try #require(QueryParser(string: "((.a == 1 AND .b == 2) OR (.a == 999 AND .b == 999)) AND (.a == 1)")).evaluate(on: feature))
     }
 
 }


### PR DESCRIPTION
- Parenthesized expressions: (A AND B) OR C via recursive parsing
- All comparison operators handle nil values gracefully (push false)
- Whitespace handling: tabs, newlines, carriage returns everywhere
- String escaping: mixed quotes, Unicode characters
- Numeric edge cases: Int min/max, negative values
- Property access: deep nesting, array bounds
- Spatial edge cases: zero/negative tolerance, degenerate bboxes
- Boolean logic: triple not, long chains (1000 conditions)
- Keywords as property values (and, or, not, exists, in)
- Case-insensitive keywords (AND, AND, OR)
- OSM-like multi-condition spatial queries
- Missing property comparisons safely return false
- DocC and README updated with parentheses syntax documentation

Closes #217 