### PR TITLE
Add geometry format auto-detection to GeoJsonReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,26 @@ static func geoJsonFrom(jsonData: Data) -> GeoJson?
 static func geoJsonFrom(jsonString: String) -> GeoJson?
 ```
 
+The reader can also auto-detect a geometry from a string or data payload, regardless of whether it is GeoJSON, WKT (with or without an `SRID=…;` prefix), or hex-encoded WKB/EWKB/TWKB:
+```swift
+/// Try to initialize a geometry from a string, auto-detecting the format.
+static func geometryFrom(string: String, targetProjection: Projection = .epsg4326) -> GeoJsonGeometry?
+
+/// Try to initialize a geometry from data, auto-detecting the format.
+static func geometryFrom(data: Data, targetProjection: Projection = .epsg4326) -> GeoJsonGeometry?
+```
+
 Example:
+```swift
+// A PostGIS EWKB hex string (SRID 3857) is decoded and projected to EPSG:4326.
+let ewkb = "0102000020110F00000F000000B1AB426CB24C3141FF9A56141D015741..."
+let lineString = GeoJsonReader.geometryFrom(string: ewkb) as! LineString
+
+// Plain WKT and SRID-prefixed WKT are both recognized.
+let point = GeoJsonReader.geometryFrom(string: "SRID=4326;POINT (11.5 48.1)") as! Point
+```
+
+The `geoJsonFrom` methods work on any GeoJSON-shaped input:
 ```swift
 let json: [String: Any] = [
     "type": "Point",

--- a/Sources/GISTools/Extensions/DataExtensions.swift
+++ b/Sources/GISTools/Extensions/DataExtensions.swift
@@ -13,7 +13,7 @@ extension Data {
             .map { String(chars[$0]) + String(chars[$0 + 1]) }
             .compactMap { UInt8($0, radix: 16) }
 
-        guard hex.count / bytes.count == 2 else { return nil }
+        guard !bytes.isEmpty, hex.count / bytes.count == 2 else { return nil }
 
         self.init(bytes)
     }

--- a/Sources/GISTools/GeoJson/GeoJsonReader.swift
+++ b/Sources/GISTools/GeoJson/GeoJsonReader.swift
@@ -47,4 +47,101 @@ public enum GeoJsonReader {
         return geoJsonFrom(json: json)
     }
 
+    // MARK: - Geometry auto-detection
+
+    /// Try to initialize a geometry from a string, auto-detecting the format.
+    ///
+    /// The following formats are recognized, in order:
+    /// 1. GeoJSON (a JSON object with a `type` field).
+    /// 2. WKT, with or without an `SRID=…;` prefix.
+    /// 3. Hex-encoded WKB, EWKB, or TWKB.
+    ///
+    /// - Parameters:
+    ///    - string: The geometry string to parse.
+    ///    - targetProjection: The projection to decode into (default `.epsg4326`).
+    /// - Returns: A geometry, or `nil` if the string could not be parsed.
+    public static func geometryFrom(
+        string: String,
+        targetProjection: Projection = .epsg4326
+    ) -> GeoJsonGeometry? {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // GeoJSON.
+        if trimmed.hasPrefix("{") {
+            return Feature.tryCreateGeometry(json: try? JSONSerialization.jsonObject(with: Data(trimmed.utf8)))
+        }
+
+        // WKT.
+        if isWKT(trimmed) {
+            let sourceProjection: Projection? = trimmed.hasPrefix("SRID=") ? nil : .epsg4326
+            return try? WKTCoder.decode(wkt: trimmed, sourceProjection: sourceProjection, targetProjection: targetProjection)
+        }
+
+        // Hex-encoded WKB/EWKB/TWKB.
+        if let data = Data(hex: trimmed) {
+            return geometryFrom(data: data, targetProjection: targetProjection)
+        }
+
+        return nil
+    }
+
+    /// Try to initialize a geometry from data, auto-detecting the format.
+    ///
+    /// The following formats are recognized, in order:
+    /// 1. GeoJSON (a JSON object with a `type` field).
+    /// 2. WKB/EWKB.
+    /// 3. TWKB.
+    ///
+    /// When a WKB or TWKB payload carries no embedded SRID, it is assumed to
+    /// be in EPSG:4326.
+    ///
+    /// - Parameters:
+    ///    - data: The geometry data to parse.
+    ///    - targetProjection: The projection to decode into (default `.epsg4326`).
+    /// - Returns: A geometry, or `nil` if the data could not be parsed.
+    public static func geometryFrom(
+        data: Data,
+        targetProjection: Projection = .epsg4326
+    ) -> GeoJsonGeometry? {
+        guard !data.isEmpty else { return nil }
+
+        // GeoJSON.
+        if let json = try? JSONSerialization.jsonObject(with: data),
+           let geometry = Feature.tryCreateGeometry(json: json)
+        {
+            return geometry
+        }
+
+        // WKB/EWKB.
+        if let geometry = try? WKBCoder.decode(wkb: data, sourceProjection: nil, targetProjection: targetProjection) {
+            return geometry
+        }
+        if let geometry = try? WKBCoder.decode(wkb: data, sourceProjection: .epsg4326, targetProjection: targetProjection) {
+            return geometry
+        }
+
+        // TWKB.
+        if let geometry = try? TWKBCoder.decode(twkb: data, sourceProjection: nil, targetProjection: targetProjection) {
+            return geometry
+        }
+        if let geometry = try? TWKBCoder.decode(twkb: data, sourceProjection: .epsg4326, targetProjection: targetProjection) {
+            return geometry
+        }
+
+        return nil
+    }
+
+    /// Whether a string looks like WKT.
+    private static func isWKT(_ string: String) -> Bool {
+        let upper = string.uppercased()
+        let keywords = [
+            "POINT", "LINESTRING", "POLYGON", "MULTIPOINT",
+            "MULTILINESTRING", "MULTIPOLYGON", "GEOMETRYCOLLECTION",
+            "TRIANGLE", "CIRCULARSTRING", "COMPOUNDCURVE", "CURVEPOLYGON",
+            "MULTICURVE", "MULTISURFACE", "POLYHEDRALSURFACE", "TIN",
+        ]
+        return upper.hasPrefix("SRID=") || keywords.contains(where: { upper.hasPrefix($0) })
+    }
+
 }

