### PR TITLE
Fix _dictionaryUpCast crash during GeoJSON parsing

### DIFF
--- a/CRASH_NOTE.md
+++ b/CRASH_NOTE.md
@@ -1,0 +1,157 @@
+# Crash: Swift `_dictionaryUpCast` during GeoJSON parsing
+
+Status: **fixed** (in gis-tools; requires the oa-app-ios app to pick up the new GISTools package revision).
+
+## Problem
+
+The iOS app (oa-app-ios) crashes with `EXC_BREAKPOINT` / `EXC_BAD_ACCESS` (a hard,
+non-catchable trap) inside Swift's standard library helper
+`_dictionaryUpCast<A, B, C, D>(_:)` while parsing GeoJSON route data. The stack:
+
+```
+_dictionaryUpCast
+Feature.init(json:calculateBoundingBox:)     GISTools/GeoJson/Feature.swift
+static GeoJson.tryCreate(json:)              GISTools/GeoJson/GeoJson.swift
+FeatureCollection.init(geoJson:...)          GISTools/GeoJson/FeatureCollection.swift
+... down through Segment.init(json:), TourPath.init(json:), Tour.path.getter (OASDK),
+RoutePlannerMapController.showGeometry (oa-app-ios, main thread)
+```
+
+### Why it's a hard crash and not a `nil`/error
+
+GeoJSON `init?(json:)` methods do **whole-dictionary conditional casts** such as
+
+```swift
+json as? [String: Sendable]
+```
+
+on values produced by `Foundation.JSONSerialization` (bridged `NSDictionary` /
+`NSArray` / `NSNumber`). For certain bridged layout combinations (inhomogeneous
+nested values, `NSNumber`-backed numbers, booleans) the stdlib `_dictionaryUpCast`
+trips an internal assertion *before* the `as?` can return `nil`. Because it is a
+trap and not a thrown error, downstream `try?`/`init?(json:)` guards never get a
+chance to short-circuit — the process dies.
+
+### Where the casts live
+
+`Sources/GISTools/GeoJson/`: `Feature.swift`, `FeatureCollection.swift`,
+`Polygon.swift`, `Point.swift`, `LineString.swift`, `MultiPoint.swift`,
+`MultiLineString.swift`, `MultiPolygon.swift`, `GeometryCollection.swift`;
+and the two top-level dispatchers in `GeoJson.swift`
+(`tryCreate(json:) -> GeoJson?`, `tryCreateGeometry(json:) -> GeoJsonGeometry?`).
+
+## Attempted fix (incomplete)
+
+*(Superseded — see "Completed fix" below. Kept for context: the first
+attempt rebuilt arrays as `[any Sendable]`, which broke downstream concrete
+typed casts like `as? [Double?]` and made Point parsing return `nil`.)*
+
+Replace the whole-dictionary `as? [String: Sendable]` with a **recursive,
+element-by-element coercion** that never relies on the stdlib whole-dictionary
+upcast — a bad element yields `nil` (graceful) instead of trapping.
+
+Helpers added (top of `GeoJson.swift`):
+
+- `func jsonCoerceSendable(_ value: Any?) -> Any?`
+- `func jsonCoercibleDictionary(_ value: Any?) -> [String: Sendable]?`
+- `Dictionary.coercedAsJsonDictionary()` / `NSDictionary.coercedAsNSDictionary()`
+
+`Feature.swift`, `GeoJson.swift`, `Polygon.swift`, etc. changed their
+`json as? [String: Sendable]` casts to `jsonCoercibleDictionary(json)`.
+
+### Verified so far
+
+- Valid **Polygon** fixture (`TestData/Circle/CircleResult.geojson`) parses
+  correctly (1 ring, 65 points) — geometry arrays preserved.
+- Real **FeatureCollection** fixture (`TestData/Graph/RoadNetwork_Raploch.geojson`)
+  parses correctly (670 features, LineString geometry).
+- **NSNull** property values degrade gracefully (no crash).
+
+### Still broken
+
+- A **Point** geometry (single coordinate, `coordinates: [1.0, 2.0]`) fails to
+  parse; a `FeatureCollection` whose features have Point geometry drops those
+  features (features count 0 vs 1).
+- Root cause: arrays are coerced to `[any Sendable]`, but downstream code reads
+  coordinates via concrete typed casts such as `json as? [Double?]`,
+  `json as? [Any]`, `[[Any]]` in `Coordinate3D` / `tryCreate`/geometry paths.
+  `[any Sendable]` does not satisfy those casts, so `Coordinate3D` / `Point`
+  parsing returns `nil`. The original Swift bridging produced arrays that these
+  casts succeed on.
+- Also tricky: Swift 6 strict concurrency forbids storing `[Any]` (not
+  `Sendable`) inside `[String: Sendable]`, so changing arrays to `[Any]` to
+  satisfy the downstream `as? [Any]`/`as? [Double?]` casts conflicts with the
+  `[String: Sendable]` model. This tension is the core of the unfinished work.
+
+## Reproducer (minimal)
+
+Run in `gis-tools` after building (`swift build`):
+
+```swift
+import Foundation
+import GISTools
+
+let pointJSON = #"{"type":"Point","coordinates":[1.0,2.0]}"#
+print(try? Point(jsonString: pointJSON))   // now parses (was nil in the first attempt)
+
+let fcJSON = #"{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[1.0,2.0]}}]}"#
+print((try? FeatureCollection(jsonString: fcJSON))?.features.count)  // now 1
+
+let lineJSON = #"{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"LineString","coordinates":[[1.0,2.0],[3.0,4.0],[5.0,6.0]]}}]}"#
+print((try? FeatureCollection(jsonString: lineJSON))?.features.count) // 1
+```
+
+## Completed fix (2026-09-02)
+
+New file `Sources/GISTools/GeoJson/JsonCoercion.swift` — a `private enum
+JsonCoercion` namespace with element-wise coercion helpers:
+
+- `JsonCoercion.dictionary(_:)` — coerces any JSON object into
+  `[String: Sendable]` **element by element**. Bridged dictionaries
+  (`NSDictionary`) are iterated instead of whole-cast, so the trapping
+  `_dictionaryUpCast` is never invoked. Nested dictionaries recurse; bad
+  elements (non-string keys, non-JSON values) yield `nil` gracefully.
+- `JsonCoercion.array(_:)`, `.coordinateArray(_:)`, `.doubleArray(_)`,
+  `.coordinateArrayList(_)`, `.double(_:)` — element-wise array/number reads
+  for `Coordinate3D`, `BoundingBox` and `Validatable`.
+- **Arrays are coerced element-wise** into native `[Sendable]` boxes — only
+  dictionaries are rebuilt wholesale. Elements keep their runtime types
+  (numbers stay `NSNumber`), so downstream `as? [Double?]` / `as? [Any]`
+  casts keep working (they cast elements one by one) and the
+  `[String: Sendable]` model is satisfied. Note: the raw `NSArray` cannot be
+  stored directly — its `Sendable` conformance is unavailable in Swift 6
+  mode on Darwin.
+- Numbers stay `NSNumber` (runtime representation unchanged), so
+  `as? Int`/`as? Double` reads and integer-valued coordinate arrays work.
+- Boolean rejection in `double(_:)` uses `objCType == "c"` — `value is Bool`
+  is *not* reliable on Linux corelibs (plain numbers like `1.0` answer
+  `true` there).
+
+All 11 whole-dictionary cast sites replaced: the 9 type initializers
+(`Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`,
+`MultiPolygon`, `GeometryCollection`, `Feature`, plus `Feature.properties`)
+and the two dispatchers in `GeoJson.swift` (`tryCreate(json:)`,
+`tryCreateGeometry(json:)`) plus the four generic array `tryCreate`s.
+
+### Verification
+
+- All acceptance criteria 1–4 verified; `swift build` has zero warnings.
+- `swift test`: 2355 tests in 171 suites pass (incl. new
+  `Tests/GISToolsTests/GeoJson/JsonCoercionTests.swift`, 19 tests).
+- Note on criterion 5: `Circle.geojson` was a red herring — no test
+  references it; `CircleTests` uses `CircleResult.geojson`, which exists.
+  `swift test` passes on this environment.
+
+## Minimum acceptance criteria for a complete fix
+
+*(All met — see "Completed fix".)*
+
+1. `Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`,
+   `MultiPolygon`, `Feature`, `FeatureCollection` all parse from
+   `JSONSerialization`-bridged input including Point/coordinate depths. ✅
+2. Empty / `NSNull` / malformed values degrade to `nil`/skipped (no
+   `_dictionaryUpCast` trap), not a crash. ✅
+3. Integer-valued JSON properties preserve `as? Int` reads (e.g. `id: 5` →
+   `as? Int`), and float values preserve `as? Double`. ✅
+4. Existing fixtures under `Tests/GISToolsTests/TestData/` parse unchanged. ✅
+5. `swift test` passes. ✅

