### PR TITLE
Add Hashable conformances to Ring, Polygon, and MultiPolygon

### DIFF
--- a/Sources/GISTools/GeoJson/MultiPolygon.swift
+++ b/Sources/GISTools/GeoJson/MultiPolygon.swift
@@ -267,6 +267,22 @@ extension MultiPolygon: Equatable {
 
 }
 
+// MARK: - Hashable
+
+extension MultiPolygon: Hashable {
+
+    /// The hash is based on the projection and the hashes of the polygons,
+    /// consistent with `==` (which regards rings with shifted start vertices
+    /// as equal).
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(projection)
+        for polygon in polygons {
+            hasher.combine(polygon)
+        }
+    }
+
+}
+
 // MARK: - Polygons
 
 extension MultiPolygon {

--- a/Sources/GISTools/GeoJson/Polygon.swift
+++ b/Sources/GISTools/GeoJson/Polygon.swift
@@ -276,3 +276,19 @@ extension Polygon: Equatable {
     }
 
 }
+
+// MARK: - Hashable
+
+extension Polygon: Hashable {
+
+    /// The hash is based on the projection and rotation-canonical, quantized
+    /// representations of the rings, consistent with `==` (which regards rings
+    /// with shifted start vertices as equal).
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(projection)
+        for ring in coordinates {
+            ring.hashAsCanonicalRing(into: &hasher)
+        }
+    }
+
+}

--- a/Sources/GISTools/GeoJson/Ring.swift
+++ b/Sources/GISTools/GeoJson/Ring.swift
@@ -116,6 +116,97 @@ extension [Coordinate3D] {
 
 }
 
