### PR TITLE
Fix MapTile coordinate conversion at world edges

### DIFF
--- a/Sources/GISTools/Other/MapTile.swift
+++ b/Sources/GISTools/Other/MapTile.swift
@@ -86,6 +86,10 @@ public struct MapTile: CustomStringConvertible, Sendable {
 
     /// Creates a map tile from a geographic coordinate at the given zoom level.
     ///
+    /// Longitudes beyond ±180 wrap around the anti-meridian, latitudes beyond
+    /// the Web Mercator limits (±85.0511°) are clamped, and the resulting
+    /// tile is always within `0 ..< 2^zoom` on both axes.
+    ///
     /// - Parameters:
     ///    - coordinate: The geographic coordinate
     ///    - zoom: The zoom level
@@ -93,8 +97,8 @@ public struct MapTile: CustomStringConvertible, Sendable {
         let scale = Double(1 << zoom)
         let normalizedCoordinate = MapTile.normalizeCoordinate(coordinate.projected(to: .epsg4326))
 
-        self.x = Int(normalizedCoordinate.longitude * scale)
-        self.y = Int(normalizedCoordinate.latitude * scale)
+        self.x = min(max(Int(floor(normalizedCoordinate.longitude * scale)), 0), (1 << zoom) - 1)
+        self.y = min(max(Int(floor(normalizedCoordinate.latitude * scale)), 0), (1 << zoom) - 1)
         self.z = zoom
     }
 
@@ -480,11 +484,19 @@ public struct MapTile: CustomStringConvertible, Sendable {
     // MARK: - Private
 
     /// Normalizes a coordinate for tile indexing using Web Mercator projection.
+    ///
+    /// The returned coordinate lies in `[0, 1]²` (up to floating point
+    /// round-off at the edges), with longitudes beyond ±180 wrapped into
+    /// range and latitudes clamped to the Web Mercator limits.
     static func normalizeCoordinate(_ coordinate: Coordinate3D) -> Coordinate3D {
         var (latitude, longitude) = (coordinate.latitude, coordinate.longitude)
 
+        longitude = longitude.truncatingRemainder(dividingBy: 360.0)
         if longitude > 180.0 {
-           longitude -= 360.0
+            longitude -= 360.0
+        }
+        if longitude < -180.0 {
+            longitude += 360.0
         }
 
         latitude = min(85.05112877980659, max(-85.05112877980659, latitude))

--- a/Tests/GISToolsTests/Other/MapTileTests.swift
+++ b/Tests/GISToolsTests/Other/MapTileTests.swift
@@ -15,6 +15,70 @@ struct MapTileTests {
         #expect(MapTile(coordinate: Coordinate3D(latitude: -33.8566, longitude: 151.215), atZoom: 14) == MapTile(x: 15073, y: 9831, z: 14))
     }
 
+    // Verifies that coordinates just west and east of the prime meridian land
+    // in different tiles: truncation towards zero would place -0.04° and
+    // +0.04° into the same tile.
+    @Test
+    func tileFromCoordinateNegativePrecision() async throws {
+        // At zoom 12, tiles are 360/4096 ≈ 0.0879° wide; ±0.04° are on
+        // opposite sides of tile border 2048.
+        let west = MapTile(coordinate: Coordinate3D(latitude: 0.0, longitude: -0.04), atZoom: 12)
+        let east = MapTile(coordinate: Coordinate3D(latitude: 0.0, longitude: 0.04), atZoom: 12)
+
+        #expect(west.x == 2047)
+        #expect(east.x == 2048)
+    }
+
+    // Verifies that longitudes beyond the anti-meridian wrap into range
+    // instead of producing invalid tile coordinates.
+    @Test
+    func tileFromCoordinateAntiMeridianWrapping() async throws {
+        // -190° is the same meridian as +170°.
+        let wrapped = MapTile(coordinate: Coordinate3D(latitude: 0.0, longitude: -190.0), atZoom: 12)
+        let expected = MapTile(coordinate: Coordinate3D(latitude: 0.0, longitude: 170.0), atZoom: 12)
+        #expect(wrapped == expected)
+
+        // Beyond the dateline east: +185° is the same meridian as -175°.
+        let east = MapTile(coordinate: Coordinate3D(latitude: 0.0, longitude: 185.0), atZoom: 12)
+        let equivalent = MapTile(coordinate: Coordinate3D(latitude: 0.0, longitude: -175.0), atZoom: 12)
+        #expect(east == equivalent)
+    }
+
+    // Verifies that latitudes beyond the Web Mercator limits clamp to the
+    // first/last tile row instead of producing out-of-range tiles.
+    @Test
+    func tileFromCoordinatePoleClamping() async throws {
+        let northPole = MapTile(coordinate: Coordinate3D(latitude: 90.0, longitude: 0.0), atZoom: 4)
+        #expect(northPole.y == 0)
+        #expect(northPole.x == 8)
+
+        let southPole = MapTile(coordinate: Coordinate3D(latitude: -90.0, longitude: 0.0), atZoom: 4)
+        #expect(southPole.y == 15)
+
+        // The exact Mercator limit at the north edge must not produce a
+        // negative y through floating point round-off.
+        let mercatorMax = MapTile(coordinate: Coordinate3D(latitude: 85.05112877980659, longitude: 0.0), atZoom: 12)
+        #expect(mercatorMax.y == 0)
+        #expect(mercatorMax.x == 2048)
+    }
+
+    // Verifies that tile coordinates stay within 0 ..< 2^zoom on both axes
+    // for a dense sample of the full coordinate range.
+    @Test
+    func tileFromCoordinateStaysInWorld() async throws {
+        var latitude = -90.0
+        while latitude <= 90.0 {
+            var longitude = -540.0
+            while longitude <= 540.0 {
+                let tile = MapTile(coordinate: Coordinate3D(latitude: latitude, longitude: longitude), atZoom: 9)
+                #expect(tile.x >= 0 && tile.x < (1 << 9), "x out of range at \(latitude), \(longitude)")
+                #expect(tile.y >= 0 && tile.y < (1 << 9), "y out of range at \(latitude), \(longitude)")
+                longitude += 13.7
+            }
+            latitude += 3.3
+        }
+    }
+
     // Verifies MapTile initialization from bounding boxes with optional maxZoom clamping.
     @Test
     func tileFromBoundingBox() async throws {


### PR DESCRIPTION
## Summary

`MapTile(coordinate:atZoom:)` had three related issues at the edges of the coordinate range:

1. **Anti-meridian wrapping only went one direction.** `normalizeCoordinate` subtracted 360° for longitudes above 180 but never handled longitudes below -180. A coordinate at `-190°` normalized to a negative value and produced invalid tile coordinates (e.g. `x = 0` at every zoom) instead of wrapping to the equivalent `+170°` meridian. Both directions now wrap via `truncatingRemainder(dividingBy: 360)` plus range correction.

2. **Truncation instead of floor.** `Int(...)` truncates towards zero. Normalized tile-space coordinates are normally in `[0, 1]`, where truncation and floor agree — but the unwrapped-longitude case above produces negative normalized values, and the clamped north-pole latitude produces `-1.1e-16` through floating-point round-off. Floor is the correct rounding for tile indexing.

3. **No clamping.** The exact Mercator latitude limit `85.05112877980659` normalizes to a tiny negative value, which floors to tile `-1`. Tile coordinates are now clamped to `0 ..< 2^zoom` on both axes, guaranteeing in-world results for any input.