### PR TITLE
Add MapTile ancestry, descendant, and containment methods

### DIFF
--- a/Sources/GISTools/Other/MapTile.swift
+++ b/Sources/GISTools/Other/MapTile.swift
@@ -378,6 +378,105 @@ public struct MapTile: CustomStringConvertible, Sendable {
         GISTool.metersPerPixel(atZoom: z, latitude: centerCoordinate().latitude)
     }
 
+    // MARK: - Ancestry / Descendant
+
+    /// Returns `true` if this tile is an ancestor of `other`.
+    ///
+    /// A tile is an ancestor of another if the other tile can be reached by
+    /// repeatedly applying ``children`` (i.e. the other tile is at a higher
+    /// zoom level and falls within this tile's quadrant). A tile is not
+    /// considered an ancestor of itself.
+    ///
+    /// - Parameter other: The potential descendant tile.
+    /// - Returns: `true` if this tile is an ancestor of `other`.
+    public func isAncestorOf(_ other: MapTile) -> Bool {
+        guard other.z > z else { return false }
+        var tile = other
+        while tile.z > z {
+            tile = tile.parent
+        }
+        return tile == self
+    }
+
+    /// Returns `true` if this tile is a descendant of `other`.
+    ///
+    /// A tile is a descendant of another if this tile can be reached by
+    /// repeatedly applying ``children`` from the other tile (i.e. this tile
+    /// is at a higher zoom level and falls within the other tile's quadrant).
+    /// A tile is not considered a descendant of itself.
+    ///
+    /// - Parameter other: The potential ancestor tile.
+    /// - Returns: `true` if this tile is a descendant of `other`.
+    public func isDescendantOf(_ other: MapTile) -> Bool {
+        other.isAncestorOf(self)
+    }
+
+    /// Returns `true` if this tile is an ancestor or descendant of `other`,
+    /// or if they are the same tile.
+    ///
+    /// Two tiles are related if one can be reached from the other by walking
+    /// the ``parent`` chain. Tiles at the same zoom are related only if they
+    /// are identical.
+    ///
+    /// - Parameter other: The tile to check for a relationship.
+    /// - Returns: `true` if the tiles are ancestors, descendants, or identical.
+    public func isRelated(to other: MapTile) -> Bool {
+        if self == other { return true }
+        return isAncestorOf(other) || isDescendantOf(other)
+    }
+
+    /// All ancestor tiles from the immediate parent up to the root tile
+    /// (z = 0), ordered from nearest (smallest zoom difference) to farthest.
+    ///
+    /// At zoom level 0 this is an empty array.
+    public var ancestors: [MapTile] {
+        guard z > 0 else { return [] }
+        var result: [MapTile] = []
+        var tile = parent
+        while tile.z >= 0 {
+            result.append(tile)
+            if tile.z == 0 { break }
+            tile = tile.parent
+        }
+        return result
+    }
+
+    /// All descendant tiles of this tile at the given target zoom level.
+    ///
+    /// The target zoom must be greater than or equal to this tile's zoom.
+    /// If the target zoom equals this tile's zoom, the result contains only
+    /// this tile. If the target zoom is less than this tile's zoom, the result
+    /// is empty.
+    ///
+    /// - Parameter zoom: The target zoom level.
+    /// - Returns: An array of descendant tiles at the given zoom level.
+    public func descendants(atZoom zoom: Int) -> [MapTile] {
+        guard zoom >= z else { return [] }
+        if zoom == z { return [self] }
+
+        var tiles: [MapTile] = [self]
+        for _ in z ..< zoom {
+            tiles = tiles.flatMap { $0.children }
+        }
+        return tiles
+    }
+
+    // MARK: - Containment
+
+    /// Returns `true` if the given geographic coordinate falls within this
+    /// tile's bounding box.
+    ///
+    /// The coordinate is projected to EPSG:4326 before testing. Coordinates
+    /// exactly on the tile boundary (east or south edge) are considered
+    /// outside, matching the half-open interval convention used by the
+    /// tile pyramid.
+    ///
+    /// - Parameter coordinate: The geographic coordinate to test.
+    /// - Returns: `true` if the coordinate is within this tile.
+    public func contains(_ coordinate: Coordinate3D) -> Bool {
+        boundingBox().contains(coordinate.projected(to: .epsg4326))
+    }
+
     // MARK: - Private
 
     /// Normalizes a coordinate for tile indexing using Web Mercator projection.