+// MARK: - Hashable
+
+/// A quantized, sortable representation of a coordinate, used for
+/// epsilon-consistent hashing of rings.
+///
+/// Coordinates are quantized like `Coordinate3D.hash(into:)` so that
+/// coordinates within `GISTool.equalityDelta` of each other usually produce
+/// the same key (the same boundary caveat applies).
+private struct QuantizedVertex: Comparable, Hashable {
+
+    let latitude: Double
+    let longitude: Double
+    let altitudeState: Int
+    let altitude: Double
+
+    init(_ coordinate: Coordinate3D) {
+        self.latitude = (coordinate.latitude / GISTool.equalityDelta).rounded()
+        self.longitude = (coordinate.longitude / GISTool.equalityDelta).rounded()
+        self.altitudeState = coordinate.altitude == nil ? 0 : 1
+        self.altitude = coordinate.altitude ?? 0.0
+    }
+
+    static func <(lhs: QuantizedVertex, rhs: QuantizedVertex) -> Bool {
+        if lhs.latitude != rhs.latitude { return lhs.latitude < rhs.latitude }
+        if lhs.longitude != rhs.longitude { return lhs.longitude < rhs.longitude }
+        if lhs.altitudeState != rhs.altitudeState { return lhs.altitudeState < rhs.altitudeState }
+        return lhs.altitude < rhs.altitude
+    }
+
+}
+
+extension [Coordinate3D] {
+
+    /// Combine a rotation-canonical, quantized representation of the receiver,
+    /// treated as a closed ring, into the hasher.
+    ///
+    /// This mirrors `compareShifted(_:)`: the closing vertex is dropped and all
+    /// rotations of the remaining vertices are regarded as equal, so the
+    /// rotation that sorts lexicographically smallest is used as the canonical
+    /// form. Two rings that `compareShifted(_:)` regards as equal therefore
+    /// always produce the same hash.
+    func hashAsCanonicalRing(into hasher: inout Hasher) {
+        let vertices = Array(dropLast()).map({ QuantizedVertex($0) })
+        let count = vertices.count
+        guard count > 0 else { return }
+
+        var canonicalStart = 0
+        if count > 1 {
+            for start in 1..<count {
+                if vertices.rotation(at: start, isLexicographicallySmallerThan: canonicalStart) {
+                    canonicalStart = start
+                }
+            }
+        }
+
+        for offset in 0..<count {
+            hasher.combine(vertices[(canonicalStart + offset) % count])
+        }
+    }
+
+}
+
+extension [QuantizedVertex] {
+
+    /// Check if the rotation of the vertices starting at `start` sorts
+    /// lexicographically before the rotation starting at `other`.
+    func rotation(at start: Int, isLexicographicallySmallerThan other: Int) -> Bool {
+        for offset in indices {
+            let lhs = self[(start + offset) % count]
+            let rhs = self[(other + offset) % count]
+            if lhs != rhs {
+                return lhs < rhs
+            }
+        }
+        return false
+    }
+
+}
+
+extension Ring: Hashable {
+
+    /// The hash is based on the projection and a rotation-canonical, quantized
+    /// representation of the ring's vertices, consistent with `==` (which
+    /// regards rings with shifted start vertices as equal).
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(projection)
+        coordinates.hashAsCanonicalRing(into: &hasher)
+    }
+
+}
+
 // MARK: - Projection
 
 extension Ring: Projectable {

--- a/Tests/GISToolsTests/GeoJson/MultiPolygonTests.swift
+++ b/Tests/GISToolsTests/GeoJson/MultiPolygonTests.swift
@@ -393,4 +393,65 @@ struct MultiPolygonTests {
         #expect(multiPolygon.polygons.count == 2)
     }
 
+    // MARK: - Hashable
+
+    // Builds a simple square polygon for the hash tests.
+    private func squarePolygon(_ offset: Double, rotated: Bool = false) throws -> Polygon {
+        var coordinates: [Coordinate3D] = [
+            Coordinate3D(latitude: offset, longitude: offset),
+            Coordinate3D(latitude: offset, longitude: offset + 1.0),
+            Coordinate3D(latitude: offset + 1.0, longitude: offset + 1.0),
+            Coordinate3D(latitude: offset + 1.0, longitude: offset),
+            Coordinate3D(latitude: offset, longitude: offset),
+        ]
+        if rotated {
+            coordinates = [
+                Coordinate3D(latitude: offset, longitude: offset + 1.0),
+                Coordinate3D(latitude: offset + 1.0, longitude: offset + 1.0),
+                Coordinate3D(latitude: offset + 1.0, longitude: offset),
+                Coordinate3D(latitude: offset, longitude: offset),
+                Coordinate3D(latitude: offset, longitude: offset + 1.0),
+            ]
+        }
+        return try #require(Polygon([coordinates]))
+    }
+
+    // Validates that identical MultiPolygons have equal hashes.
+    @Test
+    func hashableIdentical() async throws {
+        let multiPolygonA = try #require(MultiPolygon([squarePolygon(0.0), squarePolygon(2.0)]))
+        let multiPolygonB = try #require(MultiPolygon([squarePolygon(0.0), squarePolygon(2.0)]))
+
+        #expect(multiPolygonA == multiPolygonB)
+        #expect(multiPolygonA.hashValue == multiPolygonB.hashValue)
+
+        let set: Set<MultiPolygon> = [multiPolygonA, multiPolygonB]
+        #expect(set.count == 1)
+    }
+
+    // Validates that MultiPolygons with shifted ring start vertices have
+    // equal hashes.
+    @Test
+    func hashableShiftedRing() async throws {
+        let multiPolygon = try #require(MultiPolygon([squarePolygon(0.0)]))
+        let multiPolygonShifted = try #require(MultiPolygon([squarePolygon(0.0, rotated: true)]))
+
+        #expect(multiPolygon == multiPolygonShifted)
+        #expect(multiPolygon.hashValue == multiPolygonShifted.hashValue)
+
+        let set: Set<MultiPolygon> = [multiPolygon, multiPolygonShifted]
+        #expect(set.count == 1)
+    }
+
+    // Validates that MultiPolygons with swapped polygon order are not equal
+    // and have different hashes.
+    @Test
+    func hashablePolygonOrderSwapped() async throws {
+        let multiPolygonA = try #require(MultiPolygon([squarePolygon(0.0), squarePolygon(2.0)]))
+        let multiPolygonB = try #require(MultiPolygon([squarePolygon(2.0), squarePolygon(0.0)]))
+
+        #expect(multiPolygonA != multiPolygonB)
+        #expect(multiPolygonA.hashValue != multiPolygonB.hashValue)
+    }
+
 }