--- a/Sources/GISTools/GeoJson/WKBCoder.swift
+++ b/Sources/GISTools/GeoJson/WKBCoder.swift
@@ -31,14 +31,14 @@ extension GeoJsonGeometry {
     ///
     /// - Parameters:
     ///    - wkb: The WKB encoded data.
-    ///    - sourceProjection: The source projection.
+    ///    - sourceProjection: The projection of the source coordinates, or `nil` to read the SRID from the WKB data.
     ///    - targetProjection: The target projection (default `.epsg4326`).
     ///    - calculateBoundingBox: Whether to calculate a bounding box (default `false`).
     /// - Returns: A GeoJSON geometry, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkb: Data,
-        sourceProjection: Projection,
+        sourceProjection: Projection?,
         targetProjection: Projection = .epsg4326,
         calculateBoundingBox: Bool = false
     ) {
@@ -73,13 +73,13 @@ extension GeoJsonGeometry {
     ///
     /// - Parameters:
     ///    - wkb: The WKB encoded data.
-    ///    - sourceProjection: The source projection.
+    ///    - sourceProjection: The projection of the source coordinates, or `nil` to read the SRID from the WKB data.
     ///    - targetProjection: The target projection (default `.epsg4326`).
     /// - Returns: A GeoJSON geometry, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func parse(
         wkb: Data,
-        sourceProjection: Projection,
+        sourceProjection: Projection?,
         targetProjection: Projection = .epsg4326
     ) -> GeoJsonGeometry? {
         try? WKBCoder.decode(
@@ -132,7 +132,7 @@ extension Feature {
     ///
     /// - Parameters:
     ///    - wkb: The WKB encoded data.
-    ///    - sourceProjection: The source projection.
+    ///    - sourceProjection: The projection of the source coordinates, or `nil` to read the SRID from the WKB data.
     ///    - targetProjection: The target projection (default `.epsg4326`).
     ///    - id: A feature identifier (default `nil`).
     ///    - properties: Feature properties (default `[:]`).
@@ -141,7 +141,7 @@ extension Feature {
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkb: Data,
-        sourceProjection: Projection,
+        sourceProjection: Projection?,
         targetProjection: Projection = .epsg4326,
         id: Identifier? = nil,
         properties: [String: Sendable] = [:],
@@ -187,14 +187,14 @@ extension FeatureCollection {
     ///
     /// - Parameters:
     ///    - wkb: The WKB encoded data.
-    ///    - sourceProjection: The source projection.
+    ///    - sourceProjection: The projection of the source coordinates, or `nil` to read the SRID from the WKB data.
     ///    - targetProjection: The target projection (default `.epsg4326`).
     ///    - calculateBoundingBox: Whether to calculate a bounding box (default `false`).
     /// - Returns: A FeatureCollection, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public init?(
         wkb: Data,
-        sourceProjection: Projection,
+        sourceProjection: Projection?,
         targetProjection: Projection = .epsg4326,
         calculateBoundingBox: Bool = false
     ) {
@@ -235,12 +235,12 @@ extension Data {
     /// Decode a GeoJSON object from WKB.
     ///
     /// - Parameters:
-    ///    - sourceProjection: The source projection.
+    ///    - sourceProjection: The projection of the source coordinates, or `nil` to read the SRID from the WKB data.
     ///    - targetProjection: The target projection (default `.epsg4326`).
     /// - Returns: A GeoJSON geometry, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asGeoJsonGeometry(
-        sourceProjection: Projection,
+        sourceProjection: Projection?,
         targetProjection: Projection = .epsg4326
     ) -> GeoJsonGeometry? {
         GeometryCollection.parse(
@@ -275,14 +275,14 @@ extension Data {
     /// Decode a GeoJSON object from WKB.
     ///
     /// - Parameters:
-    ///    - sourceProjection: The source projection.
+    ///    - sourceProjection: The projection of the source coordinates, or `nil` to read the SRID from the WKB data.
     ///    - targetProjection: The target projection (default `.epsg4326`).
     ///    - id: A feature identifier (default `nil`).
     ///    - properties: Feature properties (default `[:]`).
     /// - Returns: A Feature, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeature(
-        sourceProjection: Projection,
+        sourceProjection: Projection?,
         targetProjection: Projection = .epsg4326,
         id: Feature.Identifier? = nil,
         properties: [String: Sendable] = [:]
@@ -315,12 +315,12 @@ extension Data {
     /// Decode a GeoJSON object from WKB.
     ///
     /// - Parameters:
-    ///    - sourceProjection: The source projection.
+    ///    - sourceProjection: The projection of the source coordinates, or `nil` to read the SRID from the WKB data.
     ///    - targetProjection: The target projection (default `.epsg4326`).
     /// - Returns: A FeatureCollection, or `nil` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public func asFeatureCollection(
-        sourceProjection: Projection,
+        sourceProjection: Projection?,
         targetProjection: Projection = .epsg4326
     ) -> FeatureCollection? {
         FeatureCollection(
@@ -412,14 +412,14 @@ extension WKBCoder {
     ///
     /// - Parameters:
     ///    - wkb: The WKB encoded data.
-    ///    - sourceProjection: The source projection.
+    ///    - sourceProjection: The projection of the source coordinates, or `nil` to read the SRID from the WKB data.
     ///    - targetProjection: The target projection (default `.epsg4326`).
     /// - Returns: A decoded GeoJSON geometry.
     /// - Throws: A `WKBCoderError` if decoding fails.
     /// - Important: The resulting GeoJSON will always be projected to EPSG:4326.
     public static func decode(
         wkb: Data,
-        sourceProjection: Projection,
+        sourceProjection: Projection?,
         targetProjection: Projection = .epsg4326
     ) throws -> GeoJsonGeometry {
         let bytes = [UInt8](wkb)
@@ -447,6 +447,7 @@ extension WKBCoder {
         var typeCodeValue = try decodeUInt32(bytes: bytes, offset: &offset, byteOrder: byteOrder)
         var decodeZ = false
         var decodeM = false
+        let hasSRID = typeCodeValue & 0x2000_0000 != 0
 
         if typeCodeValue & 0x8000_0000 != 0 {
             decodeZ = true
@@ -461,7 +462,9 @@ extension WKBCoder {
         }
 
         var sourceProjection = sourceProjection
-        if sourceProjection == nil {
+        if sourceProjection == nil,
+           hasSRID
+        {
             let srid = try decodeUInt32(bytes: bytes, offset: &offset, byteOrder: byteOrder)
             sourceProjection = Projection(srid: Int(srid))
         }

--- a/Tests/GISToolsTests/GeoJson/ReaderTests.swift
+++ b/Tests/GISToolsTests/GeoJson/ReaderTests.swift
@@ -36,4 +36,98 @@ struct ReaderTests {
         #expect(castedPoint.asJsonString(prettyPrinted: true) == point.asJsonString(prettyPrinted: true))
     }
 
+    // MARK: - Geometry auto-detection
+
+    // A PostGIS EWKB LINESTRING with embedded SRID 3857 (Web Mercator).
+    private let ewkbLineStringHex = "0102000020110F00000F000000B1AB426CB24C3141FF9A56141D015741AC6335BCD04C31414C475DB321015741ED12DD37F14C3141A108733D240157410B3F0D08104D3141930997E929015741B6607F03364D3141EF0AD7643A0157415F3425CA4C4D31411CA75DBE43015741EE7275C6624D3141BB7F3DBC4A01574143F574298B4D314127F08B8E550157412E207A6FB24D314172BC8B0E59015741DEEDD74ECD4D31412A5F69605801574149F56264EE4D3141B4213FDD540157417E97E4BB044E31414813A5AB54015741383AAE891E4E3141201F4C71580157413CF330C6434E3141D260EB125E015741CEAD8B65734E3141034DA5EF63015741"
+
+    // Validates auto-detecting a WKT string.
+    @Test
+    func geometryFromWKT() async throws {
+        let geometry = try #require(GeoJsonReader.geometryFrom(string: "POINT (11.5 48.1)"))
+        let point = try #require(geometry as? Point)
+        #expect(point.coordinate.longitude == 11.5)
+        #expect(point.coordinate.latitude == 48.1)
+    }
+
+    // Validates auto-detecting an SRID-prefixed WKT string.
+    @Test
+    func geometryFromSRIDWKT() async throws {
+        let geometry = try #require(GeoJsonReader.geometryFrom(string: "SRID=4326;POINT (11.5 48.1)"))
+        let point = try #require(geometry as? Point)
+        #expect(point.coordinate.longitude == 11.5)
+        #expect(point.coordinate.latitude == 48.1)
+    }
+
+    // Validates auto-detecting a GeoJSON string.
+    @Test
+    func geometryFromGeoJsonString() async throws {
+        let geometry = try #require(GeoJsonReader.geometryFrom(string: pointJson))
+        #expect(geometry is Point)
+    }
+
+    // Validates auto-detecting an EWKB hex string with an embedded SRID.
+    @Test
+    func geometryFromEWKBHex() async throws {
+        let geometry = try #require(GeoJsonReader.geometryFrom(string: ewkbLineStringHex))
+        let lineString = try #require(geometry as? LineString)
+        #expect(lineString.coordinates.count == 15)
+        #expect(abs(lineString.coordinates[0].longitude - 10.184617401417709) < 0.0000001)
+        #expect(abs(lineString.coordinates[0].latitude - 47.53870670004494) < 0.0000001)
+    }
+
+    // Validates auto-detecting a plain WKB hex string (no embedded SRID).
+    @Test
+    func geometryFromPlainWKBHex() async throws {
+        // SELECT 'LINESTRING (1 1, 1 2, 1 3, 2 2)'::geometry;
+        let hex = "010200000004000000000000000000F03F000000000000F03F000000000000F03F0000000000000040000000000000F03F000000000000084000000000000000400000000000000040"
+        let geometry = try #require(GeoJsonReader.geometryFrom(string: hex))
+        let lineString = try #require(geometry as? LineString)
+        #expect(lineString.coordinates.count == 4)
+        #expect(lineString.coordinates[0] == Coordinate3D(latitude: 1, longitude: 1))
+    }
+
+    // Validates auto-detecting a TWKB hex string.
+    @Test
+    func geometryFromTWKBHex() async throws {
+        // TWKB Point at (0, 0) with precision 6.
+        let hex = "61000000"
+        let geometry = try #require(GeoJsonReader.geometryFrom(string: hex))
+        #expect(geometry is Point)
+    }
+
+    // Validates auto-detecting a WKB data payload.
+    @Test
+    func geometryFromWKBData() async throws {
+        let data = try #require(Data(hex: "0101000000000000000000F03F0000000000000040"))
+        let geometry = try #require(GeoJsonReader.geometryFrom(data: data))
+        let point = try #require(geometry as? Point)
+        #expect(point.coordinate.longitude == 1)
+        #expect(point.coordinate.latitude == 2)
+    }
+
+    // Validates auto-detecting a TWKB data payload.
+    @Test
+    func geometryFromTWKBData() async throws {
+        let data = Data([0x61, 0x00, 0x00, 0x00])
+        let geometry = try #require(GeoJsonReader.geometryFrom(data: data))
+        #expect(geometry is Point)
+    }
+
+    // Validates auto-detecting a GeoJSON data payload.
+    @Test
+    func geometryFromGeoJsonData() async throws {
+        let data = Data(pointJson.utf8)
+        let geometry = try #require(GeoJsonReader.geometryFrom(data: data))
+        #expect(geometry is Point)
+    }
+
+    // Validates that invalid input returns nil.
+    @Test
+    func geometryFromInvalid() async throws {
+        #expect(GeoJsonReader.geometryFrom(string: "NOT A GEOMETRY") == nil)
+        #expect(GeoJsonReader.geometryFrom(string: "") == nil)
+        #expect(GeoJsonReader.geometryFrom(data: Data()) == nil)
+    }
+
 }

--- a/Tests/GISToolsTests/GeoJson/WKBTests.swift
+++ b/Tests/GISToolsTests/GeoJson/WKBTests.swift
@@ -228,6 +228,27 @@ struct WKBTests {
         #expect(encodedMultiPointZSRID == multiPointZSRIDData)
     }
 
+    // A PostGIS EWKB LINESTRING with embedded SRID 3857 (Web Mercator).
+    private let lineStringSRID3857Data = Data(hex: "0102000020110F00000F000000B1AB426CB24C3141FF9A56141D015741AC6335BCD04C31414C475DB321015741ED12DD37F14C3141A108733D240157410B3F0D08104D3141930997E929015741B6607F03364D3141EF0AD7643A0157415F3425CA4C4D31411CA75DBE43015741EE7275C6624D3141BB7F3DBC4A01574143F574298B4D314127F08B8E550157412E207A6FB24D314172BC8B0E59015741DEEDD74ECD4D31412A5F69605801574149F56264EE4D3141B4213FDD540157417E97E4BB044E31414813A5AB54015741383AAE891E4E3141201F4C71580157413CF330C6434E3141D260EB125E015741CEAD8B65734E3141034DA5EF63015741")!
+
+    // Validates auto-detecting the embedded SRID from a PostGIS EWKB LINESTRING.
+    @Test
+    func lineStringSRIDAutoDetection() async throws {
+        let lineString = try WKBCoder.decode(wkb: lineStringSRID3857Data, sourceProjection: nil) as! LineString
+        #expect(lineString.coordinates.count == 15)
+        #expect(abs(lineString.coordinates[0].longitude - 10.184617401417709) < 0.0000001)
+        #expect(abs(lineString.coordinates[0].latitude - 47.53870670004494) < 0.0000001)
+    }
+
+    // Validates that a plain WKB (no SRID flag) with no explicit projection fails cleanly
+    // instead of misreading the point count as an SRID.
+    @Test
+    func plainWKBNoSRIDAutoDetection() async throws {
+        #expect(throws: WKBCoder.WKBCoderError.unknownSRID) {
+            _ = try WKBCoder.decode(wkb: lineStringData, sourceProjection: nil)
+        }
+    }
+
     // MARK: - LineString
 
     // SELECT 'LINESTRING (1 1, 1 2, 1 3, 2 2)'::geometry;


### PR DESCRIPTION
Add GeoJsonReader.geometryFrom(string:data:) helpers that auto-detect whether a payload is GeoJSON, WKT (with or without an SRID prefix), or hex-encoded WKB/EWKB/TWKB, and decode it into a GeoJsonGeometry.

Also:
- Make WKBCoder's sourceProjection optional so the embedded SRID is auto-detected from EWKB payloads.
- Fix a division-by-zero crash in Data(hex:) for non-hex input.