--- a/Tests/GISToolsTests/Other/MapTileTests.swift
+++ b/Tests/GISToolsTests/Other/MapTileTests.swift
@@ -372,4 +372,122 @@ struct MapTileTests {
         #expect(MapTile(string: "16/34626/22899") == MapTile(x: 34626, y: 22899, z: 16))
     }
 
+    // MARK: - Ancestry
+
+    // Verifies isAncestorOf for direct parents, grandparents, and non-ancestors.
+    @Test
+    func isAncestorOf() async throws {
+        let parent = MapTile(x: 1, y: 1, z: 2)
+        // Direct children at z=3
+        #expect(parent.isAncestorOf(MapTile(x: 2, y: 2, z: 3)))
+        #expect(parent.isAncestorOf(MapTile(x: 3, y: 2, z: 3)))
+        #expect(parent.isAncestorOf(MapTile(x: 2, y: 3, z: 3)))
+        #expect(parent.isAncestorOf(MapTile(x: 3, y: 3, z: 3)))
+        // Grandchildren at z=4
+        #expect(parent.isAncestorOf(MapTile(x: 4, y: 4, z: 4)))
+        #expect(parent.isAncestorOf(MapTile(x: 7, y: 7, z: 4)))
+        // Not a descendant
+        #expect(!parent.isAncestorOf(MapTile(x: 0, y: 0, z: 3)))
+        #expect(!parent.isAncestorOf(MapTile(x: 0, y: 0, z: 4)))
+        // Same tile is not an ancestor of itself
+        #expect(!parent.isAncestorOf(parent))
+        // Higher zoom is not an ancestor of lower zoom
+        #expect(!MapTile(x: 2, y: 2, z: 3).isAncestorOf(parent))
+    }
+
+    // Verifies isDescendantOf is the inverse of isAncestorOf.
+    @Test
+    func isDescendantOf() async throws {
+        let child = MapTile(x: 2, y: 2, z: 3)
+        #expect(child.isDescendantOf(MapTile(x: 1, y: 1, z: 2)))
+        #expect(child.isDescendantOf(MapTile(x: 0, y: 0, z: 0)))
+        // Not a descendant
+        #expect(!child.isDescendantOf(MapTile(x: 0, y: 0, z: 2)))
+        // Same tile
+        #expect(!child.isDescendantOf(child))
+        // Lower zoom is not a descendant of higher zoom
+        #expect(!MapTile(x: 1, y: 1, z: 2).isDescendantOf(child))
+    }
+
+    // Verifies isRelated covers ancestors, descendants, and identity.
+    @Test
+    func isRelated() async throws {
+        let tile = MapTile(x: 2, y: 2, z: 3)
+        // Same tile
+        #expect(tile.isRelated(to: tile))
+        // Ancestor
+        #expect(tile.isRelated(to: MapTile(x: 1, y: 1, z: 2)))
+        #expect(tile.isRelated(to: MapTile(x: 0, y: 0, z: 0)))
+        // Descendant
+        #expect(tile.isRelated(to: MapTile(x: 4, y: 4, z: 4)))
+        #expect(tile.isRelated(to: MapTile(x: 4, y: 5, z: 4)))
+        // Not related
+        #expect(!tile.isRelated(to: MapTile(x: 0, y: 0, z: 2)))
+        #expect(!tile.isRelated(to: MapTile(x: 1, y: 0, z: 2)))
+        #expect(!tile.isRelated(to: MapTile(x: 3, y: 3, z: 3)))
+    }
+
+    // Verifies ancestors returns the chain from immediate parent to root.
+    @Test
+    func ancestors() async throws {
+        let tile = MapTile(x: 4, y: 6, z: 3)
+        let chain = tile.ancestors
+        #expect(chain.count == 3)
+        #expect(chain[0] == MapTile(x: 2, y: 3, z: 2))
+        #expect(chain[1] == MapTile(x: 1, y: 1, z: 1))
+        #expect(chain[2] == MapTile(x: 0, y: 0, z: 0))
+
+        // z=0 has no ancestors
+        #expect(MapTile(x: 0, y: 0, z: 0).ancestors.isEmpty)
+    }
+
+    // Verifies descendants(atZoom:) returns all tiles at the target zoom.
+    @Test
+    func descendants() async throws {
+        let tile = MapTile(x: 1, y: 1, z: 2)
+
+        // Same zoom → just self
+        #expect(tile.descendants(atZoom: 2) == [tile])
+
+        // One level deeper → 4 children
+        let d3 = tile.descendants(atZoom: 3)
+        #expect(d3.count == 4)
+        #expect(d3.contains(MapTile(x: 2, y: 2, z: 3)))
+        #expect(d3.contains(MapTile(x: 3, y: 2, z: 3)))
+        #expect(d3.contains(MapTile(x: 2, y: 3, z: 3)))
+        #expect(d3.contains(MapTile(x: 3, y: 3, z: 3)))
+
+        // Two levels deeper → 16 grandchildren
+        #expect(tile.descendants(atZoom: 4).count == 16)
+
+        // Lower zoom → empty
+        #expect(tile.descendants(atZoom: 1).isEmpty)
+    }
+
+    // MARK: - Containment
+
+    // Verifies contains for coordinates inside and outside a tile.
+    @Test
+    func containsCoordinate() async throws {
+        // z=2, x=1, y=1 covers lon -90..0, lat 0..66.51 (northern hemisphere,
+        // second row from the top in the XYZ convention where y=0 is north).
+        let tile = MapTile(x: 1, y: 1, z: 2)
+
+        // Interior point
+        let interior = Coordinate3D(latitude: 40.0, longitude: -45.0)
+        #expect(tile.contains(interior))
+
+        // Near NW corner (interior)
+        let nearNw = Coordinate3D(latitude: 60.0, longitude: -89.5)
+        #expect(tile.contains(nearNw))
+
+        // Outside (wrong longitude)
+        let east = Coordinate3D(latitude: 40.0, longitude: 45.0)
+        #expect(!tile.contains(east))
+
+        // Outside (wrong latitude — southern hemisphere)
+        let south = Coordinate3D(latitude: -40.0, longitude: -45.0)
+        #expect(!tile.contains(south))
+    }
+
 }