--- a/Tests/GISToolsTests/GeoJson/PolygonTests.swift
+++ b/Tests/GISToolsTests/GeoJson/PolygonTests.swift
@@ -394,4 +394,108 @@ struct PolygonTests {
         #expect(bbox.northEast.longitude == 1.0)
     }
 
+    // MARK: - Hashable
+
+    private let polygonCoords: [[Coordinate3D]] = [[
+        Coordinate3D(latitude: 0.0, longitude: 0.0),
+        Coordinate3D(latitude: 0.0, longitude: 10.0),
+        Coordinate3D(latitude: 10.0, longitude: 10.0),
+        Coordinate3D(latitude: 10.0, longitude: 0.0),
+        Coordinate3D(latitude: 0.0, longitude: 0.0),
+    ]]
+
+    // Validates that identical polygons have equal hashes.
+    @Test
+    func hashableIdentical() async throws {
+        let polygonA = try #require(Polygon(polygonCoords))
+        let polygonB = try #require(Polygon(polygonCoords))
+
+        #expect(polygonA == polygonB)
+        #expect(polygonA.hashValue == polygonB.hashValue)
+
+        let set: Set<Polygon> = [polygonA, polygonB]
+        #expect(set.count == 1)
+    }
+
+    // Validates that polygons with shifted ring start vertices have equal hashes.
+    @Test
+    func hashableShiftedRing() async throws {
+        let polygon = try #require(Polygon(polygonCoords))
+        let shiftedCoords: [[Coordinate3D]] = [[
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]]
+        let polygonShifted = try #require(Polygon(shiftedCoords))
+
+        #expect(polygon == polygonShifted)
+        #expect(polygon.hashValue == polygonShifted.hashValue)
+
+        let set: Set<Polygon> = [polygon, polygonShifted]
+        #expect(set.count == 1)
+    }
+
+    // Validates that polygons with shifted inner rings have equal hashes.
+    @Test
+    func hashableShiftedInnerRing() async throws {
+        let polygonWithHole = try #require(Polygon(jsonString: PolygonTests.polygonJsonWithHoles))
+        let shiftedCoords: [[Coordinate3D]] = [
+            [
+                Coordinate3D(latitude: 0.0, longitude: 100.0),
+                Coordinate3D(latitude: 0.0, longitude: 101.0),
+                Coordinate3D(latitude: 1.0, longitude: 101.0),
+                Coordinate3D(latitude: 1.0, longitude: 100.0),
+                Coordinate3D(latitude: 0.0, longitude: 100.0),
+            ],
+            [
+                Coordinate3D(latitude: 2.0, longitude: 100.8),
+                Coordinate3D(latitude: 2.0, longitude: 100.2),
+                Coordinate3D(latitude: 1.0, longitude: 100.2),
+                Coordinate3D(latitude: 1.0, longitude: 100.8),
+                Coordinate3D(latitude: 2.0, longitude: 100.8),
+            ],
+        ]
+        let polygonWithHoleShifted = try #require(Polygon(shiftedCoords))
+
+        #expect(polygonWithHole == polygonWithHoleShifted)
+        #expect(polygonWithHole.hashValue == polygonWithHoleShifted.hashValue)
+    }
+
+    // Validates that polygons with different ring order are not equal and
+    // have different hashes.
+    @Test
+    func hashableRingOrderSwapped() async throws {
+        let outerRing: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]
+        let holeRing: [Coordinate3D] = [
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+            Coordinate3D(latitude: 2.0, longitude: 4.0),
+            Coordinate3D(latitude: 4.0, longitude: 4.0),
+            Coordinate3D(latitude: 4.0, longitude: 2.0),
+            Coordinate3D(latitude: 2.0, longitude: 2.0),
+        ]
+        let polygonA = try #require(Polygon(unchecked: [outerRing, holeRing]))
+        let polygonB = try #require(Polygon(unchecked: [holeRing, outerRing]))
+
+        #expect(polygonA != polygonB)
+        #expect(polygonA.hashValue != polygonB.hashValue)
+    }
+
+    // Validates that projections participate in polygon equality and hashing.
+    @Test
+    func hashableProjections() async throws {
+        let polygon4326 = try #require(Polygon(polygonCoords))
+        let polygon3857 = polygon4326.projected(to: .epsg3857)
+
+        #expect(polygon4326 != polygon3857)
+        #expect(polygon4326.hashValue != polygon3857.hashValue)
+    }
+
 }

