### PR TITLE
Clamp ECEF-to-geodetic latitude to [-90, 90]

### DIFF
--- a/Sources/GISTools/GeoJson/Coordinate3D.swift
+++ b/Sources/GISTools/GeoJson/Coordinate3D.swift
@@ -691,18 +691,19 @@ extension Coordinate3D {
         }
 
         var phi = atan2(z, p * (1.0 - e2))
-        for _ in 0..<10 {
+        var h: Double = 0.0
+        for _ in 0 ..< 10 {
             let sinPhi = sin(phi)
+            let cosPhi = cos(phi)
             let N = a / sqrt(1.0 - e2 * sinPhi * sinPhi)
-            let h = p / cos(phi) - N
+            h = p / cosPhi - N
             phi = atan2(z * (N + h), p * ((1.0 - e2) * N + h))
         }
 
-        let sinPhi = sin(phi)
-        let N = a / sqrt(1.0 - e2 * sinPhi * sinPhi)
-        let h = p / cos(phi) - N
-
-        let lat = phi * 180.0 / .pi
+        // Clamp latitude to the valid geodetic range. The iterative solver
+        // can diverge for points near the geocenter (huge negative altitude),
+        // producing |lat| > 90.
+        let lat = Swift.min(90.0, Swift.max(-90.0, phi * 180.0 / .pi))
         let lon = atan2(y, x) * 180.0 / .pi
 
         return (lat, lon, h)

--- a/Tests/GISToolsTests/GeoJson/ProjectionTests.swift
+++ b/Tests/GISToolsTests/GeoJson/ProjectionTests.swift
@@ -129,6 +129,26 @@ struct ProjectionTests {
         #expect(abs(merc.latitude - via4326.latitude) < 0.001)
     }
 
+    /// Tests that near-geocenter ECEF coordinates project to valid latitudes
+    /// in [-90, 90]. The iterative ECEF→geodetic solver can diverge for
+    /// points near the geocenter (huge negative altitude), producing
+    /// |latitude| > 90 without clamping.
+    @Test
+    func convertFrom4978NearOriginClampsLatitude() {
+        let nearOriginPoints: [(x: Double, y: Double, z: Double)] = [
+            (0.0, 0.0, 0.0),
+            (1_000.0, 0.0, 0.0),
+            (1_000.0, 1_000.0, 0.0),
+            (0.0, 1_000.0, 0.0),
+            (500.0, 500.0, 0.0),
+        ]
+        for (x, y, z) in nearOriginPoints {
+            let geo = Coordinate3D(x: x, y: y, z: z, projection: .epsg4978).projected(to: .epsg4326)
+            #expect(geo.latitude >= -90.0, "latitude \(geo.latitude) < -90 for ECEF (\(x), \(y), \(z))")
+            #expect(geo.latitude <= 90.0, "latitude \(geo.latitude) > 90 for ECEF (\(x), \(y), \(z))")
+        }
+    }
+
     /// Validates that each projection case reports the correct SRID number.
     @Test
     func cases() async throws {


### PR DESCRIPTION
The iterative ECEF-to-geodetic solver in ecefToGeodetic can diverge for points near the geocenter (huge negative altitude), producing |latitude| > 90. This caused BoundingBox.contains to reject valid points and made Polygon.intersects return false for contained ECEF points (intersectsEPSG4978 test failure).

Clamp the resulting latitude to the valid geodetic range and add a regression test for near-origin ECEF coordinates.