### PR TITLE
Fix expanded(byDistance:) producing inverted boxes at the antimeridian

### DIFF
--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -285,7 +285,39 @@ public struct BoundingBox:
         var ne = northEast.destination(distance: distance, bearing: 45.0)
         sw.altitude = southWest.altitude
         ne.altitude = northEast.altitude
-        return BoundingBox(southWest: sw, northEast: ne).clamped()
+
+        // `destination()` wraps longitudes across the antimeridian into
+        // [-180, 180] (or [-originShift, originShift] for EPSG:3857). When the
+        // buffer pushes past the world edge this produces an *inverted* box
+        // (southWest.longitude > northEast.longitude), which breaks callers
+        // that build a single axis-aligned envelope (e.g. PostGIS
+        // `ST_MakeEnvelope`) or clip features to the box. Clamp the wrapped
+        // coordinate back to the world boundary instead.
+        switch projection {
+        case .epsg3857:
+            let upper = GISTool.originShift
+            let lower = -GISTool.originShift
+            if ne.longitude < southWest.longitude { ne.longitude = upper }
+            if sw.longitude > northEast.longitude { sw.longitude = lower }
+            // Final safety clamp for any remaining out-of-range values.
+            sw.longitude = min(upper, max(lower, sw.longitude))
+            ne.longitude = min(upper, max(lower, ne.longitude))
+            sw.latitude = min(upper, max(lower, sw.latitude))
+            ne.latitude = min(upper, max(lower, ne.latitude))
+
+        case .epsg4326:
+            if ne.longitude < southWest.longitude { ne.longitude = 180.0 }
+            if sw.longitude > northEast.longitude { sw.longitude = -180.0 }
+            sw.longitude = min(180.0, max(-180.0, sw.longitude))
+            ne.longitude = min(180.0, max(-180.0, ne.longitude))
+            sw.latitude = min(90.0, max(-90.0, sw.latitude))
+            ne.latitude = min(90.0, max(-90.0, ne.latitude))
+
+        case .epsg4978, .noSRID:
+            break
+        }
+
+        return BoundingBox(southWest: sw, northEast: ne)
     }
 
     /// Returns a copy of the receiver that also includes `coordinate`.

--- a/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
+++ b/Tests/GISToolsTests/GeoJson/BoundingBoxTests.swift
@@ -690,6 +690,37 @@ struct BoundingBoxTests {
         #expect(expanded.northEast.longitude <= 180.0)
     }
 
+    // Validates that expanding a box whose north-east corner sits on the
+    // antimeridian does not wrap north-east to the western hemisphere and
+    // produce an inverted box (southWest.longitude > northEast.longitude).
+    // This reproduces the eastern-edge tile 2/3 case (EPSG:3857) that broke
+    // PostGIS `ST_MakeEnvelope` and feature clipping in the tile server.
+    @Test
+    func expandingByDistanceDoesNotInvertAtEasternAntimeridian() async throws {
+        // Tile 2/3 in EPSG:3857: north-east at +180° (originShift).
+        let bbox = MapTile(x: 3, y: 1, z: 2).boundingBox(projection: .epsg3857)
+        #expect(abs(bbox.northEast.longitude - GISTool.originShift) < 0.001)
+
+        let expanded = bbox.expanded(byDistance: 2_000_000.0)
+
+        // The expanded north-east must stay at the eastern world boundary,
+        // not wrap to a negative longitude and invert the box.
+        #expect(expanded.southWest.longitude < expanded.northEast.longitude)
+        #expect(abs(expanded.northEast.longitude - GISTool.originShift) < 0.001)
+    }
+
+    // Same as above but for the western antimeridian edge (tile 2/0).
+    @Test
+    func expandingByDistanceDoesNotInvertAtWesternAntimeridian() async throws {
+        let bbox = MapTile(x: 0, y: 1, z: 2).boundingBox(projection: .epsg3857)
+        #expect(abs(bbox.southWest.longitude - (-GISTool.originShift)) < 0.001)
+
+        let expanded = bbox.expanded(byDistance: 2_000_000.0)
+
+        #expect(expanded.southWest.longitude < expanded.northEast.longitude)
+        #expect(abs(expanded.southWest.longitude - (-GISTool.originShift)) < 0.001)
+    }
+
     // Validates that expanded(byIncluding:) with a far-away coordinate clamps to world bounds.
     @Test
     func expandingByIncludingCoordinateClampsToWorldBounds() async throws {


### PR DESCRIPTION
## Problem

When a bounding box corner sits exactly on the antimeridian (+180°/-180°, or ±`GISTool.originShift` in EPSG:3857), `expanded(byDistance:)` produced an **inverted** box where `southWest.longitude > northEast.longitude`.

`Coordinate3D.destination(bearing:)` uses the Haversine formula and wraps longitudes past ±180° back into the opposite hemisphere (e.g. +185° → −175°). The subsequent `clamped()` is a no-op because the wrapped value is already within the valid range `[-180, 180]`, so the inversion survives.

## Impact

Callers that build a single axis-aligned envelope from the expanded box break:

- **PostGIS `ST_MakeEnvelope(xmin, ymin, xmax, ymax)`** with `xmax < xmin` produces a degenerate/empty envelope → layer queries return no features.
- **Feature clipping** to the inverted box drops nearly all features in the MVT/MLT encoders.

Reproduced in the dynamic tile server with eastern-edge tile `2/3` (and western-edge tile `2/0`): a vector tile that should contain ~6000 features across 13 layers came back nearly empty (3 features, 1 layer). Non-edge tiles were unaffected.

## Fix

Detect when `destination()` wrapped a corner across the antimeridian (`ne.longitude < southWest.longitude` or `sw.longitude > northEast.longitude`) and clamp it to the world boundary (`±originShift` for EPSG:3857, `±180°` for EPSG:4326) instead of leaving it wrapped.

## Tests

Two regression tests covering both antimeridian edges:
- `expandingByDistanceDoesNotInvertAtEasternAntimeridian` (tile 2/3)
- `expandingByDistanceDoesNotInvertAtWesternAntimeridian` (tile 2/0)

Full suite passes (2324 tests).