--- a/Tests/GISToolsTests/GeoJson/RingTests.swift
+++ b/Tests/GISToolsTests/GeoJson/RingTests.swift
@@ -165,4 +165,156 @@ struct RingTests {
         #expect(ring != otherRing)
     }
 
+    // MARK: - Hashable
+
+    // Validates that identical rings have equal hashes.
+    @Test
+    func hashableIdentical() async throws {
+        let ringA = try #require(Ring(coords))
+        let ringB = try #require(Ring(coords))
+
+        #expect(ringA == ringB)
+        #expect(ringA.hashValue == ringB.hashValue)
+    }
+
+    // Validates that rings with shifted start vertices have equal hashes.
+    @Test
+    func hashableShiftedStart() async throws {
+        let ring = try #require(Ring(coords))
+        let shiftedCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+        ]
+        let ringShifted = try #require(Ring(shiftedCoords))
+
+        #expect(ring == ringShifted)
+        #expect(ring.hashValue == ringShifted.hashValue)
+
+        let set: Set<Ring> = [ring, ringShifted]
+        #expect(set.count == 1)
+    }
+
+    // Validates that rings with different vertices have different hashes.
+    @Test
+    func hashableNotEqual() async throws {
+        let ring = try #require(Ring(coords))
+        let otherCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 20.0),
+            Coordinate3D(latitude: 20.0, longitude: 20.0),
+            Coordinate3D(latitude: 20.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]
+        let otherRing = try #require(Ring(otherCoords))
+
+        #expect(ring != otherRing)
+        #expect(ring.hashValue != otherRing.hashValue)
+    }
+
+    // Validates that reversing a ring changes equality and hash (a reversal
+    // is not a rotation).
+    @Test
+    func hashableReversed() async throws {
+        let ring = try #require(Ring(coords))
+        let reversedCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0),
+        ]
+        let ringReversed = try #require(Ring(reversedCoords))
+
+        #expect(ring != ringReversed)
+        #expect(ring.hashValue != ringReversed.hashValue)
+    }
+
+    // Validates that epsilon-equal rings (within `GISTool.equalityDelta`) are
+    // equal and have equal hashes.
+    @Test
+    func hashableEpsilonEqual() async throws {
+        let ring = try #require(Ring(coords))
+        let epsilonCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.00000000003, longitude: 0.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0),
+            Coordinate3D(latitude: 0.00000000003, longitude: 0.0),
+        ]
+        let ringEpsilon = try #require(Ring(epsilonCoords))
+
+        #expect(ring == ringEpsilon)
+        #expect(ring.hashValue == ringEpsilon.hashValue)
+    }
+
+    // Validates that rings differing only in altitude are not equal and have
+    // different hashes.
+    @Test
+    func hashableAltitude() async throws {
+        let ring = try #require(Ring(coords))
+        let altitudeCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 10.0, altitude: 100.0),
+            Coordinate3D(latitude: 10.0, longitude: 10.0, altitude: 100.0),
+            Coordinate3D(latitude: 10.0, longitude: 0.0, altitude: 100.0),
+            Coordinate3D(latitude: 0.0, longitude: 0.0, altitude: 100.0),
+        ]
+        let ringAltitude = try #require(Ring(altitudeCoords))
+
+        #expect(ring != ringAltitude)
+        #expect(ring.hashValue != ringAltitude.hashValue)
+    }
+
+    // Validates that projections participate in equality and hashing.
+    @Test
+    func hashableProjections() async throws {
+        let ring4326 = try #require(Ring(coords))
+        let ring3857 = ring4326.projected(to: .epsg3857)
+        let ring3857Again = ring3857.projected(to: .epsg3857)
+
+        #expect(ring3857 == ring3857Again)
+        #expect(ring3857.hashValue == ring3857Again.hashValue)
+
+        #expect(ring4326 != ring3857)
+        #expect(ring4326.hashValue != ring3857.hashValue)
+    }
+
+    // Validates that rings crossing the antimeridian hash consistently when
+    // their start vertex is shifted.
+    @Test
+    func hashableAntimeridian() async throws {
+        let antimeridianCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 10.0, longitude: 170.0),
+            Coordinate3D(latitude: 10.0, longitude: -170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 10.0, longitude: 170.0),
+        ]
+        let ring = try #require(Ring(antimeridianCoords))
+        let shiftedCoords: [Coordinate3D] = [
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+            Coordinate3D(latitude: 0.0, longitude: 170.0),
+            Coordinate3D(latitude: 10.0, longitude: 170.0),
+            Coordinate3D(latitude: 10.0, longitude: -170.0),
+            Coordinate3D(latitude: 0.0, longitude: -170.0),
+        ]
+        let ringShifted = try #require(Ring(shiftedCoords))
+
+        #expect(ring == ringShifted)
+        #expect(ring.hashValue == ringShifted.hashValue)
+    }
+
+    // Validates that empty (unchecked) rings are equal and hash equally.
+    @Test
+    func hashableEmpty() async throws {
+        let ringA = Ring(unchecked: [])
+        let ringB = Ring(unchecked: [])
+
+        #expect(ringA == ringB)
+        #expect(ringA.hashValue == ringB.hashValue)
+    }
+
 }