--- a/Sources/GISTools/Algorithms/Validatable.swift
+++ b/Sources/GISTools/Algorithms/Validatable.swift
@@ -206,7 +206,7 @@ extension GeoJson {
 
         switch type {
         case .point:
-            guard let coordinates = geoJson["coordinates"] as? [Any],
+            guard let coordinates = JsonCoercion.array(geoJson["coordinates"]),
                   !coordinates.isEmpty
             else { return false }
             return true

--- a/Sources/GISTools/GeoJson/BoundingBox.swift
+++ b/Sources/GISTools/GeoJson/BoundingBox.swift
@@ -152,7 +152,7 @@ public struct BoundingBox:
         self.projection = .epsg4326
 
         // GeoJSON
-        if let geoJsonCoordinates = json as? [Double] {
+        if let geoJsonCoordinates = JsonCoercion.doubleArray(json) {
             if geoJsonCoordinates.count == 4 {
                 self.southWest = Coordinate3D(latitude: geoJsonCoordinates[1], longitude: geoJsonCoordinates[0])
                 self.northEast = Coordinate3D(latitude: geoJsonCoordinates[3], longitude: geoJsonCoordinates[2])
@@ -167,7 +167,7 @@ public struct BoundingBox:
             }
         }
         // Not GeoJSON
-        else if let geoJsonCoordinates = json as? [[Double]],
+        else if let geoJsonCoordinates = JsonCoercion.coordinateArrayList(json),
                 !geoJsonCoordinates.isEmpty
         {
             let coordinates = geoJsonCoordinates.compactMap { Coordinate3D(json: $0) }

--- a/Sources/GISTools/GeoJson/Coordinate3D.swift
+++ b/Sources/GISTools/GeoJson/Coordinate3D.swift
@@ -733,7 +733,7 @@ extension Coordinate3D: GeoJsonReadable {
         var pAltitude: CLLocationDistance?
         var pM: Double?
 
-        if let pointArray = json as? [Double?],
+        if let pointArray = JsonCoercion.coordinateArray(json),
            pointArray.count >= 2
         {
             pLongitude = pointArray[0]
@@ -741,11 +741,11 @@ extension Coordinate3D: GeoJsonReadable {
             pAltitude = if pointArray.count >= 3 { pointArray[2] } else { nil }
             pM = if pointArray.count >= 4 { pointArray[3] } else { nil }
         }
-        else if let pointDictionary = json as? [String: Any] {
-            pLongitude = pointDictionary["x"] as? Double
-            pLatitude = pointDictionary["y"] as? Double
-            pAltitude = pointDictionary["z"] as? CLLocationDistance
-            pM = pointDictionary["m"] as? Double
+        else if let pointDictionary = JsonCoercion.dictionary(json) {
+            pLongitude = JsonCoercion.double(pointDictionary["x"])
+            pLatitude = JsonCoercion.double(pointDictionary["y"])
+            pAltitude = JsonCoercion.double(pointDictionary["z"]).map { CLLocationDistance($0) }
+            pM = JsonCoercion.double(pointDictionary["m"])
         }
         else {
             return nil

--- a/Sources/GISTools/GeoJson/Feature.swift
+++ b/Sources/GISTools/GeoJson/Feature.swift
@@ -152,14 +152,14 @@ public struct Feature:
     ///    - calculateBoundingBox: When true, calculate the bounding box from the geometry
     /// - Returns: A feature, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
-        guard let geoJson = json as? [String: Sendable],
+        guard let geoJson = JsonCoercion.dictionary(json),
               Feature.isValid(geoJson: geoJson),
               let geometry: GeoJsonGeometry = Feature.tryCreateGeometry(json: geoJson["geometry"])
         else { return nil }
 
         self.geometry = geometry
         self.id = Identifier(value: geoJson["id"])
-        self.properties = (geoJson["properties"] as? [String: Sendable]) ?? [:]
+        self.properties = JsonCoercion.dictionary(geoJson["properties"]) ?? [:]
         self.boundingBox = Feature.tryCreate(json: geoJson["bbox"])
 
         if calculateBoundingBox {

--- a/Sources/GISTools/GeoJson/GeoJson.swift
+++ b/Sources/GISTools/GeoJson/GeoJson.swift
@@ -218,7 +218,7 @@ extension GeoJson {
 
     /// Try to create an array of objects from any JSON object.
     public static func tryCreate<V: GeoJsonReadable>(json: Any?) -> [V]? {
-        if let array = json as? [Any] {
+        if let array = JsonCoercion.array(json) {
             return array.compactMap { V(json: $0) }
         }
         return nil
@@ -226,7 +226,7 @@ extension GeoJson {
 
     /// Try to create an array of arrays of objects from any JSON object.
     static func tryCreate<V: GeoJsonReadable>(json: Any?) -> [[V]]? {
-        if let array = json as? [Any] {
+        if let array = JsonCoercion.array(json) {
             return array.compactMap { tryCreate(json: $0) }
         }
         return nil
@@ -234,7 +234,7 @@ extension GeoJson {
 
     /// Try to create an array of arrays of arrays of objects from any JSON object.
     static func tryCreate<V: GeoJsonReadable>(json: Any?) -> [[[V]]]? {
-        if let array = json as? [Any] {
+        if let array = JsonCoercion.array(json) {
             return array.compactMap { tryCreate(json: $0) }
         }
         return nil
@@ -242,7 +242,7 @@ extension GeoJson {
 
     /// Try to create a GeoJSON object from any JSON object.
     public static func tryCreate(json: Any?) -> GeoJson? {
-        if let geoJson = json as? [String: Sendable],
+        if let geoJson = JsonCoercion.dictionary(json),
            let typeString = geoJson["type"] as? String,
            let type = GeoJsonType(rawValue: typeString),
            type != .invalid
@@ -265,7 +265,7 @@ extension GeoJson {
 
     /// Try to create a GeoJSON geometry from any JSON object.
     public static func tryCreateGeometry(json: Any?) -> GeoJsonGeometry? {
-        if let geoJson = json as? [String: Sendable],
+        if let geoJson = JsonCoercion.dictionary(json),
            let typeString = geoJson["type"] as? String,
            let type = GeoJsonType(rawValue: typeString),
            type != .invalid
@@ -286,7 +286,7 @@ extension GeoJson {
 
     /// Try to create an array of GeoJSON geometries from any JSON object.
     public static func tryCreate(json: Any?) -> [GeoJsonGeometry]? {
-        if let array = json as? [Any] {
+        if let array = JsonCoercion.array(json) {
             return array.compactMap { tryCreateGeometry(json: $0) }
         }
         return nil

--- a/Sources/GISTools/GeoJson/GeometryCollection.swift
+++ b/Sources/GISTools/GeoJson/GeometryCollection.swift
@@ -67,7 +67,7 @@ public struct GeometryCollection: GeoJsonGeometry {
     /// - important: The source is expected to be in EPSG:4326.
     /// - Returns: A geometry collection, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
-        guard let geoJson = json as? [String: Sendable],
+        guard let geoJson = JsonCoercion.dictionary(json),
               GeometryCollection.isValid(geoJson: geoJson),
               let geometries: [GeoJsonGeometry] = GeometryCollection.tryCreate(json: geoJson["geometries"])
         else { return nil }

--- a/Sources/GISTools/GeoJson/JsonCoercion.swift
+++ b/Sources/GISTools/GeoJson/JsonCoercion.swift
@@ -1,0 +1,280 @@
+import Foundation
+
+/// Element-wise JSON coercion helpers.
+///
+/// GeoJSON parsing historically relied on whole-dictionary conditional casts
+/// such as `json as? [String: Sendable]` on values produced by
+/// `Foundation.JSONSerialization`. On Darwin, that cast funnels into the
+/// standard library's `_dictionaryUpCast`, which trips an internal assertion
+/// (an uncatchable trap) for certain bridged layouts — inhomogeneous nested
+/// values, `NSNumber`-backed numbers, booleans — *before* the `as?` can
+/// return `nil`.
+///
+/// These helpers never whole-cast a dictionary. Bridged dictionaries are
+/// iterated element by element; every value is checked individually so a bad
+/// element degrades gracefully instead of trapping the process.
+///
+/// - note: Array elements are coerced **individually**, keeping each element's
+///   runtime representation (numbers stay `NSNumber`). Rebuilding arrays as
+///   opaque boxes would break downstream concrete typed casts (`as? [Double?]`,
+///   `as? [Any]`, `as? [[Any]]`) used by ``Coordinate3D`` and the geometry
+///   parsers — those casts succeed because they cast elements one by one.
+enum JsonCoercion {
+
+    /// Coerce a JSON object into `[String: Sendable]` without whole-dictionary casts.
+    ///
+    /// - Parameter value: A JSON object (`NSDictionary`, native dictionary, or `nil`)
+    /// - Returns: A dictionary whose values are JSON-compatible, or `nil` if
+    ///            the input is not a JSON object or contains a non-string key
+    static func dictionary(_ value: Any?) -> [String: Sendable]? {
+        guard let value else { return nil }
+
+        // Bridged dictionaries (JSONSerialization output on Darwin): iterate
+        // element-wise. A whole-dictionary upcast can trap inside the standard
+        // library for inhomogeneous content.
+        if let nsDictionary = value as? NSDictionary {
+            return dictionary(from: nsDictionary)
+        }
+
+        // Native Swift dictionaries are coerced element-wise as well, so that
+        // nested values get the same treatment on every platform.
+        if let nativeDictionary = value as? [String: Any] {
+            var result: [String: Sendable] = [:]
+            result.reserveCapacity(nativeDictionary.count)
+
+            for (key, element) in nativeDictionary {
+                guard let coerced = sendable(element) else { return nil }
+                result[key] = coerced
+            }
+
+            return result
+        }
+
+        return nil
+    }
+
+    /// Element-wise coercion of a bridged dictionary.
+    private static func dictionary(from nsDictionary: NSDictionary) -> [String: Sendable]? {
+        var result: [String: Sendable] = [:]
+        result.reserveCapacity(nsDictionary.count)
+
+        for (key, element) in nsDictionary {
+            guard let key = key as? String else { return nil }
+            guard let coerced = sendable(element) else { return nil }
+            result[key] = coerced
+        }
+
+        return result
+    }
+
+    /// Coerce a JSON array into `[Any]` without whole-array casts that could
+    /// trap on unexpected element layouts.
+    ///
+    /// - Parameter value: A JSON array (`NSArray`, native array, or `nil`)
+    /// - Returns: The elements as `[Any]`, or `nil` if the input is not an array
+    static func array(_ value: Any?) -> [Any]? {
+        guard let value else { return nil }
+
+        if let nsArray = value as? NSArray {
+            return nsArray.map { $0 }
+        }
+
+        if let nativeArray = value as? [Any] {
+            return nativeArray
+        }
+
+        return nil
+    }
+
+    /// Coerce a GeoJSON position array into `[Double?]`.
+    ///
+    /// Element-wise: a `null` (altitude/`m` placeholder) maps to `nil`, numbers
+    /// (bridged `NSNumber` or native) map to `Double`, and anything else makes
+    /// the whole array invalid — mirroring the semantics of the previous
+    /// `as? [Double?]` cast without relying on bridging internals.
+    ///
+    /// - Parameter value: A JSON array of numbers (and `null` placeholders)
+    /// - Returns: The coordinate values, or `nil` if the input is not an all-number array
+    static func coordinateArray(_ value: Any?) -> [Double?]? {
+        guard let elements = array(value) else { return nil }
+
+        var result: [Double?] = []
+        result.reserveCapacity(elements.count)
+
+        for element in elements {
+            if element is NSNull {
+                result.append(nil)
+            }
+            else if let double = double(element) {
+                result.append(double)
+            }
+            else {
+                return nil
+            }
+        }
+
+        return result
+    }
+
+    /// Numeric value of a JSON number, tolerating both bridged `NSNumber` and
+    /// native Swift numeric types (including `Float`).
+    ///
+    /// - Parameter value: A JSON value
+    /// - Returns: The value as `Double`, or `nil` if the value is not a number
+    static func double(_ value: Any?) -> Double? {
+        guard let value else { return nil }
+
+        if let number = value as? NSNumber {
+            // Reject booleans: they are `NSNumber`-backed (`__NSCFBoolean` on
+            // Darwin, and bridged native `Bool`). Note that `value is Bool`
+            // is *not* usable as a discriminator on Linux corelibs, where
+            // plain numbers like `1.0` also answer `true`; `objCType == "c"`
+            // is the reliable boolean marker on both platforms. (An `Int8`
+            // would also report `"c"`, but JSON has no `Int8` numbers.)
+            if String(cString: number.objCType) == "c" {
+                return nil
+            }
+            return number.doubleValue
+        }
+        if let double = value as? Double {
+            return double
+        }
+        if let float = value as? Float {
+            return Double(float)
+        }
+        return nil
+    }
+
+    /// Coerce a JSON array of numbers into `[Double]`.
+    ///
+    /// - Parameter value: A JSON array of numbers
+    /// - Returns: The values as `[Double]`, or `nil` if any element is not a number
+    static func doubleArray(_ value: Any?) -> [Double]? {
+        guard let elements = array(value) else { return nil }
+
+        var result: [Double] = []
+        result.reserveCapacity(elements.count)
+
+        for element in elements {
+            guard let double = double(element) else { return nil }
+            result.append(double)
+        }
+
+        return result
+    }
+
+    /// Coerce an array of JSON number arrays into `[[Double]]`.
+    ///
+    /// - Parameter value: An array of JSON number arrays
+    /// - Returns: The values as `[[Double]]`, or `nil` if the input shape doesn't match
+    static func coordinateArrayList(_ value: Any?) -> [[Double]]? {
+        guard let elements = array(value) else { return nil }
+
+        var result: [[Double]] = []
+        result.reserveCapacity(elements.count)
+
+        for element in elements {
+            guard let inner = doubleArray(element) else { return nil }
+            result.append(inner)
+        }
+
+        return result
+    }
+
+    /// Coerce a single JSON value into a `Sendable` box.
+    ///
+    /// - Parameter value: A JSON value
+    /// - Returns: The value unchanged (numbers, booleans and strings keep their
+    ///            original runtime representation), a recursively coerced
+    ///            dictionary, or `nil` if the value is not JSON-compatible
+    private static func sendable(_ value: Any) -> Sendable? {
+        // Dictionaries: recurse element-wise. This is where the trapping
+        // upcast lives, so nested dictionaries must never be whole-cast.
+        if let nsDictionary = value as? NSDictionary {
+            return dictionary(from: nsDictionary)
+        }
+        if let nativeDictionary = value as? [String: Any] {
+            return dictionary(nativeDictionary)
+        }
+
+        // Strings (including toll-free bridged `NSString`).
+        if let string = value as? String {
+            return string
+        }
+
+        // Numbers and booleans produced by `JSONSerialization` on Darwin are
+        // `NSNumber` (booleans are `__NSCFBoolean`, an `NSNumber` subclass).
+        // They must stay `NSNumber`: converting them to native `Int`/`Double`
+        // would break integer-valued coordinate arrays (`as? [Double?]`) and
+        // change `as? Double`/`as? Int` read semantics downstream.
+        if let number = value as? NSNumber {
+            return number
+        }
+
+        // Native Swift scalars (values not bridged from ObjC).
+        if let bool = value as? Bool {
+            return bool
+        }
+        if let int = value as? Int {
+            return int
+        }
+        if let uint = value as? UInt {
+            return uint
+        }
+        if let int64 = value as? Int64 {
+            return int64
+        }
+        if let uint64 = value as? UInt64 {
+            return uint64
+        }
+        if let double = value as? Double {
+            return double
+        }
+        if let float = value as? Float {
+            return float
+        }
+
+        if value is NSNull {
+            return NSNull()
+        }
+
+        // Arrays: coerce element-wise, preserving each element's runtime
+        // representation (numbers stay `NSNumber`). The boxed `[Sendable]`
+        // array still satisfies all downstream dynamic reads
+        // (`as? [Double?]`, `as? [Any]`, `as? [[Any]]`, …) because those
+        // perform element-wise casts. The raw `NSArray` cannot be stored
+        // directly: its `Sendable` conformance is unavailable in Swift 6 mode
+        // on Darwin.
+        if let array = value as? [Any] {
+            return sendableArray(from: array)
+        }
+        if let array = value as? NSArray {
+            return sendableArray(from: array.map { $0 })
+        }
+
+        // Tolerate common non-JSON but hashable value types (e.g. `Data`) the
+        // same way the previous whole-dictionary cast did: keep them, wrapped.
+        if let data = value as? Data {
+            return data
+        }
+
+        return nil
+    }
+
+    /// Element-wise coercion of an array's elements into a `[Sendable]` box.
+    ///
+    /// - Parameter elements: The array elements
+    /// - Returns: The coerced array, or `nil` if any element is not JSON-compatible
+    private static func sendableArray(from elements: [Any]) -> [Sendable]? {
+        var result: [Sendable] = []
+        result.reserveCapacity(elements.count)
+
+        for element in elements {
+            guard let coerced = sendable(element) else { return nil }
+            result.append(coerced)
+        }
+
+        return result
+    }
+
+}

--- a/Sources/GISTools/GeoJson/LineString.swift
+++ b/Sources/GISTools/GeoJson/LineString.swift
@@ -132,7 +132,7 @@ public struct LineString:
     /// - important: The source is expected to be in EPSG:4326.
     /// - Returns: A line string, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
-        guard let geoJson = json as? [String: Sendable],
+        guard let geoJson = JsonCoercion.dictionary(json),
               LineString.isValid(geoJson: geoJson),
               let coordinates: [Coordinate3D] = LineString.tryCreate(json: geoJson["coordinates"])
         else { return nil }

--- a/Sources/GISTools/GeoJson/MultiLineString.swift
+++ b/Sources/GISTools/GeoJson/MultiLineString.swift
@@ -143,7 +143,7 @@ public struct MultiLineString:
     /// - important: The source is expected to be in EPSG:4326.
     /// - Returns: A multi line string, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
-        guard let geoJson = json as? [String: Sendable],
+        guard let geoJson = JsonCoercion.dictionary(json),
               MultiLineString.isValid(geoJson: geoJson),
               let coordinates: [[Coordinate3D]] = MultiLineString.tryCreate(json: geoJson["coordinates"])
         else { return nil }

--- a/Sources/GISTools/GeoJson/MultiPoint.swift
+++ b/Sources/GISTools/GeoJson/MultiPoint.swift
@@ -114,7 +114,7 @@ public struct MultiPoint:
     /// - Returns: A `MultiPoint`, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
-        guard let geoJson = json as? [String: Sendable],
+        guard let geoJson = JsonCoercion.dictionary(json),
               MultiPoint.isValid(geoJson: geoJson),
               let coordinates: [Coordinate3D] = MultiPoint.tryCreate(json: geoJson["coordinates"])
         else { return nil }

--- a/Sources/GISTools/GeoJson/MultiPolygon.swift
+++ b/Sources/GISTools/GeoJson/MultiPolygon.swift
@@ -119,7 +119,7 @@ public struct MultiPolygon:
     /// - important: The source is expected to be in EPSG:4326.
     /// - Returns: A multi polygon, or `nil` if the input is invalid
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
-        guard let geoJson = json as? [String: Sendable],
+        guard let geoJson = JsonCoercion.dictionary(json),
               MultiPolygon.isValid(geoJson: geoJson),
               let coordinates: [[[Coordinate3D]]] = MultiPolygon.tryCreate(json: geoJson["coordinates"])
         else { return nil }

--- a/Sources/GISTools/GeoJson/Point.swift
+++ b/Sources/GISTools/GeoJson/Point.swift
@@ -66,7 +66,7 @@ public struct Point: PointGeometry {
     /// - Returns: A `Point`, or `nil` if parsing failed
     /// - important: The source is expected to be in EPSG:4326.
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
-        guard let geoJson = json as? [String: Sendable],
+        guard let geoJson = JsonCoercion.dictionary(json),
               Point.isValid(geoJson: geoJson),
               let coordinate: Coordinate3D = Point.tryCreate(json: geoJson["coordinates"])
         else { return nil }

--- a/Sources/GISTools/GeoJson/Polygon.swift
+++ b/Sources/GISTools/GeoJson/Polygon.swift
@@ -138,7 +138,7 @@ public struct Polygon:
     ///    - calculateBoundingBox: When true, calculate the bounding box from the coordinates
     /// - important: The source is expected to be in EPSG:4326.
     public init?(json: Any?, calculateBoundingBox: Bool = false) {
-        guard let geoJson = json as? [String: Sendable],
+        guard let geoJson = JsonCoercion.dictionary(json),
               Polygon.isValid(geoJson: geoJson),
               let coordinates: [[Coordinate3D]] = Polygon.tryCreate(json: geoJson["coordinates"])
         else { return nil }

--- a/Tests/GISToolsTests/GeoJson/JsonCoercionTests.swift
+++ b/Tests/GISToolsTests/GeoJson/JsonCoercionTests.swift
@@ -1,0 +1,271 @@
+import Foundation
+@testable import GISTools
+import Testing
+
+/// Tests for the element-wise JSON coercion that replaced whole-dictionary
+/// conditional casts (`json as? [String: Sendable]`).
+///
+/// The whole-dictionary cast funnels into the standard library's
+/// `_dictionaryUpCast` on Darwin, which can trap (uncatchable
+/// `EXC_BREAKPOINT`) for certain `JSONSerialization`-bridged layouts instead
+/// of returning `nil`. The coercion must degrade gracefully for every value
+/// shape instead, and must preserve number/boolean/string runtime types so
+/// downstream `as? Int`/`as? Double`/`as? Bool` reads keep working.
+struct JsonCoercionTests {
+
+    // MARK: - Geometry parsing from JSON strings (JSONSerialization-bridged)
+
+    // Validates that a Point parses from a JSON string (bridged NSNumber coordinates).
+    @Test
+    func parsePointFromString() async throws {
+        let point = try #require(Point(jsonString: #"{"type":"Point","coordinates":[1.0,2.0]}"#))
+
+        #expect(point.coordinate.longitude == 1.0)
+        #expect(point.coordinate.latitude == 2.0)
+    }
+
+    // Validates that a Point with integer-valued (JSON integer) coordinates parses.
+    @Test
+    func parsePointWithIntegerCoordinates() async throws {
+        let point = try #require(Point(jsonString: #"{"type":"Point","coordinates":[1,2]}"#))
+
+        #expect(point.coordinate.longitude == 1.0)
+        #expect(point.coordinate.latitude == 2.0)
+    }
+
+    // Validates that a Point with a null altitude placeholder and an `m` value parses.
+    @Test
+    func parsePointWithNullAltitudeAndM() async throws {
+        let point = try #require(Point(jsonString: #"{"type":"Point","coordinates":[1.0,2.0,null,5.0]}"#))
+
+        #expect(point.coordinate.altitude == nil)
+        #expect(point.coordinate.m == 5.0)
+    }
+
+    // Validates that all geometry types parse from a single FeatureCollection.
+    @Test
+    func parseAllGeometryTypes() async throws {
+        let jsonString = """
+        {"type":"FeatureCollection","features":[
+        {"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[1.0,2.0]}},
+        {"type":"Feature","properties":{},"geometry":{"type":"MultiPoint","coordinates":[[1.0,2.0],[3.0,4.0]]}},
+        {"type":"Feature","properties":{},"geometry":{"type":"LineString","coordinates":[[1.0,2.0],[3.0,4.0]]}},
+        {"type":"Feature","properties":{},"geometry":{"type":"MultiLineString","coordinates":[[[1.0,2.0],[3.0,4.0]]]}},
+        {"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[0.0,0.0],[1.0,0.0],[1.0,1.0],[0.0,0.0]]]}},
+        {"type":"Feature","properties":{},"geometry":{"type":"MultiPolygon","coordinates":[[[[0.0,0.0],[1.0,0.0],[1.0,1.0],[0.0,0.0]]]]}},
+        {"type":"Feature","properties":{},"geometry":{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[1.0,2.0]}]}}
+        ]}
+        """
+        let featureCollection = try #require(FeatureCollection(jsonString: jsonString))
+
+        #expect(featureCollection.features.count == 7)
+        #expect(featureCollection.features[0].geometry.type == .point)
+        #expect(featureCollection.features[1].geometry.type == .multiPoint)
+        #expect(featureCollection.features[2].geometry.type == .lineString)
+        #expect(featureCollection.features[3].geometry.type == .multiLineString)
+        #expect(featureCollection.features[4].geometry.type == .polygon)
+        #expect(featureCollection.features[5].geometry.type == .multiPolygon)
+        #expect(featureCollection.features[6].geometry.type == .geometryCollection)
+    }
+
+    // MARK: - Bridged dictionary parsing (the crashing shapes)
+
+    // Validates that a Feature with inhomogeneous nested property values parses,
+    // mimicking `JSONSerialization` output on Darwin.
+    @Test
+    func parseFeatureWithInhomogeneousProperties() async throws {
+        let json: NSDictionary = [
+            "type": "Feature",
+            "id": NSNumber(value: 5),
+            "properties": NSDictionary(dictionary: [
+                "n": NSNumber(value: 42),
+                "f": NSNumber(value: 3.14),
+                "b": true,
+                "null": NSNull(),
+                "s": "x",
+                "nested": ["a": [1, 2], "b": true, "c": NSNull()],
+                "inhomogeneous": [1, "two", 3.0],
+            ]),
+            "geometry": NSDictionary(dictionary: [
+                "type": "Point",
+                "coordinates": [NSNumber(value: 1.5), NSNumber(value: 2.5)],
+            ]),
+        ]
+        let feature = try #require(Feature(json: json))
+
+        #expect(feature.id == .int(5))
+        #expect(feature.properties["n"] as? Int == 42)
+        #expect(feature.properties["f"] as? Double == 3.14)
+        #expect(feature.properties["b"] as? Bool == true)
+        #expect(feature.geometry.type == .point)
+    }
+
+    // Validates that NSNull property values degrade gracefully instead of crashing.
+    @Test
+    func parseFeatureWithNSNullProperties() async throws {
+        let json: NSDictionary = [
+            "type": "Feature",
+            "properties": ["a": NSNull(), "b": NSNumber(value: 1)],
+            "geometry": ["type": "Point", "coordinates": [1.0, 2.0]],
+        ]
+        let feature = try #require(Feature(json: json))
+
+        #expect(feature.properties["a"] is NSNull)
+        #expect(feature.properties["b"] as? Int == 1)
+    }
+
+    // Validates that a dictionary with non-string keys degrades to `nil`.
+    @Test
+    func parseWithNonStringKeysReturnsNil() {
+        let json: NSDictionary = [
+            "type": "Point",
+            5: "non-string key",
+            "coordinates": [1.0, 2.0],
+        ]
+
+        #expect(Point(json: json) == nil)
+    }
+
+    // Validates that a dictionary containing a non-JSON value degrades to `nil`.
+    @Test
+    func parseWithNonJsonValueReturnsNil() {
+        let json: NSDictionary = [
+            "type": "Feature",
+            "geometry": ["type": "Point", "coordinates": [1.0, 2.0]],
+            "properties": ["bad": NSObject()],
+        ]
+
+        #expect(Feature(json: json) == nil)
+    }
+
+    // MARK: - Property type preservation
+
+    // Validates that integer-valued JSON properties preserve `as? Int` reads.
+    @Test
+    func propertyIntRead() async throws {
+        let feature = try #require(Feature(jsonString: #"{"type":"Feature","properties":{"id":5,"count":0},"geometry":{"type":"Point","coordinates":[1.0,2.0]}}"#))
+
+        #expect(feature.properties["id"] as? Int == 5)
+        #expect(feature["id"] == 5)
+        #expect(feature.properties["count"] as? Int == 0)
+    }
+
+    // Validates that float JSON properties preserve `as? Double` reads.
+    @Test
+    func propertyDoubleRead() async throws {
+        let feature = try #require(Feature(jsonString: #"{"type":"Feature","properties":{"f":3.14},"geometry":{"type":"Point","coordinates":[1.0,2.0]}}"#))
+
+        #expect(feature.properties["f"] as? Double == 3.14)
+    }
+
+    // Validates that boolean JSON properties preserve `as? Bool` reads,
+    // and that `__NSCFBoolean`-style booleans don't read as `Int`.
+    @Test
+    func propertyBoolRead() async throws {
+        let json: NSDictionary = [
+            "type": "Feature",
+            "properties": ["flag": true, "off": false],
+            "geometry": ["type": "Point", "coordinates": [1.0, 2.0]],
+        ]
+        let feature = try #require(Feature(json: json))
+
+        #expect(feature.properties["flag"] as? Bool == true)
+        #expect(feature.properties["off"] as? Bool == false)
+    }
+
+    // Validates that nested foreign members survive parsing.
+    @Test
+    func foreignMemberPreservation() async throws {
+        let json: NSDictionary = [
+            "type": "Feature",
+            "custom": ["deep": [1.0, 2.0, NSNull()]],
+            "extra": "foreign",
+            "geometry": ["type": "Point", "coordinates": [1.0, 2.0]],
+        ]
+        let feature = try #require(Feature(json: json))
+        let nested: [String: Sendable]? = feature[foreignMember: "custom"]
+
+        #expect(nested?["deep"] != nil)
+    }
+
+    // MARK: - BoundingBox parsing
+
+    // Validates the flat GeoJSON bbox form (4 doubles).
+    @Test
+    func parseBoundingBoxFlat() async throws {
+        let feature = try #require(Feature(jsonString: #"{"type":"Feature","bbox":[1.0,2.0,3.0,4.0],"geometry":{"type":"Point","coordinates":[2.0,3.0]}}"#))
+
+        #expect(feature.boundingBox?.southWest == Coordinate3D(latitude: 2.0, longitude: 1.0))
+        #expect(feature.boundingBox?.northEast == Coordinate3D(latitude: 4.0, longitude: 3.0))
+    }
+
+    // Validates the nested bbox form (2 coordinate arrays).
+    @Test
+    func parseBoundingBoxNested() async throws {
+        let feature = try #require(Feature(jsonString: #"{"type":"Feature","bbox":[[1.0,2.0],[3.0,4.0]],"geometry":{"type":"Point","coordinates":[2.0,3.0]}}"#))
+
+        #expect(feature.boundingBox?.southWest == Coordinate3D(latitude: 2.0, longitude: 1.0))
+        #expect(feature.boundingBox?.northEast == Coordinate3D(latitude: 4.0, longitude: 3.0))
+    }
+
+    // MARK: - Malformed coordinates
+
+    // Validates that malformed coordinate arrays return `nil` instead of crashing.
+    @Test
+    func malformedCoordinatesReturnNil() {
+        #expect(Point(jsonString: #"{"type":"Point","coordinates":[1.0,"two"]}"#) == nil)
+        #expect(Point(jsonString: #"{"type":"Point","coordinates":"not an array"}"#) == nil)
+        #expect(Point(jsonString: #"{"type":"Point","coordinates":[1.0]}"#) == nil)
+        #expect(Point(jsonString: #"{"type":"Point","coordinates":{}}"#) == nil)
+        #expect(Point(jsonString: #"{"type":"Point"}"#) == nil)
+    }
+
+    // MARK: - Coercion helpers
+
+    // Validates `JsonCoercion.dictionary` accepts and rejects the expected shapes.
+    @Test
+    func dictionaryCoercion() {
+        #expect(JsonCoercion.dictionary(nil) == nil)
+        #expect(JsonCoercion.dictionary("string") == nil)
+        #expect(JsonCoercion.dictionary([1.0, 2.0]) == nil)
+
+        let result = JsonCoercion.dictionary(["a": 1, "b": "x", "c": true, "d": NSNull(), "e": [1.0]])
+        #expect(result?.count == 5)
+        #expect(result?["a"] as? Int == 1)
+        #expect(result?["b"] as? String == "x")
+        #expect(result?["c"] as? Bool == true)
+        #expect(result?["d"] is NSNull)
+    }
+
+    // Validates `JsonCoercion.coordinateArray` semantics.
+    @Test
+    func coordinateArrayCoercion() {
+        #expect(JsonCoercion.coordinateArray(nil) == nil)
+        #expect(JsonCoercion.coordinateArray([1.0, 2.0]) == [1.0, 2.0])
+        #expect(JsonCoercion.coordinateArray([1, 2]) == [1.0, 2.0])
+        #expect(JsonCoercion.coordinateArray([1.0, 2.0, NSNull()]) == [1.0, 2.0, nil])
+        #expect(JsonCoercion.coordinateArray([1.0, "two"]) == nil)
+        #expect(JsonCoercion.coordinateArray("x") == nil)
+    }
+
+    // Validates `JsonCoercion.array` semantics.
+    @Test
+    func arrayCoercion() {
+        #expect(JsonCoercion.array(nil) == nil)
+        #expect(JsonCoercion.array(["x"])?.count == 1)
+        #expect(JsonCoercion.array([[1.0], [2.0]])?.count == 2)
+        #expect(JsonCoercion.array("x") == nil)
+    }
+
+    // Validates `JsonCoercion.double` semantics.
+    @Test
+    func doubleCoercion() {
+        #expect(JsonCoercion.double(nil) == nil)
+        #expect(JsonCoercion.double(5) == 5.0)
+        #expect(JsonCoercion.double(NSNumber(value: 2.5)) == 2.5)
+        #expect(JsonCoercion.double(Float(2.5)) == 2.5)
+        #expect(JsonCoercion.double("x") == nil)
+        #expect(JsonCoercion.double(true) == nil)
+    }
+
+}


### PR DESCRIPTION
## Problem

An iOS app crashes with `EXC_BREAKPOINT` / `EXC_BAD_ACCESS` (uncatchable trap) inside the Swift stdlib helper `_dictionaryUpCast` while parsing GeoJSON route data on the main thread.

GeoJSON `init?(json:)` methods performed **whole-dictionary conditional casts** (`json as? [String: Sendable]`) on `JSONSerialization`-bridged values. On Darwin, that cast funnels into `_dictionaryUpCast`, which trips an internal assertion for certain bridged layouts (inhomogeneous nested values, `NSNumber`-backed numbers, booleans) *before* the `as?` can return `nil` — downstream `try?`/`init?(json:)` guards never get a chance to short-circuit.

## Fix

New `Sources/GISTools/GeoJson/JsonCoercion.swift`: element-wise JSON coercion that never whole-casts a dictionary.

- `JsonCoercion.dictionary(_:)` — coerces any JSON object into `[String: Sendable]` **element by element**; bridged `NSDictionary` values are iterated, never whole-cast. Bad elements (non-string keys, non-JSON values) yield `nil` gracefully.
- Arrays are coerced **element-wise** into native `[Sendable]`, keeping each element's runtime type (numbers stay `NSNumber`), so downstream concrete casts (`as? [Double?]`, `as? [Any]`, `as? [[Any]]`) keep working. (A raw `NSArray` cannot be stored as `Sendable` — its conformance is unavailable in Swift 6 mode on Darwin.)
- `JsonCoercion.array/coordinateArray/doubleArray/coordinateArrayList/double` — element-wise array/number reads for `Coordinate3D`, `BoundingBox`, and `Validatable`.
- All 11 whole-dictionary cast sites replaced: the 9 type initializers (`Point`, `MultiPoint`, `LineString`, `MultiLineString`, `Polygon`, `MultiPolygon`, `GeometryCollection`, `Feature`, `Feature.properties`) and the two dispatchers in `GeoJson.swift` (`tryCreate(json:)`, `tryCreateGeometry(json:)`), plus the generic array `tryCreate`s.

### Notable platform quirk

Boolean rejection in `JsonCoercion.double(_:)` uses `objCType == "c"` — `value is Bool` is **not** reliable on Linux corelibs, where plain numbers like `1.0` also answer `true`.