### PR DESCRIPTION
## Summary

Adds tile pyramid navigation methods to `MapTile` for determining relationships between tiles at different zoom levels and checking geographic containment.

## New methods

| Method | Description |
|--------|-------------|
| `isAncestorOf(_:)` | True if this tile is an ancestor of the given tile (the other is at a higher zoom and within this tile's quadrant) |
| `isDescendantOf(_:)` | True if this tile is a descendant of the given tile (inverse of `isAncestorOf`) |
| `isRelated(to:)` | True if tiles are ancestors, descendants, or identical |
| `ancestors` | Array of all parent tiles from immediate parent to z=0 |
| `descendants(atZoom:)` | All child tiles at a target zoom level (4^n descendants) |
| `contains(_:)` | True if a geographic coordinate falls within the tile's bounding box |

## Motivation

These methods support tile pyramid navigation use cases such as:
- **Overzooming/underzooming vector tiles** — determining whether a source tile can be rezoomed to a target tile (the source must be an ancestor or descendant of the target). See [mvt-tools#46](https://github.com/Outdooractive/mvt-tools/issues/46).
- **Tile coverage checks** — enumerating all tiles at a target zoom that descend from a given tile.
- **Spatial containment** — testing whether a coordinate falls within a specific tile.

## API design

- `isAncestorOf` and `isDescendantOf` are inverses; `isRelated` is the convenience union (including identity).
- `ancestors` returns the chain from the immediate parent to z=0, ordered nearest to farthest.
- `descendants(atZoom:)` handles arbitrary zoom differences via repeated `flatMap { $0.children }`.
- `contains(_:)` projects the coordinate to EPSG:4326 and delegates to `BoundingBox.contains`.

## Tests

6 new test functions in `MapTileTests`:
- `isAncestorOf()` — direct children, grandchildren, non-ancestors, self, inverse direction
- `isDescendantOf()` — inverse of `isAncestorOf`
- `isRelated()` — ancestors, descendants, identity, unrelated tiles
- `ancestors()` — full chain from z=3 to z=0, empty at z=0
- `descendants()` — same zoom (self), 4 children, 16 grandchildren, lower zoom (empty)
- `containsCoordinate()` — interior, near-corner, outside (wrong lon), outside (wrong lat)

## Test plan

- [x] `swift build` — clean, no warnings
- [x] `swift test --filter MapTileTests` — 24/24 pass
- [x] `swift test` — 1991/1991 pass across 138 suites