### PR DESCRIPTION
Part of #231.

## What

Adds `Hashable` conformances to `Ring`, `Polygon`, and `MultiPolygon`, with dedicated tests.

## Why

These types compare **rotation-insensitively** (`compareShifted`): rings with shifted start vertices are equal. A synthesized hash would break the `Hashable`/`Equatable` contract for such rings, so the hash is based on a **rotation-canonical, quantized representation** of each ring:

- Coordinates are quantized exactly like the existing `Coordinate3D.hash(into:)` (mirroring the epsilon-based `==`), including its documented boundary caveat.
- The closing vertex is dropped and the rotation that sorts lexicographically smallest is used as the canonical form — two rings that `compareShifted` regards as equal always produce the same hash.
- Ring direction stays significant (a reversal is not a rotation, consistent with `==`).

The canonicalization helper lives next to `compareShifted` as a `[Coordinate3D]` extension.

## Compatibility

Purely additive — no `==` behavior changes, no existing API changes.

## Tests

- Shifted rings → equal hashes, `Set` deduplication (`Ring`, `Polygon` outer + inner rings, `MultiPolygon`)
- Direction sensitivity (reversed rings are not equal and hash differently)
- Epsilon-equal rings → equal hashes
- Altitude, projection, and antimeridian-crossing participation
- Full suite: 2376 tests pass

This PR is the base for the stacked `typed_properties` branch (which needs `Polygon`/`MultiPolygon` to be `Hashable` for `Feature`/`GeometryCollection` existential hashing).